### PR TITLE
RE2: removed context extern thread_local object

### DIFF
--- a/recipes/recipes_emscripten/re2/patches/no-context.patch
+++ b/recipes/recipes_emscripten/re2/patches/no-context.patch
@@ -1,0 +1,37 @@
+diff --git a/re2/re2.h b/re2/re2.h
+index 7fd2245..9f30c63 100644
+--- a/re2/re2.h
++++ b/re2/re2.h
+@@ -963,31 +963,8 @@ class LazyRE2 {
+ 
+ namespace hooks {
+ 
+-// Most platforms support thread_local. Older versions of iOS don't support
+-// thread_local, but for the sake of brevity, we lump together all versions
+-// of Apple platforms that aren't macOS. If an iOS application really needs
+-// the context pointee someday, we can get more specific then...
+-//
+-// As per https://github.com/google/re2/issues/325, thread_local support in
+-// MinGW seems to be buggy. (FWIW, Abseil folks also avoid it.)
+-#define RE2_HAVE_THREAD_LOCAL
+-#if (defined(__APPLE__) && !TARGET_OS_OSX) || defined(__MINGW32__)
++// Force deactivation of thread_local context object
+ #undef RE2_HAVE_THREAD_LOCAL
+-#endif
+-
+-// A hook must not make any assumptions regarding the lifetime of the context
+-// pointee beyond the current invocation of the hook. Pointers and references
+-// obtained via the context pointee should be considered invalidated when the
+-// hook returns. Hence, any data about the context pointee (e.g. its pattern)
+-// would have to be copied in order for it to be kept for an indefinite time.
+-//
+-// A hook must not use RE2 for matching. Control flow reentering RE2::Match()
+-// could result in infinite mutual recursion. To discourage that possibility,
+-// RE2 will not maintain the context pointer correctly when used in that way.
+-#ifdef RE2_HAVE_THREAD_LOCAL
+-extern thread_local const RE2* context;
+-#endif
+-
+ struct DFAStateCacheReset {
+   int64_t state_budget;
+   size_t state_cache_size;

--- a/recipes/recipes_emscripten/re2/recipe.yaml
+++ b/recipes/recipes_emscripten/re2/recipe.yaml
@@ -9,6 +9,8 @@ package:
 source:
   - url: http://github.com/google/re2/archive/{{ versionhyphen }}.tar.gz
     sha256: 8c45f7fba029ab41f2a7e6545058d9eec94eef97ce70df58e92d85cfc08b4669
+    patches:
+      - patches/no-context.patch
 
 build:
   number: 0


### PR DESCRIPTION
This is an attempt to remove the `re2::hooks::context` (which is optional anyway if `thread_local` is not supported) to help with building `arrow-python` which depends on RE2. For some reason that extern object leads to linking issues so this is an attempt to remove it from the the whole problem.