### PR TITLE
Revert "Remove ipywidgets recipe (#298)"

### DIFF
--- a/recipes/recipes_emscripten/ipywidgets/recipe.yaml
+++ b/recipes/recipes_emscripten/ipywidgets/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: "ipywidgets"
-  version: "8.0.1"
+  version: "8.0.6"
 
 package:
   name: "{{ name }}"

--- a/recipes/recipes_emscripten/ipywidgets/recipe.yaml
+++ b/recipes/recipes_emscripten/ipywidgets/recipe.yaml
@@ -1,0 +1,50 @@
+context:
+  name: "ipywidgets"
+  version: "8.0.1"
+
+package:
+  name: "{{ name }}"
+  version: '{{ version }}'
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1a296094203309e834f2781a275214d255ac5d266bbfa602f9f6915e1806614c
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}
+    - pip
+  host:
+    - python >=3.7
+  run:
+    - python >=3.7
+    - ipython >=4.0.0
+    # We don't have an ipykernel recipe yet
+    # - ipykernel >=4.5.1
+    - traitlets >=4.3.1,<6.0.0
+    - nbformat >=4.2.0
+    - widgetsnbextension >=4.0.0,<5.0.0
+    - jupyterlab_widgets >=3.0.0,<4.0.0
+    - ipython_genutils >=0.2.0,<0.3.0
+
+about:
+  home: https://github.com/ipython/ipywidgets
+  license: BSD-3-Clause
+  license_file: LICENSE
+  license_family: BSD
+  summary: Jupyter Interactive Widgets
+  description: |
+    ipywidgets are interactive HTML widgets for Jupyter notebooks and the IPython kernel.
+  doc_url: https://ipywidgets.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/index.rst
+
+
+extra:
+  recipe-maintainers:
+    - DerThorsten
+    - martinRenou

--- a/recipes/recipes_emscripten/ipywidgets/recipe.yaml
+++ b/recipes/recipes_emscripten/ipywidgets/recipe.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1a296094203309e834f2781a275214d255ac5d266bbfa602f9f6915e1806614c
+  sha256: de7d779f2045d60de9f6c25f653fdae2dba57898e6a1284494b3ba20b6893bb8
 
 build:
   number: 0


### PR DESCRIPTION
Looks like we need to revert https://github.com/emscripten-forge/recipes/pull/298 if we want to continue using more recent versions of `ipywidgets` for now.

Since `ipykernel` was added back in https://github.com/jupyter-widgets/ipywidgets/pull/3749.

- [x] Re-add the `ipywidgets` recipe
- [x] Bump to `8.0.6`