### PR TITLE
use explicit release bld for pyjs

### DIFF
--- a/recipes/recipes_emscripten/pyjs/build.sh
+++ b/recipes/recipes_emscripten/pyjs/build.sh
@@ -7,6 +7,7 @@ export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
 # Configure step
 cmake ${CMAKE_ARGS} ..              \
     -GNinja                         \
+    -DCMAKE_BUILD_TYPE=Release      \
     -DCMAKE_PREFIX_PATH=$PREFIX     \
     -DCMAKE_INSTALL_PREFIX=$PREFIX  \
     -DBUILD_RUNTIME_BROWSER=ON \

--- a/recipes/recipes_emscripten/pyjs/recipe.yaml
+++ b/recipes/recipes_emscripten/pyjs/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6a2b3144e63683aa8b7aebd16e7502c31904c79a9913dc6f934118cb375b55c2
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
REPL is not working with last build since it was not in Release mode (gives some error message about cannot call slice on undefined)
