### PR TITLE
changed numpy pinning

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -630,7 +630,7 @@ ntl:
   - '11.4.3'
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
-  - 1.23.0
+  - 1.24.2
 #   # part of a zip_keys: python, python_impl, numpy
 #   - 1.18   # [not (osx and arm64)]
 #   - 1.18   # [not (osx and arm64)]

--- a/recipes/recipes_emscripten/pydro/recipe.yaml
+++ b/recipes/recipes_emscripten/pydro/recipe.yaml
@@ -12,7 +12,7 @@ source:
   - path: setup.py
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
atm the pydro build fails with:

```
2023-03-07T10:57:20.6822707Z Setting environment variables:
2023-03-07T10:57:20.6826001Z PATH = /home/runner/.cache/empack/emsdk-3.1.27:/home/runner/.cache/empack/emsdk-3.1.27/upstream/emscripten:/home/runner/.cache/empack/emsdk-3.1.27/node/14.18.2_64bit/bin:/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/bin:/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/bin:/home/runner/micromamba-root/envs/ci-env/condabin:/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env:/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place:/home/runner/micromamba-root/envs/ci-env/bin:/home/runner/micromamba-root/condabin:/home/runner/micromamba-bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
2023-03-07T10:57:20.6828238Z EMSDK = /home/runner/.cache/empack/emsdk-3.1.27
2023-03-07T10:57:20.6829822Z EMSDK_NODE = /home/runner/.cache/empack/emsdk-3.1.27/node/14.18.2_64bit/bin/node
2023-03-07T10:57:20.6830505Z Clearing existing environment variable: EMSDK_PYTHON
2023-03-07T10:57:23.1796512Z   error: subprocess-exited-with-error
2023-03-07T10:57:23.1797300Z   
2023-03-07T10:57:23.1798585Z   × Preparing metadata (pyproject.toml) did not run successfully.
2023-03-07T10:57:23.1799193Z   │ exit code: 1
2023-03-07T10:57:23.1800119Z   ╰─> [50 lines of output]
2023-03-07T10:57:23.1800570Z       Traceback (most recent call last):
2023-03-07T10:57:23.1801494Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/numpy/core/__init__.py", line 23, in <module>
2023-03-07T10:57:23.1801929Z           from . import multiarray
2023-03-07T10:57:23.1802525Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/numpy/core/multiarray.py", line 16, in <module>
2023-03-07T10:57:23.1802983Z           from ._multiarray_umath import (
2023-03-07T10:57:23.1803804Z       ImportError: cannot import name 'fastCopyAndTranspose' from 'numpy.core._multiarray_umath' (/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/numpy/core/_multiarray_umath.cpython-310-x86_64-linux-gnu.so)
2023-03-07T10:57:23.1804515Z       
2023-03-07T10:57:23.1804935Z       During handling of the above exception, another exception occurred:
2023-03-07T10:57:23.1805177Z       
2023-03-07T10:57:23.1805385Z       Traceback (most recent call last):
2023-03-07T10:57:23.1806045Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
2023-03-07T10:57:23.1806434Z           main()
2023-03-07T10:57:23.1806994Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
2023-03-07T10:57:23.1807526Z           json_out['return_val'] = hook(**hook_input['kwargs'])
2023-03-07T10:57:23.1808582Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
2023-03-07T10:57:23.1809075Z           return hook(metadata_directory, config_settings)
2023-03-07T10:57:23.1809734Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 174, in prepare_metadata_for_build_wheel
2023-03-07T10:57:23.1810160Z           self.run_setup()
2023-03-07T10:57:23.1811149Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 267, in run_setup
2023-03-07T10:57:23.1811726Z           super(_BuildMetaLegacyBackend,
2023-03-07T10:57:23.1812289Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 158, in run_setup
2023-03-07T10:57:23.1812764Z           exec(compile(code, __file__, 'exec'), locals())
2023-03-07T10:57:23.1813030Z         File "setup.py", line 5, in <module>
2023-03-07T10:57:23.1813255Z           import numpy
2023-03-07T10:57:23.1813772Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/numpy/__init__.py", line 141, in <module>
2023-03-07T10:57:23.1814138Z           from . import core
2023-03-07T10:57:23.1814684Z         File "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/numpy/core/__init__.py", line 49, in <module>
2023-03-07T10:57:23.1815044Z           raise ImportError(msg)
2023-03-07T10:57:23.1815258Z       ImportError:
2023-03-07T10:57:23.1815447Z       
2023-03-07T10:57:23.1815689Z       IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
2023-03-07T10:57:23.1815945Z       
2023-03-07T10:57:23.1816279Z       Importing the numpy C-extensions failed. This error can happen for
2023-03-07T10:57:23.1816621Z       many reasons, often due to issues with your setup or how NumPy was
2023-03-07T10:57:23.1816861Z       installed.
2023-03-07T10:57:23.1817043Z       
2023-03-07T10:57:23.1817302Z       We have compiled some common reasons and troubleshooting tips at:
2023-03-07T10:57:23.1817541Z       
2023-03-07T10:57:23.1818043Z           https://numpy.org/devdocs/user/troubleshooting-importerror.html
2023-03-07T10:57:23.1818343Z       
2023-03-07T10:57:23.1818541Z       Please note and check the following:
2023-03-07T10:57:23.1818755Z       
2023-03-07T10:57:23.1820159Z         * The Python version is: Python3.10 from "/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/bin/python"
2023-03-07T10:57:23.1820835Z         * The NumPy version is: "1.24.2"
2023-03-07T10:57:23.1821034Z       
2023-03-07T10:57:23.1821276Z       and make sure that they are the versions you expect.
2023-03-07T10:57:23.1821614Z       Please carefully study the documentation linked above for further help.
2023-03-07T10:57:23.1821867Z       
2023-03-07T10:57:23.1822652Z       Original error was: cannot import name 'fastCopyAndTranspose' from 'numpy.core._multiarray_umath' (/home/runner/micromamba-root/envs/ci-env/conda-bld/pydro-0_1678178275615/_build_env/venv/lib/python3.10/site-packages/numpy/core/_multiarray_umath.cpython-310-x86_64-linux-gnu.so)
2023-03-07T10:57:23.1823583Z       
2023-03-07T10:57:23.1823751Z       [end of output]
2023-03-07T10:57:23.1823941Z   
2023-03-07T10:57:23.1824217Z   note: This error originates from a subprocess, and is likely not a problem with pip.
2023-03-07T10:57:23.1828549Z error: metadata-generation-failed
2023-03-07T10:57:23.1828872Z 
2023-03-07T10:57:23.1829101Z × Encountered error while generating package metadata.
2023-03-07T10:57:23.1829429Z ╰─> See above for output.
2023-03-07T10:57:23.1829574Z 
```

my intuition is, that this is related to the build-prefix numpy not matching the host-prefix numpy