### PR TITLE
Extend llvm package to include clang and lld

### DIFF
--- a/recipes/recipes_emscripten/llvm/build.sh
+++ b/recipes/recipes_emscripten/llvm/build.sh
@@ -21,6 +21,7 @@ emcmake cmake ${CMAKE_ARGS} -S ../llvm -B .         \
     -DLLVM_INCLUDE_EXAMPLES=OFF                     \
     -DLLVM_INCLUDE_TESTS=OFF                        \
     -DLLVM_ENABLE_LIBEDIT=OFF                       \
+    -DLLVM_ENABLE_PROJECTS="clang;lld"              \
     -DCMAKE_CXX_FLAGS="-Dwait4=__syscall_wait4"
 
 # Build step

--- a/recipes/recipes_emscripten/llvm/recipe.yaml
+++ b/recipes/recipes_emscripten/llvm/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 56b2f75fdaa95ad5e477a246d3f0d164964ab066b4619a01836ef08e475ec9d5
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
It seems like cross-compiling Clang and LLD separately from LLVM is tricky due to requiring native versions of some LLVM components as well as WASM versions. It is also wasteful in general. This is an attempt to include these within the llvm package. It should still produce separate static libraries.