### PR TITLE
Add WASM version (`noarch`, no LinAlg solvers) of `bw2calc`

### DIFF
--- a/recipes/recipes_emscripten/bw2calc/recipe.yaml
+++ b/recipes/recipes_emscripten/bw2calc/recipe.yaml
@@ -1,0 +1,43 @@
+package:
+  name: bw2calc
+  version: '2.0.dev13'
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: fb3e8076d6048d3acda147c83534dced9568079cf9d8d8b7fb0153731a0f8d87
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - bw_processing
+    - matrix_utils
+    - numpy
+    - pandas
+    - scipy
+    - stats_arrays
+
+test:
+  imports:
+    - bw2calc
+
+about:
+  home: https://github.com/brightway-lca/brightway2-calc
+  summary: 'The calculation engine for the Brightway2 life cycle assessment framework.'
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  dev_url: https://github.com/brightway-lca/brightway2-calc
+
+extra:
+  recipe-maintainers:
+    - michaelweinold
+    - cmutel


### PR DESCRIPTION
This was discussed with @martinRenou in https://github.com/conda-forge/bw2calc-feedstock/pull/14