### PR TITLE
removed pkgs from config/pin_run_as_build

### DIFF
--- a/.github/workflows/.condarc_post
+++ b/.github/workflows/.condarc_post
@@ -4,5 +4,3 @@ channels:
   - conda-forge
   
 add_pip_as_python_dependency: false
-
-micromamba-root

--- a/.github/workflows/.condarc_post
+++ b/.github/workflows/.condarc_post
@@ -1,6 +1,8 @@
 channels:
-  - /home/runner/micromamba/envs/ci-env/conda-bld/
+  - /home/runner/micromamba-root/envs/ci-env/conda-bld/
   - https://repo.mamba.pm/emscripten-forge
   - conda-forge
   
 add_pip_as_python_dependency: false
+
+micromamba-root

--- a/.github/workflows/build_recipes.yaml
+++ b/.github/workflows/build_recipes.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: post env install config
         shell: bash -l {0}
         run: |
-          mkdir -p $HOME/micromamba/envs/ci-env/conda-bld/emscripten-32
+          mkdir -p $HOME/micromamba-root/envs/ci-env/conda-bld/emscripten-32
           mkdir -p $HOME/packed
 
           cp $GITHUB_WORKSPACE/.github/workflows/.condarc_post $HOME/.condarc

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -191,8 +191,6 @@ pin_run_as_build:
     max_pin: x.x.x
   boost-cpp:
     max_pin: x.x.x
-  bzip2:
-    max_pin: x
   cairo:
     max_pin: x.x
   curl:
@@ -245,8 +243,6 @@ pin_run_as_build:
     max_pin: x
   libevent:
     max_pin: x.x.x
-  libffi:
-    max_pin: x.x
   libgdal:
     max_pin: x.x
   libiconv:
@@ -306,8 +302,6 @@ pin_run_as_build:
     min_pin: x.x
   sox:
     max_pin: x.x.x
-  sqlite:
-    max_pin: x
   tk:
     max_pin: x.x
   tiledb:
@@ -321,8 +315,6 @@ pin_run_as_build:
   zeromq:
     max_pin: x.x  # [not win]
     max_pin: x.x.x  # [win]
-  zlib:
-    max_pin: x.x
 
 # Pinning packages
 

--- a/recipes/recipes_emscripten/python/recipe.yaml
+++ b/recipes/recipes_emscripten/python/recipe.yaml
@@ -23,9 +23,9 @@ source:
 
 build:
   # ATTENTION need to change build number in build string as well!
-  number: 4
+  number: 5
   # check with https://github.com/mamba-org/boa/issues/278
-  string: h_hash_4_cpython
+  string: h_hash_5_cpython
   # run_exports:
   #   strong:
   #     - '{{ pin_subpackage("python", max_pin="x.x") }}'


### PR DESCRIPTION
currently the python pks has run dependencies on pks which are actually linked as static libraries. In the recipe the depencies are correctly listed as run dependencies, but the build config was setup st. these pks where added as run dependencies