### PR TITLE
pinning pyjs_code_runner

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -28,4 +28,4 @@ dependencies:
   - pytest
   - networkx
   - microsoft::playwright
-  - pyjs_code_runner >= 1.1.0
+  - pyjs_code_runner == 1.1.0


### PR DESCRIPTION
pinning pyjs_code_runner before we merge and release https://github.com/emscripten-forge/empack/pull/66.
Empack itself is already upper bounded with`< 3` 