### PR TITLE
docs: add note about use of Boa

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Most of the recipes have been ported from [pyodide](https://pyodide.org/en/stabl
 
 While we already have a lot of packages built, this is still a big work in progress.
 
+> **Note**
+> The recipes used in this repository follow the [Boa recipe specification](https://boa-build.readthedocs.io/en/latest/recipe_spec.html).
+
 ## Installing Packages
 
 


### PR DESCRIPTION
When I was porting a recipe to emscripten-forge, I didn't immediately realise that it was supposed to conform to the Boa recipe specification. I hope that something like this note will make it more obvious to oblivious developers such as myself going forward! :)