### PR TITLE
use new empack stack

### DIFF
--- a/.github/workflows/build_all.yaml
+++ b/.github/workflows/build_all.yaml
@@ -57,6 +57,23 @@ jobs:
           playwright install
 
       ################################################################
+      # setup emsdk
+      ################################################################
+      - name: "setup emsdk"
+        shell: bash -l {0}
+        run: |
+          micromamba activate ci-env
+
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk 
+          ./emsdk install  ${{ matrix.emsdk_ver }}
+          ./emsdk activate  ${{ matrix.emsdk_ver }}
+          echo $(pwd)/emsdk-${{ matrix.emsdk_ver }}
+          echo $(pwd) > $HOME/.emsdkdir
+
+
+
+      ################################################################
       # install / clone custom non-master things
       # for pip, we use --no-deps --ignore-installed
       # and make sure that all dependencies are already contained
@@ -67,13 +84,6 @@ jobs:
         run: |
           micromamba activate ci-env
           python -m pip install git+https://github.com/DerThorsten/boa.git@python_api             --no-deps --ignore-installed
-
-      - name: "setup emsdk"
-        shell: bash -l {0}
-        run: |
-          micromamba activate ci-env
-          python -c "from empack.file_packager import download_and_setup_emsdk; download_and_setup_emsdk('3.1.27')"
-          echo $(python -c "from empack.file_packager import EMSDK_INSTALL_PATH; print(EMSDK_INSTALL_PATH / 'emsdk-3.1.27')") > $HOME/.emsdkdir
 
 
       ################################################################

--- a/.github/workflows/build_recipes.yaml
+++ b/.github/workflows/build_recipes.yaml
@@ -68,6 +68,22 @@ jobs:
           playwright install
 
       ################################################################
+      # setup emsdk
+      ################################################################
+      - name: "setup emsdk"
+        shell: bash -l {0}
+        run: |
+          micromamba activate ci-env
+
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk 
+          ./emsdk install  ${{ matrix.emsdk_ver }}
+          echo $(pwd)/emsdk-${{ matrix.emsdk_ver }}
+          echo $(pwd) > $HOME/.emsdkdir
+
+
+
+      ################################################################
       # install / clone custom non-master things
       # for pip, we use --no-deps --ignore-installed
       # and make sure that all dependencies are already contained
@@ -78,13 +94,6 @@ jobs:
         run: |
           micromamba activate ci-env
           python -m pip install git+https://github.com/DerThorsten/boa.git@python_api             --no-deps --ignore-installed
-
-      - name: "setup emsdk"
-        shell: bash -l {0}
-        run: |
-          micromamba activate ci-env
-          python -c "from empack.file_packager import download_and_setup_emsdk; download_and_setup_emsdk('3.1.27')"
-          echo $(python -c "from empack.file_packager import EMSDK_INSTALL_PATH; print(EMSDK_INSTALL_PATH / 'emsdk-3.1.27')") > $HOME/.emsdkdir
 
       ################################################################
       # run pytests

--- a/.github/workflows/build_simple.yaml
+++ b/.github/workflows/build_simple.yaml
@@ -56,6 +56,21 @@ jobs:
           playwright install
 
       ################################################################
+      # setup emsdk
+      ################################################################
+      - name: "setup emsdk"
+        shell: bash -l {0}
+        run: |
+          micromamba activate ci-env
+
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk 
+          ./emsdk install  ${{ matrix.emsdk_ver }}
+          ./emsdk activate  ${{ matrix.emsdk_ver }}
+          echo $(pwd)/emsdk-${{ matrix.emsdk_ver }}
+          echo $(pwd) > $HOME/.emsdkdir
+
+      ################################################################
       # install / clone custom non-master things
       # for pip, we use --no-deps --ignore-installed
       # and make sure that all dependencies are already contained
@@ -67,12 +82,6 @@ jobs:
           micromamba activate ci-env
           python -m pip install git+https://github.com/DerThorsten/boa.git@python_api             --no-deps --ignore-installed
 
-      - name: "setup emsdk"
-        shell: bash -l {0}
-        run: |
-          micromamba activate ci-env
-          python -c "from empack.file_packager import download_and_setup_emsdk; download_and_setup_emsdk('3.1.27')"
-          echo $(python -c "from empack.file_packager import EMSDK_INSTALL_PATH; print(EMSDK_INSTALL_PATH / 'emsdk-3.1.27')") > $HOME/.emsdkdir
 
       ################################################################
       # build a package which is **not** on emscripten forge

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python
   - pip
-  - empack >=2,<3
+  - empack >=3,<4
   - colorama
   - ruamel
   - ruamel.yaml <0.17.6
@@ -28,4 +28,4 @@ dependencies:
   - pytest
   - networkx
   - microsoft::playwright
-  - pyjs_code_runner == 1.1.0
+  - pyjs_code_runner >= 2,<3

--- a/testing/package_testing.py
+++ b/testing/package_testing.py
@@ -40,7 +40,7 @@ def create_test_env(pkg_name, prefix, conda_bld_dir):
     )
 
     cmd = [
-        f"""$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python "pyjs==0.19.0" pytest numpy {pkg_name}  {channels}"""
+        f"""$MAMBA_EXE create --yes --prefix {prefix} --platform=emscripten-32   python "pyjs==1.0.0" pytest numpy {pkg_name}  {channels}"""
     ]
     ret = subprocess.run(cmd, shell=True)
     #  stderr=subprocess.PIPE, stdout=subprocess.PIPE)
@@ -108,7 +108,8 @@ def test_package(recipe, work_dir, conda_bld_dir):
                     BackendType.browser_worker,
                     lambda: dict(port=find_free_port(), slow_mo=1, headless=True),
                 ),
-                (BackendType.node, lambda: dict(node_binary=get_node_binary())),
+                # the node baxckend is atm disabled because it does not work with the new empack
+                #(BackendType.node, lambda: dict(node_binary=get_node_binary())),
             ]
             print(
                 "================================================================================"
@@ -128,6 +129,7 @@ def test_package(recipe, work_dir, conda_bld_dir):
                 try:
                     r = run(
                         conda_env=prefix,
+                        relocate_prefix="/",
                         backend_type=backend_type,
                         script="main.py",
                         async_main=True,

--- a/testing/test_empack_config.py
+++ b/testing/test_empack_config.py
@@ -1,5 +1,4 @@
 import os
-from empack.file_packager import pack_environment, pack_file
 from empack.file_patterns import pkg_file_filter_from_yaml
 
 from pathlib import Path


### PR DESCRIPTION
* use new empack stack (ie empack >= 3.0.0,  pyjs-code-runner >= 2.0.0, pyjs >-= 1.0.0) 
* This disables the node tests as we dropped node support atm (this might change, because we just need to install a fetch-like package for node to make node work again)
* there should be no changes for the users/recipe authors, besides:
   *  package might start to work since pyjs 1.0.0 uses a better way of instantiation the shared libraries  (ie in the correct order)
   * The `PREFIX` in the tests is always `/` instead of some random temporary directory