### PR TITLE
Configurable emsdk

### DIFF
--- a/empack_config.yaml
+++ b/empack_config.yaml
@@ -80,6 +80,7 @@ packages:
       - pattern: '**/tests/**/*.so'
   scikit-image:
     include_patterns:
+      - pattern: '*.txt'
       - pattern: '*.so'
       - pattern: '*.py'
       - pattern: '*.json'

--- a/recipes/recipes/emscripten_emscripten-32/activate.sh
+++ b/recipes/recipes/emscripten_emscripten-32/activate.sh
@@ -8,9 +8,15 @@ if [ -z ${CONDA_FORGE_EMSCRIPTEN_ACTIVATED+x} ]; then
 
 
 
-    if [ -n "$CONDA_EMSDK_DIR" ]; then
-        echo "CONDA_EMSDK_DIR IS given, using provided CONDA_EMSDK_DIR" $CONDA_EMSDK_DIR
+    EMSDK_DIR_CONFIG_FILE=$HOME/.emsdkdir
+
+    if test -f "$EMSDK_DIR_CONFIG_FILE"; then
+        echo "found config file $EMSDK_DIR_CONFIG_FILE"
+        CONDA_EMSDK_DIR=$(<$EMSDK_DIR_CONFIG_FILE)
+        echo "I READ $CONDA_EMSDK_DIR"
+        echo "CONDA_EMSDK_DIR from $EMSDK_DIR_CONFIG_FILE is: " $CONDA_EMSDK_DIR
     else
+        echo "did **NOT** foudn confi file $EMSDK_DIR_CONFIG_FILE"
         echo "CONDA_EMSDK_DIR IS NOT given:"
 
         emsdk install  3.1.2

--- a/recipes/recipes_emscripten/bzip2/recipe.yaml
+++ b/recipes/recipes_emscripten/bzip2/recipe.yaml
@@ -13,7 +13,7 @@ source:
   path:  CMakeLists.txt
 
 build:
-  number: 0
+  number: 1
   # run_exports:
   # - '{{ pin_subpackage("bzip2") }}'
 


### PR DESCRIPTION
This pr adds a better method to use a local `CONDA_EMSDK_DIR` to avoid downloading it for each build.
Turns out it was not working to specify an env variable `CONDA_EMSDK_DIR` since the env variables are cleared at some point in the build chain (it somewhat used to work a few boa versions ago)

Here I propse that we check for a config file in the home dir: named `.emsdkdir`
with a single line of content like `/home/fobar/src/emsdk`

Inside the emscripten compiler activation script we can then do
```bash

    EMSDK_DIR_CONFIG_FILE=$HOME/.emsdkdir
    if test -f "$EMSDK_DIR_CONFIG_FILE"; then
        echo "found config file $EMSDK_DIR_CONFIG_FILE"
        CONDA_EMSDK_DIR=$(<$EMSDK_DIR_CONFIG_FILE)
        echo "I READ $CONDA_EMSDK_DIR"
        echo "CONDA_EMSDK_DIR from $EMSDK_DIR_CONFIG_FILE is: " $CONDA_EMSDK_DIR
    else
        echo "did **NOT** foudn confi file $EMSDK_DIR_CONFIG_FILE"
        echo "CONDA_EMSDK_DIR IS NOT given:"

        emsdk install  3.1.2
        emsdk activate 3.1.2
        export CONDA_EMSDK_DIR=$BUILD_PREFIX/lib/python$($PYTHON -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")/site-packages/emsdk
    fi
```