### PR TITLE
Update to `xeus-javascript` 0.2.0

### DIFF
--- a/recipes/recipes_emscripten/xeus-javascript/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-javascript/recipe.yaml
@@ -1,13 +1,13 @@
 context:
-  version: 0.1.0
+  version: 0.2.0
 
 package:
   name: xeus-javascript
   version: '{{ version }}'
 
 source:
-  url: https://github.com/DerThorsten/xeus-javascript/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 5d3779ea0c8b854c1227d13721190573888357d1e38e8598176be4a07e8069b2
+  url: https://github.com/jupyter-xeus/xeus-javascript/archive/refs/tags/{{ version }}.tar.gz
+  sha256: e06b677c46d80509d750a674fa86cb6cfe535764
 
 build:
   number: 0
@@ -29,13 +29,13 @@ test:
     - sel(emscripten): test -f $PREFIX/bin/xjavascript.js
 
 about:
-  home: https://github.com/DerThorsten/xeus-javascript
+  home: https://github.com/jupyter-xeus/xeus-javascript
   license: BSD-3
   license_family: BSD-3
   license_file: LICENSE
   summary: xeus-javascript
-  doc_url: https://github.com/DerThorsten/xeus-javascript
-  dev_url: https://github.com/DerThorsten/xeus-javascript
+  doc_url: https://github.com/jupyter-xeus/xeus-javascript
+  dev_url: https://github.com/jupyter-xeus/xeus-javascript
 
 extra:
   recipe-maintainers:

--- a/recipes/recipes_emscripten/xeus-javascript/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-javascript/recipe.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/jupyter-xeus/xeus-javascript/archive/refs/tags/{{ version }}.tar.gz
-  sha256: e06b677c46d80509d750a674fa86cb6cfe535764
+  sha256: 13f5b7068362f4e280568b62b55dba11d2b5dc4cb1cd65b967813fd0be0f287b
 
 build:
   number: 0


### PR DESCRIPTION
- Update to the latest version: https://github.com/jupyter-xeus/xeus-javascript/releases/tag/0.2.0
- Update links as the repo is now under the `jupyter-xeus` organization: https://github.com/jupyter-xeus