### PR TITLE
Add 0003-cmake-config-fix-library-suffix-and-prefix.patch to CppInterOp

### DIFF
--- a/recipes/recipes_emscripten/cppinterop/build.sh
+++ b/recipes/recipes_emscripten/cppinterop/build.sh
@@ -11,7 +11,7 @@ emcmake  cmake -DCMAKE_BUILD_TYPE=Release               \
     -DCMAKE_PREFIX_PATH=$PREFIX                         \
     -DLLVM_DIR=$PREFIX       			                \
     -DClang_DIR=$PREFIX				                    \
-    -DBUILD_SHARED_LIBS=ON                              \
+    -DBUILD_SHARED_LIBS=OFF                              \
     -DCMAKE_INSTALL_PREFIX=$PREFIX        	            \
     -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON              \
     ../

--- a/recipes/recipes_emscripten/cppinterop/patches/cppinterop/0003-cmake-config-fix-library-suffix-and-prefix.patch
+++ b/recipes/recipes_emscripten/cppinterop/patches/cppinterop/0003-cmake-config-fix-library-suffix-and-prefix.patch
@@ -1,0 +1,45 @@
+diff --git a/cmake/CppInterOp/CppInterOpConfig.cmake.in b/cmake/CppInterOp/CppInterOpConfig.cmake.in
+index 6a2a810..414c1c0 100644
+--- a/cmake/CppInterOp/CppInterOpConfig.cmake.in
++++ b/cmake/CppInterOp/CppInterOpConfig.cmake.in
+@@ -10,19 +10,20 @@ get_filename_component(CPPINTEROP_INSTALL_PREFIX "${CPPINTEROP_INSTALL_PREFIX}"
+ include(CMakeSystemSpecificInformation)
+ 
+ ### build/install workaround
++if (@BUILD_SHARED_LIBS@)
++  set(__lib_suffix ${CMAKE_SHARED_LIBRARY_SUFFIX})
++  set(__lib_prefix ${CMAKE_SHARED_LIBRARY_PREFIX})
++else()    
++  set(__lib_suffix ${CMAKE_STATIC_LIBRARY_SUFFIX})
++  set(__lib_prefix ${CMAKE_STATIC_LIBRARY_PREFIX})
++endif()
+ 
+ if (IS_DIRECTORY "${CPPINTEROP_INSTALL_PREFIX}/include")
+   set(_include "${CPPINTEROP_INSTALL_PREFIX}/include")
+-  set(_libs "${CPPINTEROP_INSTALL_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}clangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX}")
++  set(_libs "${CPPINTEROP_INSTALL_PREFIX}/lib/${__lib_prefix}clangCppInterOp${__lib_suffix}")
+ else()
+   set(_include "@CMAKE_CURRENT_SOURCE_DIR@/include")
+-  set(_libs "@CMAKE_CURRENT_BINARY_DIR@/lib/${CMAKE_SHARED_LIBRARY_PREFIX}clangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX}")
+-endif()
+-
+-if (IS_DIRECTORY "${CPPINTEROP_INSTALL_PREFIX}/lib/cmake/CppInterOp")
+-  set(_cmake "${CPPINTEROP_INSTALL_PREFIX}/lib/cmake/CppInterOp")
+-else()
+-  set(_cmake "@CMAKE_CURRENT_SOURCE_DIR@/cmake/CppInterOp")
++  set(_libs "@CMAKE_CURRENT_BINARY_DIR@/lib/${__lib_prefix}clangCppInterOp${__lib_suffix}")
+ endif()
+ 
+ ###
+@@ -33,7 +34,11 @@ set(CPPINTEROP_INCLUDE_DIRS "${_include}")
+ set(CPPINTEROP_LIBRARIES "${_libs}")
+ 
+ # Provide all our library targets to users.
+-add_library(clangCppInterOp SHARED IMPORTED)
++if (@BUILD_SHARED_LIBS@)
++  add_library(clangCppInterOp SHARED IMPORTED)
++else()    
++  add_library(clangCppInterOp STATIC IMPORTED)
++endif()
+ set_property(TARGET clangCppInterOp PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${_include}")
+ set_property(TARGET clangCppInterOp PROPERTY IMPORTED_LOCATION "${_libs}")

--- a/recipes/recipes_emscripten/cppinterop/recipe.yaml
+++ b/recipes/recipes_emscripten/cppinterop/recipe.yaml
@@ -11,9 +11,10 @@ source:
   patches:
     - patches/cppinterop/0001-cmake-Work-around-a-bug-in-the-llvm-config.patch
     - patches/cppinterop/0002-cmake-Fix-install-folder.patch
+    - patches/cppinterop/0003-cmake-config-fix-library-suffix-and-prefix.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
@vgvassilev Here is the patch to CppInterOp so it picks the right suffix when finding the library.

@anutosh491 @JohanMabille can you review this PR for me please?