### PR TITLE
Added cpp-argparse package

### DIFF
--- a/recipes/recipes_emscripten/argparse/build.sh
+++ b/recipes/recipes_emscripten/argparse/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+mkdir build && cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_BUILD_TYPE=Release \
+      $SRC_DIR
+
+make VERBOSE=1 -j${CPU_COUNT}
+make install

--- a/recipes/recipes_emscripten/argparse/build.sh
+++ b/recipes/recipes_emscripten/argparse/build.sh
@@ -4,6 +4,7 @@ mkdir build && cd build
 
 cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_INSTALL_LIBDIR=lib \
+      -DARGPARSE_BUILD_TESTS=OFF \
       -DCMAKE_BUILD_TYPE=Release \
       $SRC_DIR
 

--- a/recipes/recipes_emscripten/argparse/recipe.yaml
+++ b/recipes/recipes_emscripten/argparse/recipe.yaml
@@ -1,0 +1,38 @@
+context:
+  version: "3.0"
+
+package:
+  name: cpp-argparse
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/p-ranav/argparse/archive/v{{ version }}.tar.gz
+  sha256: ba7b465759bb01069d57302855eaf4d1f7d677f21ad7b0b00b92939645c30f47
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - "{{ compiler('cxx') }}"
+    - cmake
+    - make  # [unix]
+
+# test:
+#   commands:
+#     - test -d ${PREFIX}/include/argparse  # [unix]
+#     - test -f ${PREFIX}/include/argparse/argparse.hpp  # [unix]
+#     - if exist %LIBRARY_PREFIX%\include\argparse\argparse.hpp (exit 0) else (exit 1)  # [win]
+
+about:
+  home: https://github.com/p-ranav/argparse
+  summary: 'Argument Parser for Modern C++ '
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/p-ranav/argparse
+
+extra:
+  recipe-maintainers:
+    - p-ranav
+    - DerThorsten
+    - anutosh491


### PR DESCRIPTION
This PR adds the 3.0 version of the argparse package (https://github.com/p-ranav/argparse). I've used cpp-argparse to keep the naming convention similar to that of conda-forge