### PR TITLE
use old quetz-client

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -21,7 +21,7 @@ dependencies:
   - pyyaml
   - click == 8.0.4
   - typer >= 0.7.0
-  - quetz-client
+  - quetz-client <= 0.0.4
   - boa
   - nodejs >= 18.7.0
   - pydantic

--- a/recipes/recipes_emscripten/python/recipe.yaml
+++ b/recipes/recipes_emscripten/python/recipe.yaml
@@ -23,9 +23,9 @@ source:
 
 build:
   # ATTENTION need to change build number in build string as well!
-  number: 22
+  number: 23
   # check with https://github.com/mamba-org/boa/issues/278
-  string: h_hash_22_cpython
+  string: h_hash_23_cpython
   # run_exports:
   #   strong:
   #     - '{{ pin_subpackage("python", max_pin="x.x") }}'


### PR DESCRIPTION
- use quetz-client <= 0.0.4 since the newer quetz-clients break  the upload
- trigger another build of python since this was not uploaded properly