### PR TITLE
Add CppInterOp recipe

### DIFF
--- a/recipes/recipes_emscripten/CppInterOp/build.sh
+++ b/recipes/recipes_emscripten/CppInterOp/build.sh
@@ -1,0 +1,23 @@
+mkdir build
+cd build
+
+export CMAKE_PREFIX_PATH=$PREFIX
+export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
+
+# Configure step
+emcmake  cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+    -DUSE_CLING=OFF                                     \
+    -DUSE_REPL=ON                                       \
+    -DCMAKE_PREFIX_PATH=$PREFIX                         \
+    -DLLVM_DIR=$PREFIX       			        \
+    -DClang_DIR=$PREFIX				        \
+    -DBUILD_SHARED_LIBS=ON                              \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX        	        \
+    -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON              \
+    ../
+
+# Build step
+EMCC_CFLAGS='-sERROR_ON_UNDEFINED_SYMBOLS=0' emmake make -j1
+
+# Install step
+emmake make install

--- a/recipes/recipes_emscripten/CppInterOp/patches/CppInterOp/0001-cmake-Work-around-a-bug-in-the-llvm-config.patch
+++ b/recipes/recipes_emscripten/CppInterOp/patches/CppInterOp/0001-cmake-Work-around-a-bug-in-the-llvm-config.patch
@@ -1,0 +1,28 @@
+From 3069b953dd1303eb4bd1171a8f5c5501ecdafc29 Mon Sep 17 00:00:00 2001
+From: Vassil Vassilev <v.g.vassilev@gmail.com>
+Date: Sun, 3 Mar 2024 20:32:15 +0000
+Subject: [PATCH] [cmake] Work around a bug in the llvm config.
+
+In short we use variables which require including `GNUInstallDirs` but we are
+expecting somebody else to include it for us.
+
+See llvm/llvm-project#83802
+---
+ CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 548e535..f4efb0e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,7 @@
+ cmake_minimum_required(VERSION 3.13)
+ 
++include(GNUInstallDirs)
++
+ set(CMAKE_MODULE_PATH
+   ${CMAKE_MODULE_PATH}
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+-- 
+2.37.1 (Apple Git-137.1)
+

--- a/recipes/recipes_emscripten/CppInterOp/patches/CppInterOp/0002-cmake-Fix-install-folder.patch
+++ b/recipes/recipes_emscripten/CppInterOp/patches/CppInterOp/0002-cmake-Fix-install-folder.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d8b340a..d4e066b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -326,7 +326,7 @@ configure_file(
+   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CppInterOp/CppInterOpConfigVersion.cmake.in
+   ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/CppInterOp/CppInterOpConfigVersion.cmake
+   @ONLY)
+-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/CppInterOp
++install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/CppInterOp/
+   DESTINATION lib/cmake/CppInterOp
+   FILES_MATCHING
+   PATTERN "*.cmake"

--- a/recipes/recipes_emscripten/CppInterOp/recipe.yaml
+++ b/recipes/recipes_emscripten/CppInterOp/recipe.yaml
@@ -1,0 +1,48 @@
+context:
+  version: 1.2.0
+
+package:
+  name: llvm
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/compiler-research/CppInterOp/archive/refs/tags/{{ revision_tag }}.tar.gz
+  sha256: b3cf25f500624fe12ffc40f858a04c46daea808298e64d924b594eb35ca1c806
+  patches:
+    - patches/cppinterop/0001-cmake-Work-around-a-bug-in-the-llvm-config.patch
+    - patches/cppinterop/0002-cmake-Fix-install-folder.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - '{{ compiler("cxx") }}'
+    - cmake
+    - make  # [unix]
+  host:
+    - llvm
+
+about:
+  home: https://github.com/compiler-research/CppInterOp
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  license_file: cppinterop/LICENSE.txt
+  summary: |
+    The CppInterOp library provides a minimalist approach for other languages
+    to interoperate with C++ entities.
+  description: |
+    CppInterOp exposes API from Clang and LLVM in a backward compatibe way.
+    The API support downstream tools that utilize interactive C++ by using
+    the compiler as a service. That is, embed Clang and LLVM as a libraries
+    in their codebases. The API are designed to be minimalistic and aid
+    non-trivial tasks such as language interoperability on the fly. In such
+    scenarios CppInterOp can be used to provide the necessary introspection
+    information to the other side helping the language cross talk.
+  doc_url: https://cppinterop.readthedocs.io/en/{{ version }}
+  dev_url: https://cppinterop.readthedocs.io/en/{{ version }}/DevelopersDocumentation.html
+
+extra:
+  recipe-maintainers:
+    - alexander-penev
+    - vgvassilev


### PR DESCRIPTION
This adds a recipe for CppInterOp
@vgvassilev Here is the wasm build recipe we discussed. 
@alexander-penev I have added use as the second maintainer to be consistent with the conda-forge package