### PR TITLE
python pkg: add dummy file to prefix/bin

### DIFF
--- a/recipes/recipes_emscripten/python/build.sh
+++ b/recipes/recipes_emscripten/python/build.sh
@@ -106,13 +106,11 @@ if [[ $target_platform == "emscripten-32" ]]; then
     rm -rf ${PREFIX}/bin 
     rm -rf ${PREFIX}/lib/pkgconfig 
 
-
     # we actually need a build folder
     # otherwise other things downstream break
     mkdir ${PREFIX}/bin 
     touch dummy
     cp dummy ${PREFIX}/bin 
-
 
 else
     mkdir -p build

--- a/recipes/recipes_emscripten/python/build.sh
+++ b/recipes/recipes_emscripten/python/build.sh
@@ -101,9 +101,14 @@ if [[ $target_platform == "emscripten-32" ]]; then
     rm -rf ${PREFIX}/lib/python3.10/sqlite3/test
     rm -rf ${PREFIX}/lib/python3.10/unittest/tests
 
-    # rm bin and pkgconfig since they contain only broken
-    # link
-    rm -rf ${PREFIX}/bin 
+    # remove broken links but keep python3.10 binary
+    # and the non-broken link to it
+    rm  ${PREFIX}/bin/2to3
+    rm  ${PREFIX}/bin/idle3
+    rm  ${PREFIX}/bin/pydoc3
+    rm  ${PREFIX}/bin/python3-config
+
+    # remove broken links
     rm -rf ${PREFIX}/lib/pkgconfig 
 
     # we actually need a build folder

--- a/recipes/recipes_emscripten/python/build.sh
+++ b/recipes/recipes_emscripten/python/build.sh
@@ -106,6 +106,14 @@ if [[ $target_platform == "emscripten-32" ]]; then
     rm -rf ${PREFIX}/bin 
     rm -rf ${PREFIX}/lib/pkgconfig 
 
+
+    # we actually need a build folder
+    # otherwise other things downstream break
+    mkdir ${PREFIX}/bin 
+    touch dummy
+    cp dummy ${PREFIX}/bin 
+
+
 else
     mkdir -p build
     pushd build

--- a/recipes/recipes_emscripten/python/build.sh
+++ b/recipes/recipes_emscripten/python/build.sh
@@ -111,12 +111,6 @@ if [[ $target_platform == "emscripten-32" ]]; then
     # remove broken links
     rm -rf ${PREFIX}/lib/pkgconfig 
 
-    # we actually need a build folder
-    # otherwise other things downstream break
-    mkdir ${PREFIX}/bin 
-    touch dummy
-    cp dummy ${PREFIX}/bin 
-
 else
     mkdir -p build
     pushd build

--- a/recipes/recipes_emscripten/python/recipe.yaml
+++ b/recipes/recipes_emscripten/python/recipe.yaml
@@ -23,9 +23,9 @@ source:
 
 build:
   # ATTENTION need to change build number in build string as well!
-  number: 25
+  number: 26
   # check with https://github.com/mamba-org/boa/issues/278
-  string: h_hash_25_cpython
+  string: h_hash_26_cpython
   # run_exports:
   #   strong:
   #     - '{{ pin_subpackage("python", max_pin="x.x") }}'


### PR DESCRIPTION
keep python/bin and python executables as ohtherwise cross-python and other downstream tools break!