### PR TITLE
new pyjs in recipe, but old one in testing

### DIFF
--- a/recipes/recipes_emscripten/pyjs/recipe.yaml
+++ b/recipes/recipes_emscripten/pyjs/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.19.0
+  version: 1.0.0
   name: pyjs
 package:
   name: '{{name}}'
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/emscripten-forge/{{name}}/archive/refs/tags/{{version}}.tar.gz
-    sha256: 8032efdef851fa4ddc2819a123677a842f2e315c1c5d6a30cd3a5fe4e20c926e
+    sha256: 30663f7553f3a02f83db193a06a0191b30b771374f78caffb9af801dad535d1b
 build:
   number: 0
 

--- a/testing/package_testing.py
+++ b/testing/package_testing.py
@@ -40,7 +40,7 @@ def create_test_env(pkg_name, prefix, conda_bld_dir):
     )
 
     cmd = [
-        f"""$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python "pyjs>=0.18.0" pytest numpy {pkg_name}  {channels}"""
+        f"""$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python "pyjs==0.19.0" pytest numpy {pkg_name}  {channels}"""
     ]
     ret = subprocess.run(cmd, shell=True)
     #  stderr=subprocess.PIPE, stdout=subprocess.PIPE)


### PR DESCRIPTION
add new pyjs version to the recipe but pin the old version of pyjs in testing since pyjs 1.0.0 is API breaking