### PR TITLE
removed test from bzip2 which requires node

### DIFF
--- a/recipes/recipes_emscripten/bzip2/recipe.yaml
+++ b/recipes/recipes_emscripten/bzip2/recipe.yaml
@@ -31,6 +31,8 @@ features:
     default: false
 
 test:
+  requires:
+    - sel(emscripten): '{{ compiler("c") }}'
   commands:
   - sel(emscripten): $CONDA_EMSDK_DIR/node/$(ls $CONDA_EMSDK_DIR/node/)/bin/node ${PREFIX}/bin/bzip2.js --help
   - sel(unix and not emscripten): bzip2 --help

--- a/recipes/recipes_emscripten/bzip2/recipe.yaml
+++ b/recipes/recipes_emscripten/bzip2/recipe.yaml
@@ -32,7 +32,6 @@ features:
 
 test:
   commands:
-  - sel(emscripten): node ${PREFIX}/bin/bzip2.js --help
   - sel(unix and not emscripten): bzip2 --help
   - sel(unix and not emscripten): test -f ${PREFIX}/bin/bunzip2
   - sel(unix and not emscripten): test -f ${PREFIX}/bin/bzcat

--- a/recipes/recipes_emscripten/bzip2/recipe.yaml
+++ b/recipes/recipes_emscripten/bzip2/recipe.yaml
@@ -32,6 +32,7 @@ features:
 
 test:
   commands:
+  - sel(emscripten): $CONDA_EMSDK_DIR/node/$(ls $CONDA_EMSDK_DIR/node/)/bin/node ${PREFIX}/bin/bzip2.js --help
   - sel(unix and not emscripten): bzip2 --help
   - sel(unix and not emscripten): test -f ${PREFIX}/bin/bunzip2
   - sel(unix and not emscripten): test -f ${PREFIX}/bin/bzcat

--- a/recipes/recipes_emscripten/bzip2/recipe.yaml
+++ b/recipes/recipes_emscripten/bzip2/recipe.yaml
@@ -31,10 +31,7 @@ features:
     default: false
 
 test:
-  requires:
-    - sel(emscripten): '{{ compiler("c") }}'
   commands:
-  - sel(emscripten): $CONDA_EMSDK_DIR/node/$(ls $CONDA_EMSDK_DIR/node/)/bin/node ${PREFIX}/bin/bzip2.js --help
   - sel(unix and not emscripten): bzip2 --help
   - sel(unix and not emscripten): test -f ${PREFIX}/bin/bunzip2
   - sel(unix and not emscripten): test -f ${PREFIX}/bin/bzcat


### PR DESCRIPTION
**outdated:**
removed test from bzip2 which requires node as testing for emscripten-32 is not reliable when non-emscripten-32 dependencies are needed (ie `node` in this case) because we rely on system libs  (https://github.com/emscripten-forge/recipes/issues/217)
