### PR TITLE
add gettext to build env for emscripten-emscripten-32

### DIFF
--- a/recipes/recipes/emscripten_emscripten-32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-32/recipe.yaml
@@ -33,6 +33,8 @@ outputs:
           - "{{ pin_compatible('emscripten-abi', min_pin='x.x.x', max_pin='x.x.x') }}"
 
     requirements:
+      build:
+        - gettext
       run:
         # - python 3.10
         - emsdk


### PR DESCRIPTION
Otherwise envsubst isn't there on macOS