### PR TITLE
Add missing dev dependencies

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -28,6 +28,8 @@ dependencies:
   - pyjs_code_runner >= 2,<3
   - cxx-compiler
   - c-compiler
+  - cmake
+  - make
   # hack to get in boas dependencies
   - ruamel.yaml < 0.18
   - jinja2


### PR DESCRIPTION
Fixes https://github.com/emscripten-forge/recipes/issues/811

`make` and `cmake` might not be installed globally on some system, so we can also install them from conda-forge.