### PR TITLE
testdriver with `pyjs` support

### DIFF
--- a/.github/workflows/build_recipes.yaml
+++ b/.github/workflows/build_recipes.yaml
@@ -106,7 +106,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}
           emsdk activate ${{matrix.emsdk_ver}}
           source $CONDA_EMSDK_DIR/emsdk_env.sh
-          python builder.py build changed $GITHUB_WORKSPACE/recipes origin/main~1 origin/main ~/webenv ~/packed
+          python builder.py build changed $GITHUB_WORKSPACE/ origin/main~1 origin/main ~/webenv ~/packed
 
       ################################################################
       # build ALL recipes
@@ -135,7 +135,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}
           emsdk activate ${{matrix.emsdk_ver}}
           source $CONDA_EMSDK_DIR/emsdk_env.sh
-          python builder.py build changed  $GITHUB_WORKSPACE/recipes origin/main HEAD  /home/runner/webenv /home/runner/packed
+          python builder.py build changed  $GITHUB_WORKSPACE/ origin/main HEAD  /home/runner/webenv /home/runner/packed
 
 
       ################################################################

--- a/builder.py
+++ b/builder.py
@@ -231,7 +231,7 @@ def changed(
     skip_existing: Optional[bool] = typer.Option(False),
 ):
     base_work_dir = os.getcwd()
-    recipes_dir = os.path.join(base_work_dir, "recipes")
+    recipes_dir = os.path.join(root_dir, "recipes")
     pytest_driver_src_dir = os.path.join(base_work_dir, "testing", "pytest_driver")
 
     recipes_with_changes_per_subdir = find_recipes_with_changes(old=old, new=new)

--- a/builder.py
+++ b/builder.py
@@ -9,7 +9,8 @@ import rich
 from collections import OrderedDict
 import functools
 from dataclasses import dataclass, field
-
+import tempfile
+import shutil
 import empack
 from testing.browser_test_package import test_package as browser_test_package
 from testing.node_test_package import test_package as node_test_package
@@ -17,6 +18,16 @@ from testing.node_test_package import test_package as node_test_package
 RECIPES_SUBDIR_MAPPING = OrderedDict(
     [("recipes", ""), ("recipes_emscripten", "emscripten-32")]
 )
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def restore_cwd():
+    base_work_dir = os.getcwd()
+    yield
+    os.chdir(base_work_dir)
 
 
 def find_files_with_changes(old, new):
@@ -92,6 +103,7 @@ def post_build_callback(
     skip_tests,
     skip_pack,
 ):
+
     assert len(sorted_outputs) == 1, "only one output per pkg atm"
     rich.pretty.pprint(
         {
@@ -101,12 +113,14 @@ def post_build_callback(
         }
     )
     if target_platform == "emscripten-32" and (not skip_tests):
-        test_package(recipe)
+        with restore_cwd():
+            test_package(recipe)
 
     if target_platform == "emscripten-32":
-        empack.file_packager.pack_conda_pkg(
-            recipe=recipe, pack_prefix=pack_prefix, pack_outdir=pack_outdir
-        )
+        with restore_cwd():
+            empack.file_packager.pack_conda_pkg(
+                recipe=recipe, pack_prefix=pack_prefix, pack_outdir=pack_outdir
+            )
 
 
 def boa_build(
@@ -139,7 +153,6 @@ def boa_build(
     )
     if platform:
         build_args.target_platform = platform
-    print(build_args)
     run_build(build_args)
     os.chdir(base_work_dir)
 
@@ -207,7 +220,7 @@ def explicit(
 
 @build_app.command()
 def changed(
-    recipes_dir,
+    root_dir,
     old,
     new,
     pack_prefix: str,
@@ -218,33 +231,52 @@ def changed(
     skip_existing: Optional[bool] = typer.Option(False),
 ):
     base_work_dir = os.getcwd()
+    recipes_dir = os.path.join(base_work_dir, "recipes")
+    pytest_driver_src_dir = os.path.join(base_work_dir, "testing", "pytest_driver")
 
     recipes_with_changes_per_subdir = find_recipes_with_changes(old=old, new=new)
     rich.pretty.pprint(recipes_with_changes_per_subdir)
 
     for subdir, recipe_with_changes in recipes_with_changes_per_subdir.items():
 
-        for recipe_with_change in recipe_with_changes:
+        # create a  temp dir and copy all changed recipes
+        # to that dir (because Then we can let boa do the
+        # topological sorting
+        with tempfile.TemporaryDirectory() as tmp_folder_root:
 
-            recipe_dir = os.path.join(recipes_dir, subdir, recipe_with_change)
-            print("THE RECIPE DIR", recipe_dir)
-            if os.path.isdir(recipe_dir):
-                if not dryrun:
-                    boa_build(
-                        target=recipe_dir,
-                        platform=RECIPES_SUBDIR_MAPPING[subdir],
-                        skip_tests=skip_tests,
-                        skip_pack=skip_pack,
-                        pack_prefix=pack_prefix,
-                        pack_outdir=pack_outdir,
-                        skip_existing=skip_existing,
-                    )
+            tmp_recipes_root = os.path.join(
+                tmp_folder_root, "recipes", "recipes_per_platform"
+            )
+            os.makedirs(tmp_folder_root, exist_ok=True)
 
-                else:
-                    # pass
-                    print(f"dryrun build: {os.path.join(subdir,recipe_with_change)}")
-            else:
-                warnings.warn(f"skipping nonexisting dir {recipe_dir}")
+            tmp_pytest_driver_src_dir = os.path.join(
+                tmp_folder_root, "testing", "pytest_driver"
+            )
+            os.makedirs(tmp_folder_root, exist_ok=True)
+            shutil.copytree(pytest_driver_src_dir, tmp_pytest_driver_src_dir)
+
+            for recipe_with_change in recipe_with_changes:
+                recipe_dir = os.path.join(recipes_dir, subdir, recipe_with_change)
+
+                # diff can shown deleted recipe as changed
+                if os.path.isdir(recipe_dir):
+
+                    tmp_recipe_dir = os.path.join(tmp_recipes_root, recipe_with_change)
+                    # os.mkdir(tmp_recipe_dir)
+                    shutil.copytree(recipe_dir, tmp_recipe_dir)
+
+            print([x[0] for x in os.walk(tmp_recipes_root)])
+
+            boa_build(
+                target=tmp_recipes_root,
+                recipe_dir=None,
+                platform=RECIPES_SUBDIR_MAPPING[subdir],
+                skip_tests=skip_tests,
+                skip_pack=skip_pack,
+                pack_prefix=pack_prefix,
+                skip_existing=skip_existing,
+                pack_outdir=pack_outdir,
+            )
 
 
 if __name__ == "__main__":

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -9,6 +9,7 @@ dependencies:
   - ruamel.yaml <0.17.6
   - rich
   - mamba >= 0.23.1
+  - micromamba >= 0.23.1
   - jsonschema
   - cython
   - patchelf
@@ -23,4 +24,5 @@ dependencies:
   - empack
   - emsdk >=3.1.11
   - boa
+  - nodejs
   - microsoft::playwright

--- a/recipes/recipes_emscripten/pyjs/recipe.yaml
+++ b/recipes/recipes_emscripten/pyjs/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.1.1
+  version: 0.2.1
   name: pyjs
 package:
   name: '{{name}}'

--- a/recipes/recipes_emscripten/pyjs/recipe.yaml
+++ b/recipes/recipes_emscripten/pyjs/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.2.1
+  version: 0.3.1
   name: pyjs
 package:
   name: '{{name}}'
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/DerThorsten/{{name}}/archive/refs/tags/{{version}}.tar.gz
-  # sha256: 436cfc0880e3e51d2459ec5ad54e1534d373c00f4fae8c9b23fa3f0373b4e81f
+  # sha256: 17ac09f02c3c564be175a8449492526a6f1e02a5bc3d080ffe7448dd6c75aa89
 
 build:
   number: 0

--- a/recipes/recipes_emscripten/pytest_driver/build.sh
+++ b/recipes/recipes_emscripten/pytest_driver/build.sh
@@ -17,11 +17,11 @@ fi
 # Configure step
 cmake ${CMAKE_ARGS} ..              \
     -GNinja                         \
-    -DCMAKE_PROJECT_INCLUDE=overwriteProp.cmake \
+    -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH=$PREFIX     \
     -DCMAKE_INSTALL_PREFIX=$PREFIX  \
-    -DENV_NODE=$FEATURE_ENV_NODE \
-
+    -DENV_NODE=$FEATURE_ENV_NODE 
+    
 #-DCMAKE_BUILD_TYPE=Release      \
 
 # Build step

--- a/recipes/recipes_emscripten/pytest_driver/recipe.yaml
+++ b/recipes/recipes_emscripten/pytest_driver/recipe.yaml
@@ -23,7 +23,7 @@ requirements:
     - bzip2
     - libffi
     - pybind11
-    - pyjs >=0.2.1
+    - pyjs >=0.3.1
   run:
     - pytest
     - numpy

--- a/recipes/recipes_emscripten/pytest_driver/recipe.yaml
+++ b/recipes/recipes_emscripten/pytest_driver/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.4.0
+  version: 0.5.1
 
 package:
   name: pytest_driver
@@ -23,9 +23,10 @@ requirements:
     - bzip2
     - libffi
     - pybind11
-    - pyjs >=0.1.1
+    - pyjs >=0.2.1
   run:
     - pytest
+    - numpy
 
 
 features:

--- a/recipes/recipes_emscripten/pytest_driver_node/build.sh
+++ b/recipes/recipes_emscripten/pytest_driver_node/build.sh
@@ -14,6 +14,7 @@ fi
 # Configure step
 cmake ${CMAKE_ARGS} ..              \
     -GNinja                         \
+    -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PROJECT_INCLUDE=overwriteProp.cmake \
     -DCMAKE_PREFIX_PATH=$PREFIX     \
     -DCMAKE_INSTALL_PREFIX=$PREFIX  \

--- a/recipes/recipes_emscripten/pytest_driver_node/recipe.yaml
+++ b/recipes/recipes_emscripten/pytest_driver_node/recipe.yaml
@@ -23,7 +23,7 @@ requirements:
     - bzip2
     - libffi
     - pybind11
-    - pyjs >=0.2.1
+    - pyjs >=0.3.1
   run:
     - pytest
     - numpy

--- a/recipes/recipes_emscripten/pytest_driver_node/recipe.yaml
+++ b/recipes/recipes_emscripten/pytest_driver_node/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.4.0
+  version: 0.5.1
 
 package:
   name: pytest_driver_node
@@ -23,9 +23,10 @@ requirements:
     - bzip2
     - libffi
     - pybind11
-    - pyjs >=0.1.1
+    - pyjs >=0.2.1
   run:
     - pytest
+    - numpy
 
 features:
   - name: env_node

--- a/recipes/recipes_emscripten/wasm_requests/build.sh
+++ b/recipes/recipes_emscripten/wasm_requests/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+${PYTHON} -m pip install . --no-deps

--- a/recipes/recipes_emscripten/wasm_requests/recipe.yaml
+++ b/recipes/recipes_emscripten/wasm_requests/recipe.yaml
@@ -1,0 +1,41 @@
+context:
+  version: 0.1.1
+  name: wasm_requests
+package:
+  name: '{{name}}'
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/DerThorsten/{{name}}/archive/refs/tags/{{version}}.tar.gz
+  # sha256: 436cfc0880e3e51d2459ec5ad54e1534d373c00f4fae8c9b23fa3f0373b4e81f
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - cross-python_emscripten-32
+  host:
+    - python
+    - pip
+  run:
+    - numpy
+
+about:
+  home:  https://github.com/DerThorsten/wasm_requests
+  license: MIT
+  license_file: LICENSE
+  summary: Simple and powerful testing with Python.
+  description: |
+    a kind of drop in replacement for the requets library
+  doc_url:  https://github.com/DerThorsten/wasm_requests
+  dev_url: https://github.com/DerThorsten/wasm_requests
+
+extra:
+  recipe-maintainers:
+    - DerThorsten
+  emscripten_tests:
+    python:
+      pytest_files:
+      - test_wasm_requests.py

--- a/recipes/recipes_emscripten/wasm_requests/recipe.yaml
+++ b/recipes/recipes_emscripten/wasm_requests/recipe.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - python
     - pip
+    - pytest_driver >=0.5.1
+    - pytest_driver_node >=0.5.1
   run:
     - numpy
 

--- a/recipes/recipes_emscripten/wasm_requests/test_wasm_requests.py
+++ b/recipes/recipes_emscripten/wasm_requests/test_wasm_requests.py
@@ -12,6 +12,7 @@ def test_wasm_requests():
     # get with query params
     r = wasm_requests.get("https://httpbin.org/get", params=dict(foo="bar", fobar=1))
     result = r.json()
+    headers = r.headers
 
     assert result["args"]["foo"] == "bar"
     assert result["args"]["fobar"] == "1"

--- a/recipes/recipes_emscripten/wasm_requests/test_wasm_requests.py
+++ b/recipes/recipes_emscripten/wasm_requests/test_wasm_requests.py
@@ -1,0 +1,17 @@
+import pytest
+import os
+import wasm_requests
+
+
+in_node = "PYTEST_DRIVER_NODE" in os.environ
+
+
+@pytest.mark.skipif(in_node, reason="requires browser not node")
+def test_wasm_requests():
+
+    # get with query params
+    r = wasm_requests.get("https://httpbin.org/get", params=dict(foo="bar", fobar=1))
+    result = r.json()
+
+    assert result["args"]["foo"] == "bar"
+    assert result["args"]["fobar"] == "1"

--- a/recipes/recipes_emscripten/wasm_requests/test_wasm_requests.py
+++ b/recipes/recipes_emscripten/wasm_requests/test_wasm_requests.py
@@ -3,10 +3,12 @@ import os
 import wasm_requests
 
 
-in_node = "PYTEST_DRIVER_NODE" in os.environ
+skip_node = pytest.mark.skipif(
+    "PYTEST_DRIVER_NODE" in os.environ, reason="requires browser, not node"
+)
 
 
-@pytest.mark.skipif(in_node, reason="requires browser not node")
+@skip_node
 def test_wasm_requests():
 
     # get with query params

--- a/testing/browser_test_package.py
+++ b/testing/browser_test_package.py
@@ -133,7 +133,7 @@ def create_test_env(pkg_name, prefix):
     # cmd = ['$MAMBA_EXE' ,'create','--prefix', prefix,'--platform=emscripten-32'] + [pkg_name] #+ ['--dryrun']
     print("prefix", prefix)
     cmd = [
-        f"$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python pytest_driver pytest {pkg_name}"
+        f"""$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python "pytest_driver=0.3.1" pytest {pkg_name}"""
     ]
     ret = subprocess.run(cmd, shell=True)
     #  stderr=subprocess.PIPE, stdout=subprocess.PIPE)

--- a/testing/node_test_package.py
+++ b/testing/node_test_package.py
@@ -12,6 +12,7 @@ let Module = {};
 console.log("require pytest_driver.js")
 var createModule = require('./pytest_driver.js')
 
+
 function waitRunDependency() {
   const promise = new Promise((r) => {
     Module.monitorRunDependencies = (n) => {
@@ -80,7 +81,7 @@ def create_test_env(pkg_name, prefix):
     # cmd = ['$MAMBA_EXE' ,'create','--prefix', prefix,'--platform=emscripten-32'] + [pkg_name] #+ ['--dryrun']
     print("prefix", prefix)
     cmd = [
-        f"""$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python "pytest_driver_node=0.3.1" pytest {pkg_name}"""
+        f"""$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python "pytest_driver_node=0.5.1" pytest {pkg_name}"""
     ]
     ret = subprocess.run(cmd, shell=True)
     #  stderr=subprocess.PIPE, stdout=subprocess.PIPE)

--- a/testing/node_test_package.py
+++ b/testing/node_test_package.py
@@ -37,13 +37,9 @@ let res = (async function() {
   Module = myModule
   global.Module = Module
 
-  console.log("import python_data")
   await import('./python_data.js')
-  console.log("import testdata")
   await import('./testdata.js')
-  console.log("waitRunDependency")
   var deps = await waitRunDependency()
-  console.log("waitRunDependency DONE")
   myModule.initialize_interpreter()
   myModule.print = print
   myModule.error = print
@@ -169,9 +165,7 @@ def test_package(recipe, debug=False, debug_dir=None):
             os.mkdir(work_dir)
             os.chdir(work_dir)
             create_test_env(pkg_name=pkg_name, prefix=prefix)
-            print("PACK STUFF")
             pack(prefix=prefix, pytest_files=pytest_files)
-            print("COPY FROM PREFIX")
             copy_from_prefix(prefix=prefix, work_dir=work_dir)
             patch(work_dir=work_dir)
             run_node_tests(work_dir=work_dir)

--- a/testing/node_test_package.py
+++ b/testing/node_test_package.py
@@ -80,7 +80,7 @@ def create_test_env(pkg_name, prefix):
     # cmd = ['$MAMBA_EXE' ,'create','--prefix', prefix,'--platform=emscripten-32'] + [pkg_name] #+ ['--dryrun']
     print("prefix", prefix)
     cmd = [
-        f"$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python pytest_driver_node pytest {pkg_name}"
+        f"""$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python "pytest_driver_node=0.3.1" pytest {pkg_name}"""
     ]
     ret = subprocess.run(cmd, shell=True)
     #  stderr=subprocess.PIPE, stdout=subprocess.PIPE)

--- a/testing/node_test_package.py
+++ b/testing/node_test_package.py
@@ -127,7 +127,7 @@ def run_node_tests(work_dir):
         file.write(NODE_TEST_FILE_STR)
 
     os.chdir(work_dir)
-    cmd = [f"node   --trace-uncaught test.js"]
+    cmd = [f"$CONDA_PREFIX/bin/node   --trace-uncaught test.js"]
     ret = subprocess.run(cmd, shell=True)
     if ret.returncode != 0:
         raise RuntimeError("Tests Failed")

--- a/testing/pytest_driver/CMakeLists.txt
+++ b/testing/pytest_driver/CMakeLists.txt
@@ -4,25 +4,10 @@ project(pytest_driver VERSION 0.1.0 DESCRIPTION "pytest_driver description")
 
 option(ENV_NODE "Build for the node env" OFF)
 
-if(ENV_NODE)
-    SET(ENVIRONMENT "node")
-else()
-    SET(ENVIRONMENT "web")
-endif()
 
-set(EM_FLAGS "${EM_FLAGS} -s ENVIRONMENT=${ENVIRONMENT} --bind -s DISABLE_EXCEPTION_THROWING=0 -s DISABLE_EXCEPTION_CATCHING=0  -s NO_DISABLE_EXCEPTION_CATCHING -fexceptions ")
-set(EM_FLAGS "${EM_FLAGS} -fPIC -s LZ4=1")
-set(EM_FLAGS "${EM_FLAGS} --post-js post.js")
-set(EM_FLAGS "${EM_FLAGS} --pre-js pre.js")
-set(EM_FLAGS "${EM_FLAGS} -s ALLOW_MEMORY_GROWTH")
-
-set(EM_LINKER_FLAGS "${EM_LINKER_FLAGS} -WASM=1 -s FORCE_FILESYSTEM=1 -s MODULARIZE -s ERROR_ON_UNDEFINED_SYMBOLS=1")
-set(EM_LINKER_FLAGS "${EM_LINKER_FLAGS} -s EXPORT_NAME=\"createModule\" -s EXPORT_ES6=0 -s USE_ES6_IMPORT_META=0 -s ERROR_ON_UNDEFINED_SYMBOLS=1")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EM_FLAGS} ${EM_LINKER_FLAGS}")
-set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS}  ${EM_FLAGS} ${EM_LINKER_FLAGS}")
 
 find_package(pybind11 REQUIRED CONFIG)
-set(pyjs_REQUIRED_VERSION 0.1.0)
+set(pyjs_REQUIRED_VERSION 0.2.0)
 find_package(pyjs ${pyjs_REQUIRED_VERSION} REQUIRED)
 
 SET(PYTHON_UTIL_LIBS 
@@ -38,10 +23,58 @@ add_executable(pytest_driver pytest_driver.cpp)
 
 target_link_libraries(pytest_driver PRIVATE ${PYTHON_UTIL_LIBS} pybind11::embed pyjs)
 
-set_target_properties(pytest_driver PROPERTIES 
-    LINK_FLAGS "-s MAIN_MODULE=1  -lstdc++ ${EM_FLAGS} "
-    CXX_FLAGS  "${EM_FLAGS} -fPIC"
+
+if(ENV_NODE)
+    SET(ENVIRONMENT "node")
+    target_compile_definitions(pytest_driver PUBLIC -DPYTEST_DRIVER_NODE)  # -D removed
+else()
+    SET(ENVIRONMENT "web,worker")
+     target_compile_definitions(pytest_driver PUBLIC -DPYTEST_DRIVER_WEB)  # -D removed
+endif()
+
+
+
+target_compile_options(pytest_driver PRIVATE -fPIC)
+
+
+target_compile_options(pytest_driver
+    PUBLIC --std=c++17
+    PUBLIC -Wno-deprecated
+    PUBLIC "SHELL: --bind"
+    PUBLIC "SHELL: -s ENVIRONMENT=${ENVIRONMENT}"
+    PUBLIC "SHELL: -fwasm-exceptions"
+    PUBLIC "SHELL: -s FORCE_FILESYSTEM"
+    PUBLIC "SHELL: -s LZ4=1"
 )
+
+target_link_options(pytest_driver
+    PUBLIC --bind
+    PUBLIC -Wno-unused-command-line-argument
+    PUBLIC "SHELL: --bind"
+    PUBLIC "SHELL: -s MODULARIZE=1"
+    PUBLIC "SHELL: -s EXPORT_NAME=\"createModule\""
+    PUBLIC "SHELL: -s EXPORT_ES6=0"
+    PUBLIC "SHELL: -s USE_ES6_IMPORT_META=0"
+    PUBLIC "SHELL: -s DEMANGLE_SUPPORT=0"
+    PUBLIC "SHELL: -s ASSERTIONS=0"
+    PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
+    PUBLIC "SHELL: -s EXIT_RUNTIME=1"
+    PUBLIC "SHELL: -s WASM=1"
+    PUBLIC "SHELL: -s USE_PTHREADS=0"
+    PUBLIC "SHELL: -fwasm-exceptions"
+    PUBLIC "SHELL: -s MAIN_MODULE=1"
+    PUBLIC "SHELL: -s ENVIRONMENT=${ENVIRONMENT}"
+    PUBLIC "SHELL: -s TOTAL_STACK=512mb"
+    PUBLIC "SHELL: -s INITIAL_MEMORY=1024mb"
+    PUBLIC "SHELL: -s FORCE_FILESYSTEM"
+    PUBLIC "SHELL: -s LZ4=1"
+    PUBLIC "SHELL: --post-js post.js"
+    PUBLIC "SHELL: --pre-js pre.js"
+)
+
+
+
+
 
 include(GNUInstallDirs)
 install(TARGETS pytest_driver

--- a/testing/testpage/empty.html
+++ b/testing/testpage/empty.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>TEST_TITLE</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="script.js"></script>
+  </head>
+  <body>
+    <!-- page content -->
+    <script type="application/javascript" src="pytest_driver.js"></script>
+    <script type="application/javascript">
+
+      globalThis.done = false
+
+      // globalThis.createModule = createModule
+      globalThis.worker = new Worker("worker.js")
+
+      function resolver(val)
+      {
+
+      }
+
+    let res = (async function() {
+
+        var promise =  new Promise( (resolve, reject) => {
+        
+
+          globalThis.worker.onmessage = e => {
+              console.log("RESOLVE")
+              resolve(e.data)
+              console.log("RESOLVE DONE")
+              // worker.terminate();
+          }
+          worker.onerror = e => (reject(e.message), worker.terminate());
+          // worker.postMessage(args);
+
+        });
+
+
+        console.log("waiting for promise")
+        globalThis.test_output = await promise
+        console.log("DONE AWAITING DONE")
+        globalThis.done = true
+     })()
+
+    </script>
+  </body>
+</html>

--- a/testing/testpage/worker.js
+++ b/testing/testpage/worker.js
@@ -1,0 +1,4 @@
+// import createModule from './pytest_driver.js';
+importScripts('./pytest_driver.js')
+
+// var Module = {}


### PR DESCRIPTION
* added  recipes:
   * `pyjs`
   * `wasm_requests`
* integrated  `pyjs` in `pytest_driver` / `pytest_driver_node` pkg
* use `wasm_requests` as first `pyjs` based package which is tested
* changed `playwright` test suite st. tests are run in a worker
* added `nodejs` to wasm deps