### PR TITLE
remove bin and broken symlinks from python package

### DIFF
--- a/recipes/recipes_emscripten/python/build.sh
+++ b/recipes/recipes_emscripten/python/build.sh
@@ -101,6 +101,11 @@ if [[ $target_platform == "emscripten-32" ]]; then
     rm -rf ${PREFIX}/lib/python3.10/sqlite3/test
     rm -rf ${PREFIX}/lib/python3.10/unittest/tests
 
+    # rm bin and pkgconfig since they contain only broken
+    # link
+    rm -rf ${PREFIX}/bin 
+    rm -rf ${PREFIX}/lib/pkgconfig 
+
 else
     mkdir -p build
     pushd build

--- a/recipes/recipes_emscripten/python/recipe.yaml
+++ b/recipes/recipes_emscripten/python/recipe.yaml
@@ -23,9 +23,9 @@ source:
 
 build:
   # ATTENTION need to change build number in build string as well!
-  number: 24
+  number: 25
   # check with https://github.com/mamba-org/boa/issues/278
-  string: h_hash_24_cpython
+  string: h_hash_25_cpython
   # run_exports:
   #   strong:
   #     - '{{ pin_subpackage("python", max_pin="x.x") }}'


### PR DESCRIPTION
* remove broken symlinks:
    * prefix/bin contains a lot of broken links
    * prefix/lib/pkgconfig contains **only** broken links 
* also remove python binary itself as this is:
   1. completely useless
   2. completely untested
   3. the proper way is embed libpython / pyjs in the project where you need to embed python