### PR TITLE
Add new package contourpy 1.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Once the PR is merged, the package is built and uploaded to https://beta.mamba.p
 ## Local Builds
 Local builds are useful for testing new recipes or debugging build issues, but the setup is a bit more involved and will only work for Linux and MacOS. Local builds on Windows are not yet supported.
 
- **1** Create a new conda environment from `ci_env.yaml` and install playwright in this environment:
+ **1** Create a new conda environment from `ci_env.yml` and install playwright in this environment:
  On a Linux system this can be done with:
 ```bash
-micromamba create -n emscripten-forge -f ci_env.yaml --yes
+micromamba create -n emscripten-forge -f ci_env.yml --yes
 micromamba activate emscripten-forge
 playwright install
 ``` 
@@ -99,7 +99,7 @@ If you want to build multiple packages which depend on each other, you have to a
 of the `emscripten-forge` environment to the `.condarc` file. This is usually located in `~/micromamba/envs/emscripten-forge/conda-bld` on unix systems.
 ```bash
 channels:
-  - /home/your-user-name/micromanba/envs/emscripten-forge/conda-bld
+  - /home/your-user-name/micromamba/envs/emscripten-forge/conda-bld
   - "https://repo.mamba.pm/emscripten-forge"
   - conda-forge
 ```

--- a/recipes/recipes_emscripten/contourpy/build.sh
+++ b/recipes/recipes_emscripten/contourpy/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Removing this warning will not be needed after the next pybind11 release
+export CPPFLAGS="-Wno-deprecated-literal-operator"
+
+${PYTHON} -m pip install . -vvv --no-deps

--- a/recipes/recipes_emscripten/contourpy/recipe.yaml
+++ b/recipes/recipes_emscripten/contourpy/recipe.yaml
@@ -1,0 +1,39 @@
+context:
+  name: contourpy
+  version: '1.0.7'
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  - url: https://files.pythonhosted.org/packages/b4/9b/6edb9d3e334a70a212f66a844188fcb57ddbd528cbc3b1fe7abfc317ddd7/contourpy-{{ version }}.tar.gz
+    sha256: d8165a088d31798b59e91117d1f5fc3df8168d8b48c4acc10fc0df0d0bdbcc5e
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - "{{ compiler('cxx') }}"
+    - cross-python_emscripten-wasm32
+    - pybind11
+  host:
+    - python
+  run:
+    - numpy
+
+about:
+  home: https://github.org/contourpy/contourpy
+  PyPI: https://pypi.org/project/contourpy
+  summary: Python library for calculating contours of 2D quadrilateral grids
+  license: BSD-3-Clause
+
+extra:
+  emscripten_tests:
+    python:
+      pytest_files:
+        - test_contourpy.py
+
+  recipe-maintainers:
+    - ianthomas23

--- a/recipes/recipes_emscripten/contourpy/test_contourpy.py
+++ b/recipes/recipes_emscripten/contourpy/test_contourpy.py
@@ -1,0 +1,210 @@
+import pytest
+
+
+def test_import():
+    import contourpy
+    import contourpy._contourpy
+
+
+@pytest.mark.parametrize(
+    "name, line_type",
+    [
+        ("mpl2005", "SeparateCode"),
+        ("mpl2014", "SeparateCode"),
+        ("serial", "Separate"),
+        ("serial", "SeparateCode"),
+        ("serial", "ChunkCombinedCode"),
+        ("serial", "ChunkCombinedOffset"),
+        #("serial", "ChunkCombinedNan"),  # Needs contourpy >= 1.2.0
+        ("threaded", "Separate"),
+        ("threaded", "SeparateCode"),
+        ("threaded", "ChunkCombinedCode"),
+        ("threaded", "ChunkCombinedOffset"),
+        #("threaded", "ChunkCombinedNan"),  # Needs contourpy >= 1.2.0
+    ],
+)
+def test_line(name, line_type):
+    import numpy as np
+    from contourpy import LineType, contour_generator
+    from numpy.testing import assert_array_almost_equal, assert_array_equal
+
+    z = [[1.5, 1.5, 0.9, 0.0], [1.5, 2.8, 0.4, 0.8], [0.0, 0.0, 0.8, 6.0]]
+
+    cont_gen = contour_generator(z=z, name=name, line_type=line_type)
+    assert cont_gen.line_type.name == line_type
+    assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
+
+    lines = cont_gen.lines(2.0)
+
+    expect0 = np.array(
+        [
+            [0.38461538, 1.0],
+            [1.0, 0.38461538],
+            [1.33333333, 1.0],
+            [1.0, 1.28571429],
+            [0.38461538, 1.0],
+        ]
+    )
+    if name in ("mpl2005", "mpl2014"):
+        expect0 = np.vstack((expect0[1:], expect0[1]))  # Starts with index 1
+
+    expect1 = np.array([[2.23076923, 2.0], [3.0, 1.23076923]])
+    if name == "mpl2005":
+        expect1 = expect1[::-1]
+
+    if cont_gen.line_type == LineType.Separate:
+        points = lines
+        assert len(points) == 2
+        assert_array_almost_equal(points[0], expect0)
+        assert_array_almost_equal(points[1], expect1)
+    elif cont_gen.line_type == LineType.SeparateCode:
+        points, codes = lines
+        assert len(points) == 2
+        if name == "mpl2014":
+            points = points[::-1]
+            codes = codes[::-1]
+        assert_array_almost_equal(points[0], expect0)
+        assert_array_almost_equal(points[1], expect1)
+        assert_array_equal(codes[0], [1, 2, 2, 2, 79])
+        assert_array_equal(codes[1], [1, 2])
+    elif cont_gen.line_type == LineType.ChunkCombinedCode:
+        assert len(lines[0]) == 1  # Single chunk.
+        points, codes = lines[0][0], lines[1][0]
+        assert points.shape == (7, 2)
+        assert_array_almost_equal(points[:5], expect0)
+        assert_array_almost_equal(points[5:], expect1)
+        assert_array_equal(codes, [1, 2, 2, 2, 79, 1, 2])
+    elif cont_gen.line_type == LineType.ChunkCombinedOffset:
+        assert len(lines[0]) == 1  # Single chunk.
+        points, offsets = lines[0][0], lines[1][0]
+        assert points.shape == (7, 2)
+        assert_array_almost_equal(points[:5], expect0)
+        assert_array_almost_equal(points[5:], expect1)
+        assert_array_equal(offsets, [0, 5, 7])
+    elif cont_gen.line_type == LineType.ChunkCombinedNan:
+        assert len(lines[0]) == 1  # Single chunk.
+        points = lines[0][0]
+        assert points.shape == (8, 2)
+        assert_array_almost_equal(points[:5], expect0)
+        assert np.all(np.isnan(points[5, :]))
+        assert_array_almost_equal(points[6:], expect1)
+    else:
+        raise RuntimeError(f"Unexpected line_type {line_type}")
+
+
+@pytest.mark.parametrize(
+    "name, fill_type",
+    [
+        ("mpl2005", "OuterCode"),
+        ("mpl2014", "OuterCode"),
+        ("serial", "OuterCode"),
+        ("serial", "OuterOffset"),
+        ("serial", "ChunkCombinedCode"),
+        ("serial", "ChunkCombinedOffset"),
+        ("serial", "ChunkCombinedCodeOffset"),
+        ("serial", "ChunkCombinedOffsetOffset"),
+        ("threaded", "OuterCode"),
+        ("threaded", "OuterOffset"),
+        ("threaded", "ChunkCombinedCode"),
+        ("threaded", "ChunkCombinedOffset"),
+        ("threaded", "ChunkCombinedCodeOffset"),
+        ("threaded", "ChunkCombinedOffsetOffset"),
+    ],
+)
+def test_fill(name, fill_type):
+    import numpy as np
+    from contourpy import FillType, contour_generator
+    from numpy.testing import assert_array_almost_equal, assert_array_equal
+
+    z = [[1.5, 1.5, 0.9, 0.0], [1.5, 2.8, 0.4, 0.8], [0.0, 0.0, 0.8, 1.9]]
+
+    cont_gen = contour_generator(z=z, name=name, fill_type=fill_type)
+    assert cont_gen.fill_type.name == fill_type
+    assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
+
+    filled = cont_gen.filled(1.0, 2.0)
+
+    expect0 = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.83333333, 0.0],
+            [1.75, 1.0],
+            [1.0, 1.64285714],
+            [0.0, 1.33333333],
+            [0.0, 1.0],
+            [0.0, 0.0],
+            [1.0, 0.38461538],
+            [0.38461538, 1.0],
+            [1.0, 1.28571429],
+            [1.33333333, 1.0],
+            [1.0, 0.38461538],
+        ]
+    )
+    if name == "mpl2014":
+        expect0 = np.vstack((expect0[1:8], expect0[1], expect0[9:], expect0[9]))
+
+    expect1 = np.array(
+        [[2.18181818, 2.0], [3.0, 1.18181818], [3.0, 2.0], [2.18181818, 2.0]]
+    )
+    if name in ("mpl2005", "mpl2014"):
+        expect1 = np.vstack((expect1[1:], expect1[1]))  # Starts with index 1
+
+    # Helper functions to avoid code duplication for the different FillTypes.
+    def assert_outer_points(points):
+        assert isinstance(points, list) and len(points) == 2
+        assert_array_almost_equal(points[0], expect0)
+        assert_array_almost_equal(points[1], expect1)
+
+    def assert_chunk_points(points):
+        assert isinstance(points, list) and len(points) == 1
+        assert points[0].shape == (17, 2)
+        assert_array_almost_equal(points[0][:13], expect0)
+        assert_array_almost_equal(points[0][13:], expect1)
+
+    def assert_chunk_codes(codes):
+        assert isinstance(codes, list) and len(codes) == 1
+        assert_array_equal(
+            codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79]
+        )
+
+    def assert_chunk_offsets(offsets):
+        assert isinstance(offsets, list) and len(offsets) == 1
+        assert_array_equal(offsets[0], [0, 8, 13, 17])
+
+    if cont_gen.fill_type == FillType.OuterCode:
+        assert_outer_points(filled[0])
+        codes = filled[1]
+        assert isinstance(codes, list) and len(codes) == 2
+        assert_array_equal(codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79])
+        assert_array_equal(codes[1], [1, 2, 2, 79])
+    elif cont_gen.fill_type == FillType.OuterOffset:
+        assert_outer_points(filled[0])
+        offsets = filled[1]
+        assert isinstance(offsets, list) and len(offsets) == 2
+        assert_array_equal(offsets[0], [0, 8, 13])
+        assert_array_equal(offsets[1], [0, 4])
+    elif cont_gen.fill_type == FillType.ChunkCombinedCode:
+        assert_chunk_points(filled[0])
+        assert_chunk_codes(filled[1])
+    elif cont_gen.fill_type == FillType.ChunkCombinedOffset:
+        assert_chunk_points(filled[0])
+        assert_chunk_offsets(filled[1])
+    elif cont_gen.fill_type == FillType.ChunkCombinedCodeOffset:
+        assert_chunk_points(filled[0])
+        assert_chunk_codes(filled[1])
+
+        outer_offsets = filled[2]
+        assert isinstance(outer_offsets, list) and len(outer_offsets) == 1
+        assert_array_equal(outer_offsets[0], [0, 13, 17])
+    elif cont_gen.fill_type == FillType.ChunkCombinedOffsetOffset:
+        assert_chunk_points(filled[0])
+        assert_chunk_offsets(filled[1])
+
+        outer_offsets = filled[2]
+        assert isinstance(outer_offsets, list) and len(outer_offsets) == 1
+        assert_array_equal(outer_offsets[0], [0, 2, 3])
+    else:
+        raise RuntimeError(f"Unexpected fill_type {fill_type}")

--- a/recipes/recipes_emscripten/matplotlib/recipe.yaml
+++ b/recipes/recipes_emscripten/matplotlib/recipe.yaml
@@ -17,7 +17,7 @@ source:
   - path: setupext.py
 
 build:
-  number: 0
+  number: 1
 
 extra:
   emscripten_tests:
@@ -50,6 +50,7 @@ steps:
         - numpy
         - pybind11
       run:
+        - contourpy
         - cycler
         - fonttools
         - kiwisolver


### PR DESCRIPTION
The version of Matplotlib built in this repo, 3.8.2, requires ContourPy to calculate contours. As ContourPy is not yet in this repo any attempt to plot contours in Matplotlib fails with an import error.

Here I am adding ContourPy 1.0.7 which is the latest version available that does not use `meson` for building. I haven't yet succeeded with the `meson` build due to some problems cross-compiling, and I would like to have ContourPy available as soon as possible and I'll upgrade to the latest version in due course.

The build itself is quite simple with one compiler warning disabled which will not be necessary after the next `pybind11` release. The tests are similar to those for `pyodide`.

I have added `contourpy` as a runtime dependency of `matplotlib` and bumped the build number. Matplotlib runtime dependencies for the 3.8.2 are listed at https://github.com/matplotlib/matplotlib/blob/4591c5b8c5a7b8b721f8173ba5d7ed7751fe6922/setup.py#L332C1-L333C1

I've tested the new ContourPy and Matplotlib builds locally using a JupyterLite deployment that points to my local `emscripten-forge/conda-bld` directory.

I have also fixed a couple of typos in the README rather than open a separate PR.