### PR TITLE
remove build path from python sysconfig data

### DIFF
--- a/recipes/recipes_emscripten/python/build.sh
+++ b/recipes/recipes_emscripten/python/build.sh
@@ -60,19 +60,28 @@ if [[ $target_platform == "emscripten-32" ]]; then
 
     emmake make CROSS_COMPILE=yes -j8
 
-
-
+    # replace:
+    #  "some/long/path/containing_the_build_dir/emcc"  with "emcc"
+    #  "some/long/path/containing_the_build_dir/emar"  with "emar"
+    #  "some/long/path/containing_the_build_dir/em++"  with "em++"
+    FNAME_IN="build/lib.emscripten-3.10/$SYSCONFIG_NAME.py" 
+    FNAME_OUT="build/lib.emscripten-3.10/$SYSCONFIG_NAME.py"
+    EMAR=$(which emar)
+    EMCC=$(which emcc)
+    EMCPP=$(which em++)
+    $PYTHON $RECIPE_DIR/patch_sysconfigdata.py \
+        --fname-in $FNAME_IN \
+        --fname-out $FNAME_OUT \
+        --emcc=$EMCC  \
+        --emar=$EMAR  \
+        --emcpp=$EMCPP \
 
     cp build/lib.emscripten-3.10/$SYSCONFIG_NAME.py ${PREFIX}/lib/python3.10/ 
-
-
-
 
     # CHANGE PLATTFORM TRIPLET IN SYSCONFIG
     sed -i "s/-lffi -lz/ /g"    ${PREFIX}/lib/python3.10/$SYSCONFIG_NAME.py
     # sed -i "s/'SHLIB_SUFFIX': '.so',/'SHLIB_SUFFIX': '.cpython-310-wasm32-emscripten.so',/g"  ${PREFIX}/lib/python3.10/_sysconfigdata__emscripten_.py
 
- 
     # install/copy sysconfig to a place where cross-python expects the sysconfig
     mkdir -p ${PREFIX}/etc/conda
     cp ${PREFIX}/lib/python3.10/$SYSCONFIG_NAME.py ${PREFIX}/etc/conda/

--- a/recipes/recipes_emscripten/python/patch_sysconfigdata.py
+++ b/recipes/recipes_emscripten/python/patch_sysconfigdata.py
@@ -1,0 +1,42 @@
+def fix_build_shared(bldshared):
+    assert "emcc" in bldshared
+    tokens = bldshared.split(" ")
+    fixed_tokens = []
+    for token in tokens:
+        if token.endswith("emcc"):
+            fixed_tokens.append("emcc")
+        else:
+            fixed_tokens.append(token)
+
+    return " ".join(fixed_tokens)
+
+
+def fix_config_args(config_args):
+    print(config_args)
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(prog="PatchSysConfigData")
+
+    parser.add_argument("--fname-in", required=True)
+    parser.add_argument("--fname-out", required=True)
+    parser.add_argument("--emcc", required=True)
+    parser.add_argument("--emar", required=True)
+    parser.add_argument("--emcpp", required=True)
+
+    args = parser.parse_args()
+
+    fname_in = args.fname_in
+
+    with open(fname_in, "r") as f:
+        content = f.read()
+
+    content = content.replace(args.emcc, "emcc")
+    content = content.replace(args.emcpp, "em++")
+    content = content.replace(args.emar, "emar")
+
+    with open(args.fname_out, "w") as f:
+        f.write(content)

--- a/recipes/recipes_emscripten/python/recipe.yaml
+++ b/recipes/recipes_emscripten/python/recipe.yaml
@@ -23,9 +23,9 @@ source:
 
 build:
   # ATTENTION need to change build number in build string as well!
-  number: 21
+  number: 22
   # check with https://github.com/mamba-org/boa/issues/278
-  string: h_hash_21_cpython
+  string: h_hash_22_cpython
   # run_exports:
   #   strong:
   #     - '{{ pin_subpackage("python", max_pin="x.x") }}'


### PR DESCRIPTION
Since we use a emscripten install living **outside** the conda-prefixes, the python sysconfig data contains path like:
` "CC": "/home/runner/.cache/empack/emsdk-3.1.27/upstream/emscripten/emcc"`

This has only been an esthetical problem since cross-python is configured to use `emcc` as compiler. But it seems that `pyo3`/`rust`/`setuptools_rust` based build systems (as we need for the new `cryptography` pkg) do indeed parse python sysconfig data file. As a consequence one cannot compile on any machine **not** having emscripten installed at `"/home/runner/.cache/empack/emsdk-3.1.27/upstream/emscripten/` (note the user name `runner` as this was build on githubs ci)

This PR adds a tiny script replacing things like `"/home/runner/.cache/empack/emsdk-3.1.27/upstream/emscripten/emcc"` with just  `"emcc"`