### PR TITLE
Add ipywidgets recipe

### DIFF
--- a/package_platforms.json
+++ b/package_platforms.json
@@ -67,6 +67,7 @@
         "unicodedata2",
         "matplotlib",
         "ipython",
-        "widgetsnbextension"
+        "widgetsnbextension",
+        "ipywidgets"
     ]
 }

--- a/recipes/ipywidgets/recipe.yaml
+++ b/recipes/ipywidgets/recipe.yaml
@@ -1,0 +1,49 @@
+context:
+  version: "7.7.0"
+
+package:
+  name: ipywidgets
+  version: '{{ version }}'
+
+source:
+  url: https://pypi.io/packages/source/i/ipywidgets/ipywidgets-{{ version }}.tar.gz
+  sha256: ab4a5596855a88b83761921c768707d65e5847068139bc1729ddfe834703542a
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}
+  host:
+    - python >=3.3
+    - pip
+  run:
+    - python >=3.3
+    - ipython >=4.0.0
+    # We don't have an ipykernel recipe yet
+    # - ipykernel >=4.5.1
+    - traitlets >=4.3.1,<6.0.0
+    - nbformat >=4.2.0
+    - widgetsnbextension >=3.6.0,<3.7.0
+    - jupyterlab_widgets >=1.0.0,<2.0.0
+    - ipython_genutils >=0.2.0,<0.3.0
+
+about:
+  home: https://github.com/ipython/ipywidgets
+  license: BSD-3-Clause
+  license_file: LICENSE
+  license_family: BSD
+  summary: Jupyter Interactive Widgets
+  description: |
+    ipywidgets are interactive HTML widgets for Jupyter notebooks and the IPython kernel.
+  doc_url: https://ipywidgets.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/index.rst
+
+
+extra:
+  recipe-maintainers:
+    - DerThorsten
+    - martinRenou


### PR DESCRIPTION
Cutting out the ipykernel dependency for now (it's not technically needed if running in e.g. xeus-python)