### PR TITLE
Add 0005-Fix-config-for-msvc.patch & 0006-Export-symbols-in-Windows-DLL.patch patches cppinterop

### DIFF
--- a/recipes/recipes_emscripten/cppinterop/patches/cppinterop/0005-Fix-config-for-msvc.patch
+++ b/recipes/recipes_emscripten/cppinterop/patches/cppinterop/0005-Fix-config-for-msvc.patch
@@ -1,0 +1,87 @@
+From 82478204b3e52f98b3d6622f47ba21fd7c453224 Mon Sep 17 00:00:00 2001
+From: Vassil Vassilev <v.g.vassilev@gmail.com>
+Date: Mon, 18 Mar 2024 20:09:06 +0000
+Subject: [PATCH] [cmake] Clean up and improve the CppInterOp config for
+ Windows.
+
+---
+ cmake/CppInterOp/CppInterOpConfig.cmake.in | 41 ++++++++++++++++------
+ 1 file changed, 31 insertions(+), 10 deletions(-)
+
+diff --git a/cmake/CppInterOp/CppInterOpConfig.cmake.in b/cmake/CppInterOp/CppInterOpConfig.cmake.in
+index 414c1c0..b2dd5a5 100644
+--- a/cmake/CppInterOp/CppInterOpConfig.cmake.in
++++ b/cmake/CppInterOp/CppInterOpConfig.cmake.in
+@@ -9,21 +9,27 @@ get_filename_component(CPPINTEROP_INSTALL_PREFIX "${CPPINTEROP_INSTALL_PREFIX}"
+ # Determine CMAKE_SHARED_LIBRARY_SUFFIX based on operating system
+ include(CMakeSystemSpecificInformation)
+ 
++if(MSVC)
++  set(shared_lib_dir bin)
++else()
++  set(shared_lib_dir lib)
++endif()
++
+ ### build/install workaround
+ if (@BUILD_SHARED_LIBS@)
+-  set(__lib_suffix ${CMAKE_SHARED_LIBRARY_SUFFIX})
+-  set(__lib_prefix ${CMAKE_SHARED_LIBRARY_PREFIX})
++  set(_lib_suffix ${CMAKE_SHARED_LIBRARY_SUFFIX})
++  set(_lib_prefix ${CMAKE_SHARED_LIBRARY_PREFIX})
+ else()    
+-  set(__lib_suffix ${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(__lib_prefix ${CMAKE_STATIC_LIBRARY_PREFIX})
++  set(_lib_suffix ${CMAKE_STATIC_LIBRARY_SUFFIX})
++  set(_lib_prefix ${CMAKE_STATIC_LIBRARY_PREFIX})
+ endif()
+ 
+ if (IS_DIRECTORY "${CPPINTEROP_INSTALL_PREFIX}/include")
+   set(_include "${CPPINTEROP_INSTALL_PREFIX}/include")
+-  set(_libs "${CPPINTEROP_INSTALL_PREFIX}/lib/${__lib_prefix}clangCppInterOp${__lib_suffix}")
++  set(_lib "${CPPINTEROP_INSTALL_PREFIX}/${shared_lib_dir}/${_lib_prefix}clangCppInterOp${_lib_suffix}")
+ else()
+   set(_include "@CMAKE_CURRENT_SOURCE_DIR@/include")
+-  set(_libs "@CMAKE_CURRENT_BINARY_DIR@/lib/${__lib_prefix}clangCppInterOp${__lib_suffix}")
++  set(_lib "@CMAKE_CURRENT_BINARY_DIR@/${shared_lib_dir}/${_lib_prefix}clangCppInterOp${_lib_suffix}")
+ endif()
+ 
+ ###
+@@ -31,7 +37,7 @@ endif()
+ set(CPPINTEROP_EXPORTED_TARGETS "clangCppInterOp")
+ set(CPPINTEROP_CMAKE_DIR "${_cmake}")
+ set(CPPINTEROP_INCLUDE_DIRS "${_include}")
+-set(CPPINTEROP_LIBRARIES "${_libs}")
++set(CPPINTEROP_LIBRARIES "${_lib}")
+ 
+ # Provide all our library targets to users.
+ if (@BUILD_SHARED_LIBS@)
+@@ -39,9 +45,24 @@ if (@BUILD_SHARED_LIBS@)
+ else()    
+   add_library(clangCppInterOp STATIC IMPORTED)
+ endif()
+-set_property(TARGET clangCppInterOp PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${_include}")
+-set_property(TARGET clangCppInterOp PROPERTY IMPORTED_LOCATION "${_libs}")
++set_target_properties(clangCppInterOp PROPERTIES
++  INTERFACE_INCLUDE_DIRECTORIES ${_include}
++  IMPORTED_LOCATION ${_lib}
++  )
++if (MSVC)
++  if (IS_DIRECTORY "${CPPINTEROP_INSTALL_PREFIX}/include")
++    set(_static_lib "${CPPINTEROP_INSTALL_PREFIX}/lib/${_lib_prefix}clangCppInterOp.lib")
++  else()
++    set(_static_lib "@CMAKE_CURRENT_BINARY_DIR@/lib/${_lib_prefix}clangCppInterOp.lib")
++  endif()
++
++  set_target_properties(clangCppInterOp PROPERTIES
++    IMPORTED_IMPLIB ${_static_lib}
++    )
++endif(MSVC)
+ 
++unset(_lib_prefix)
++unset(_lib_suffix)
+ unset(_cmake)
+ unset(_include)
+-unset(_libs)
++unset(_lib)
+-- 
+2.37.1 (Apple Git-137.1)

--- a/recipes/recipes_emscripten/cppinterop/patches/cppinterop/0006-Export-symbols-in-Windows-DLL.patch
+++ b/recipes/recipes_emscripten/cppinterop/patches/cppinterop/0006-Export-symbols-in-Windows-DLL.patch
@@ -1,0 +1,642 @@
+From 310d7c3498442990c9a6980f063e603d5c1c843a Mon Sep 17 00:00:00 2001
+From: Alexander Penev <alexander.p.penev@gmail.com>
+Date: Wed, 20 Mar 2024 03:02:52 +0000
+Subject: [PATCH] Export symbols in Windows DLL
+
+---
+ include/clang/Interpreter/CppInterOp.h | 270 +++++++++++++------------
+ lib/Interpreter/CppInterOp.cpp         |   2 +-
+ 2 files changed, 146 insertions(+), 126 deletions(-)
+
+diff --git a/include/clang/Interpreter/CppInterOp.h b/include/clang/Interpreter/CppInterOp.h
+index 96345ff..4392950 100644
+--- a/include/clang/Interpreter/CppInterOp.h
++++ b/include/clang/Interpreter/CppInterOp.h
+@@ -15,6 +15,13 @@
+ #include <string>
+ #include <vector>
+ 
++// The cross-platform CPPINTEROP_API macro definition
++#ifdef _WIN32
++#define CPPINTEROP_API __declspec(dllexport)
++#else
++#define CPPINTEROP_API __attribute__((visibility("default")))
++#endif
++
+ namespace Cpp {
+   using TCppIndex_t = size_t;
+   using TCppScope_t = void*;
+@@ -29,7 +36,7 @@ namespace Cpp {
+   /// function, constructor or destructor.
+   class JitCall {
+   public:
+-    friend JitCall MakeFunctionCallable(TCppConstFunction_t);
++    friend CPPINTEROP_API JitCall MakeFunctionCallable(TCppConstFunction_t);
+     enum Kind : char {
+       kUnknown = 0,
+       kGenericCall,
+@@ -118,317 +125,325 @@ namespace Cpp {
+   };
+ 
+   ///\returns the version string information of the library.
+-  std::string GetVersion();
++  CPPINTEROP_API std::string GetVersion();
+ 
+   /// Enables or disables the debugging printouts on stderr.
+   /// Debugging output can be enabled also by the environment variable
+   /// CPPINTEROP_EXTRA_INTERPRETER_ARGS. For example,
+   /// CPPINTEROP_EXTRA_INTERPRETER_ARGS="-mllvm -debug-only=jitcall" to produce
+   /// only debug output for jitcall events.
+-  void EnableDebugOutput(bool value = true);
++  CPPINTEROP_API void EnableDebugOutput(bool value = true);
+ 
+   ///\returns true if the debugging printouts on stderr are enabled.
+-  bool IsDebugOutputEnabled();
++  CPPINTEROP_API bool IsDebugOutputEnabled();
+ 
+   /// Checks if the given class represents an aggregate type).
+   ///\returns true if \c scope is an array or a C++ tag (as per C++
+   ///[dcl.init.aggr]) \returns true if the scope supports aggregate
+   /// initialization.
+-  bool IsAggregate(TCppScope_t scope);
++  CPPINTEROP_API bool IsAggregate(TCppScope_t scope);
+ 
+   /// Checks if the scope is a namespace or not.
+-  bool IsNamespace(TCppScope_t scope);
++  CPPINTEROP_API bool IsNamespace(TCppScope_t scope);
+ 
+   /// Checks if the scope is a class or not.
+-  bool IsClass(TCppScope_t scope);
++  CPPINTEROP_API bool IsClass(TCppScope_t scope);
+ 
+   // See TClingClassInfo::IsLoaded
+   /// Checks if the class definition is present, or not. Performs a
+   /// template instantiation if necessary.
+-  bool IsComplete(TCppScope_t scope);
++  CPPINTEROP_API bool IsComplete(TCppScope_t scope);
+ 
+-  size_t SizeOf(TCppScope_t scope);
++  CPPINTEROP_API size_t SizeOf(TCppScope_t scope);
+ 
+   /// Checks if it is a "built-in" or a "complex" type.
+-  bool IsBuiltin(TCppType_t type);
++  CPPINTEROP_API bool IsBuiltin(TCppType_t type);
+ 
+   /// Checks if it is a templated class.
+-  bool IsTemplate(TCppScope_t handle);
++  CPPINTEROP_API bool IsTemplate(TCppScope_t handle);
+ 
+   /// Checks if it is a class template specialization class.
+-  bool IsTemplateSpecialization(TCppScope_t handle);
++  CPPINTEROP_API bool IsTemplateSpecialization(TCppScope_t handle);
+ 
+   /// Checks if \c handle introduces a typedef name via \c typedef or \c using.
+-  bool IsTypedefed(TCppScope_t handle);
++  CPPINTEROP_API bool IsTypedefed(TCppScope_t handle);
+ 
+-  bool IsAbstract(TCppType_t klass);
++  CPPINTEROP_API bool IsAbstract(TCppType_t klass);
+ 
+   /// Checks if it is an enum name (EnumDecl represents an enum name).
+-  bool IsEnumScope(TCppScope_t handle);
++  CPPINTEROP_API bool IsEnumScope(TCppScope_t handle);
+ 
+   /// Checks if it is an enum's value (EnumConstantDecl represents
+   /// each enum constant that is defined).
+-  bool IsEnumConstant(TCppScope_t handle);
++  CPPINTEROP_API bool IsEnumConstant(TCppScope_t handle);
+ 
+   /// Checks if the passed value is an enum type or not.
+-  bool IsEnumType(TCppType_t type);
++  CPPINTEROP_API bool IsEnumType(TCppType_t type);
+ 
+   /// Extracts enum declarations from a specified scope and stores them in
+   /// vector
+-  void GetEnums(TCppScope_t scope, std::vector<std::string>& Result);
++  CPPINTEROP_API void GetEnums(TCppScope_t scope,
++                               std::vector<std::string>& Result);
+ 
+   /// We assume that smart pointer types define both operator* and
+   /// operator->.
+-  bool IsSmartPtrType(TCppType_t type);
++  CPPINTEROP_API bool IsSmartPtrType(TCppType_t type);
+ 
+   /// For the given "class", get the integer type that the enum
+   /// represents, so that you can store it properly in your specific
+   /// language.
+-  TCppType_t GetIntegerTypeFromEnumScope(TCppScope_t handle);
++  CPPINTEROP_API TCppType_t GetIntegerTypeFromEnumScope(TCppScope_t handle);
+ 
+   /// For the given "type", this function gets the integer type that the enum
+   /// represents, so that you can store it properly in your specific
+   /// language.
+-  TCppType_t GetIntegerTypeFromEnumType(TCppType_t handle);
++  CPPINTEROP_API TCppType_t GetIntegerTypeFromEnumType(TCppType_t handle);
+ 
+   /// Gets a list of all the enum constants for an enum.
+-  std::vector<TCppScope_t> GetEnumConstants(TCppScope_t scope);
++  CPPINTEROP_API std::vector<TCppScope_t> GetEnumConstants(TCppScope_t scope);
+ 
+   /// Gets the enum name when an enum constant is passed.
+-  TCppType_t GetEnumConstantType(TCppScope_t scope);
++  CPPINTEROP_API TCppType_t GetEnumConstantType(TCppScope_t scope);
+ 
+   /// Gets the index value (0,1,2, etcetera) of the enum constant
+   /// that was passed into this function.
+-  TCppIndex_t GetEnumConstantValue(TCppScope_t scope);
++  CPPINTEROP_API TCppIndex_t GetEnumConstantValue(TCppScope_t scope);
+ 
+   /// Gets the size of the "type" that is passed in to this function.
+-  size_t GetSizeOfType(TCppType_t type);
++  CPPINTEROP_API size_t GetSizeOfType(TCppType_t type);
+ 
+   /// Checks if the passed value is a variable.
+-  bool IsVariable(TCppScope_t scope);
++  CPPINTEROP_API bool IsVariable(TCppScope_t scope);
+ 
+   /// Gets the name of any named decl (a class,
+   /// namespace, variable, or a function).
+-  std::string GetName(TCppScope_t klass);
++  CPPINTEROP_API std::string GetName(TCppScope_t klass);
+ 
+   /// This is similar to GetName() function, but besides
+   /// the name, it also gets the template arguments.
+-  std::string GetCompleteName(TCppType_t klass);
++  CPPINTEROP_API std::string GetCompleteName(TCppType_t klass);
+ 
+   /// Gets the "qualified" name (including the namespace) of any
+   /// named decl (a class, namespace, variable, or a function).
+-  std::string GetQualifiedName(TCppType_t klass);
++  CPPINTEROP_API std::string GetQualifiedName(TCppType_t klass);
+ 
+   /// This is similar to GetQualifiedName() function, but besides
+   /// the "qualified" name (including the namespace), it also
+   /// gets the template arguments.
+-  std::string GetQualifiedCompleteName(TCppType_t klass);
++  CPPINTEROP_API std::string GetQualifiedCompleteName(TCppType_t klass);
+ 
+   /// Gets the list of namespaces utilized in the supplied scope.
+-  std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope);
++  CPPINTEROP_API std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope);
+ 
+   /// Gets the global scope of the whole C++  instance.
+-  TCppScope_t GetGlobalScope();
++  CPPINTEROP_API TCppScope_t GetGlobalScope();
+ 
+   /// Strips the typedef and returns the underlying class, and if the
+   /// underlying decl is not a class it returns the input unchanged.
+-  TCppScope_t GetUnderlyingScope(TCppScope_t scope);
++  CPPINTEROP_API TCppScope_t GetUnderlyingScope(TCppScope_t scope);
+ 
+   /// Gets the namespace or class (by stripping typedefs) for the name 
+   /// passed as a parameter, and if the parent is not passed, 
+   /// then global scope will be assumed.
+-  TCppScope_t GetScope(const std::string &name, TCppScope_t parent = 0);
++  CPPINTEROP_API TCppScope_t GetScope(const std::string& name,
++                                      TCppScope_t parent = 0);
+ 
+   /// When the namespace is known, then the parent doesn't need
+   /// to be specified. This will probably be phased-out in
+   /// future versions of the interop library.
+-  TCppScope_t GetScopeFromCompleteName(const std::string &name);
++  CPPINTEROP_API TCppScope_t GetScopeFromCompleteName(const std::string& name);
+ 
+   /// This function performs a lookup within the specified parent,
+   /// a specific named entity (functions, enums, etcetera).
+-  TCppScope_t GetNamed(const std::string &name,
+-                       TCppScope_t parent = nullptr);
++  CPPINTEROP_API TCppScope_t GetNamed(const std::string& name,
++                                      TCppScope_t parent = nullptr);
+ 
+   /// Gets the parent of the scope that is passed as a parameter.
+-  TCppScope_t GetParentScope(TCppScope_t scope);
++  CPPINTEROP_API TCppScope_t GetParentScope(TCppScope_t scope);
+ 
+   /// Gets the scope of the type that is passed as a parameter.
+-  TCppScope_t GetScopeFromType(TCppType_t type);
++  CPPINTEROP_API TCppScope_t GetScopeFromType(TCppType_t type);
+ 
+   /// Gets the number of Base Classes for the Derived Class that
+   /// is passed as a parameter.
+-  TCppIndex_t GetNumBases(TCppType_t klass);
++  CPPINTEROP_API TCppIndex_t GetNumBases(TCppType_t klass);
+ 
+   /// Gets a specific Base Class using its index. Typically GetNumBases()
+   /// is used to get the number of Base Classes, and then that number
+   /// can be used to iterate through the index value to get each specific
+   /// base class.
+-  TCppScope_t GetBaseClass(TCppType_t klass, TCppIndex_t ibase);
++  CPPINTEROP_API CPPINTEROP_API TCppScope_t GetBaseClass(TCppType_t klass,
++                                                         TCppIndex_t ibase);
+ 
+   /// Checks if the supplied Derived Class is a sub-class of the
+   /// provided Base Class.
+-  bool IsSubclass(TCppScope_t derived, TCppScope_t base);
++  CPPINTEROP_API bool IsSubclass(TCppScope_t derived, TCppScope_t base);
+ 
+   /// Each base has its own offset in a Derived Class. This offset can be
+   /// used to get to the Base Class fields.
+-  int64_t GetBaseClassOffset(TCppScope_t derived, TCppScope_t base);
++  CPPINTEROP_API int64_t GetBaseClassOffset(TCppScope_t derived,
++                                            TCppScope_t base);
+ 
+   /// Gets a list of all the Methods that are in the Class that is
+   /// supplied as a parameter.
+-  std::vector<TCppFunction_t> GetClassMethods(TCppScope_t klass);
++  CPPINTEROP_API std::vector<TCppFunction_t> GetClassMethods(TCppScope_t klass);
+ 
+   ///\returns if a class has a default constructor.
+-  bool HasDefaultConstructor(TCppScope_t scope);
++  CPPINTEROP_API bool HasDefaultConstructor(TCppScope_t scope);
+ 
+   ///\returns the default constructor of a class, if any.
+-  TCppFunction_t GetDefaultConstructor(TCppScope_t scope);
++  CPPINTEROP_API TCppFunction_t GetDefaultConstructor(TCppScope_t scope);
+ 
+   ///\returns the class destructor, if any.
+-  TCppFunction_t GetDestructor(TCppScope_t scope);
++  CPPINTEROP_API TCppFunction_t GetDestructor(TCppScope_t scope);
+ 
+   /// Looks up all the functions that have the name that is
+   /// passed as a parameter in this function.
+-  std::vector<TCppFunction_t> GetFunctionsUsingName(
+-        TCppScope_t scope, const std::string& name);
++  CPPINTEROP_API std::vector<TCppFunction_t>
++  GetFunctionsUsingName(TCppScope_t scope, const std::string& name);
+ 
+   /// Gets the return type of the provided function.
+-  TCppType_t GetFunctionReturnType(TCppFunction_t func);
++  CPPINTEROP_API TCppType_t GetFunctionReturnType(TCppFunction_t func);
+ 
+   /// Gets the number of Arguments for the provided function.
+-  TCppIndex_t GetFunctionNumArgs(TCppFunction_t func);
++  CPPINTEROP_API TCppIndex_t GetFunctionNumArgs(TCppFunction_t func);
+ 
+   /// Gets the number of Required Arguments for the provided function.
+-  TCppIndex_t GetFunctionRequiredArgs(TCppConstFunction_t func);
++  CPPINTEROP_API TCppIndex_t GetFunctionRequiredArgs(TCppConstFunction_t func);
+ 
+   /// For each Argument of a function, you can get the Argument Type
+   /// by providing the Argument Index, based on the number of arguments
+   /// from the GetFunctionNumArgs() function.
+-  TCppType_t GetFunctionArgType(TCppFunction_t func, TCppIndex_t iarg);
++  CPPINTEROP_API TCppType_t GetFunctionArgType(TCppFunction_t func,
++                                               TCppIndex_t iarg);
+ 
+   ///\returns a stringified version of a given function signature in the form:
+   /// void N::f(int i, double d, long l = 0, char ch = 'a').
+-  std::string GetFunctionSignature(TCppFunction_t func);
++  CPPINTEROP_API std::string GetFunctionSignature(TCppFunction_t func);
+ 
+   ///\returns if a function was marked as \c =delete.
+-  bool IsFunctionDeleted(TCppConstFunction_t function);
++  CPPINTEROP_API bool IsFunctionDeleted(TCppConstFunction_t function);
+ 
+-  bool IsTemplatedFunction(TCppFunction_t func);
++  CPPINTEROP_API bool IsTemplatedFunction(TCppFunction_t func);
+ 
+   /// This function performs a lookup to check if there is a
+   /// templated function of that type.
+-  bool ExistsFunctionTemplate(const std::string& name,
+-          TCppScope_t parent = 0);
++  CPPINTEROP_API bool ExistsFunctionTemplate(const std::string& name,
++                                             TCppScope_t parent = 0);
+ 
+   /// Checks if the provided parameter is a method.
+-  bool IsMethod(TCppConstFunction_t method);
++  CPPINTEROP_API bool IsMethod(TCppConstFunction_t method);
+ 
+   /// Checks if the provided parameter is a 'Public' method.
+-  bool IsPublicMethod(TCppFunction_t method);
++  CPPINTEROP_API bool IsPublicMethod(TCppFunction_t method);
+ 
+   /// Checks if the provided parameter is a 'Protected' method.
+-  bool IsProtectedMethod(TCppFunction_t method);
++  CPPINTEROP_API bool IsProtectedMethod(TCppFunction_t method);
+ 
+   /// Checks if the provided parameter is a 'Private' method.
+-  bool IsPrivateMethod(TCppFunction_t method);
++  CPPINTEROP_API bool IsPrivateMethod(TCppFunction_t method);
+ 
+   /// Checks if the provided parameter is a Constructor.
+-  bool IsConstructor(TCppConstFunction_t method);
++  CPPINTEROP_API bool IsConstructor(TCppConstFunction_t method);
+ 
+   /// Checks if the provided parameter is a Destructor.
+-  bool IsDestructor(TCppConstFunction_t method);
++  CPPINTEROP_API bool IsDestructor(TCppConstFunction_t method);
+ 
+   /// Checks if the provided parameter is a 'Static' method.
+-  bool IsStaticMethod(TCppConstFunction_t method);
++  CPPINTEROP_API bool IsStaticMethod(TCppConstFunction_t method);
+ 
+   ///\returns the address of the function given its potentially mangled name.
+-  TCppFuncAddr_t GetFunctionAddress(const char* mangled_name);
++  CPPINTEROP_API TCppFuncAddr_t GetFunctionAddress(const char* mangled_name);
+ 
+   ///\returns the address of the function given its function declaration.
+-  TCppFuncAddr_t GetFunctionAddress(TCppFunction_t method);
++  CPPINTEROP_API TCppFuncAddr_t GetFunctionAddress(TCppFunction_t method);
+ 
+   /// Checks if the provided parameter is a 'Virtual' method.
+-  bool IsVirtualMethod(TCppFunction_t method);
++  CPPINTEROP_API bool IsVirtualMethod(TCppFunction_t method);
+ 
+   /// Gets all the Fields/Data Members of a Class. For now, it
+   /// only gets non-static data members but in a future update,
+   /// it may support getting static data members as well.
+-  std::vector<TCppScope_t> GetDatamembers(TCppScope_t scope);
++  CPPINTEROP_API std::vector<TCppScope_t> GetDatamembers(TCppScope_t scope);
+ 
+   /// This is a Lookup function to be used specifically for data members.
+-  TCppScope_t LookupDatamember(const std::string& name, TCppScope_t parent);
++  CPPINTEROP_API TCppScope_t LookupDatamember(const std::string& name,
++                                              TCppScope_t parent);
+ 
+   /// Gets the type of the variable that is passed as a parameter.
+-  TCppType_t GetVariableType(TCppScope_t var);
++  CPPINTEROP_API TCppType_t GetVariableType(TCppScope_t var);
+ 
+   /// Gets the address of the variable, you can use it to get the
+   /// value stored in the variable.
+-  intptr_t GetVariableOffset(TCppScope_t var);
++  CPPINTEROP_API intptr_t GetVariableOffset(TCppScope_t var);
+ 
+   /// Checks if the provided variable is a 'Public' variable.
+-  bool IsPublicVariable(TCppScope_t var);
++  CPPINTEROP_API bool IsPublicVariable(TCppScope_t var);
+ 
+   /// Checks if the provided variable is a 'Protected' variable.
+-  bool IsProtectedVariable(TCppScope_t var);
++  CPPINTEROP_API bool IsProtectedVariable(TCppScope_t var);
+ 
+   /// Checks if the provided variable is a 'Private' variable.
+-  bool IsPrivateVariable(TCppScope_t var);
++  CPPINTEROP_API bool IsPrivateVariable(TCppScope_t var);
+ 
+   /// Checks if the provided variable is a 'Static' variable.
+-  bool IsStaticVariable(TCppScope_t var);
++  CPPINTEROP_API bool IsStaticVariable(TCppScope_t var);
+ 
+   /// Checks if the provided variable is a 'Constant' variable.
+-  bool IsConstVariable(TCppScope_t var);
++  CPPINTEROP_API bool IsConstVariable(TCppScope_t var);
+ 
+   /// Checks if the provided parameter is a Record (struct).
+-  bool IsRecordType(TCppType_t type);
++  CPPINTEROP_API bool IsRecordType(TCppType_t type);
+ 
+   /// Checks if the provided parameter is a Plain Old Data Type (POD).
+-  bool IsPODType(TCppType_t type);
++  CPPINTEROP_API bool IsPODType(TCppType_t type);
+ 
+   /// Gets the pure, Underlying Type (as opposed to the Using Type).
+-  TCppType_t GetUnderlyingType(TCppType_t type);
++  CPPINTEROP_API TCppType_t GetUnderlyingType(TCppType_t type);
+ 
+   /// Gets the Type (passed as a parameter) as a String value.
+-  std::string GetTypeAsString(TCppType_t type);
++  CPPINTEROP_API std::string GetTypeAsString(TCppType_t type);
+ 
+   /// Gets the Canonical Type string from the std string. A canonical type
+   /// is the type with any typedef names, syntactic sugars or modifiers stripped
+   /// out of it.
+-  TCppType_t GetCanonicalType(TCppType_t type);
++  CPPINTEROP_API TCppType_t GetCanonicalType(TCppType_t type);
+ 
+   /// Used to either get the built-in type of the provided string, or
+   /// use the name to lookup the actual type.
+-  TCppType_t GetType(const std::string &type);
++  CPPINTEROP_API TCppType_t GetType(const std::string& type);
+ 
+   ///\returns the complex of the provided type.
+-  TCppType_t GetComplexType(TCppType_t element_type);
++  CPPINTEROP_API TCppType_t GetComplexType(TCppType_t element_type);
+ 
+   /// This will convert a class into its type, so for example, you can
+   /// use it to declare variables in it.
+-  TCppType_t GetTypeFromScope(TCppScope_t klass);
++  CPPINTEROP_API TCppType_t GetTypeFromScope(TCppScope_t klass);
+ 
+   /// Checks if a C++ type derives from another.
+-  bool IsTypeDerivedFrom(TCppType_t derived, TCppType_t base);
++  CPPINTEROP_API bool IsTypeDerivedFrom(TCppType_t derived, TCppType_t base);
+ 
+   /// Creates a trampoline function by using the interpreter and returns a
+   /// uniform interface to call it from compiled code.
+-  JitCall MakeFunctionCallable(TCppConstFunction_t func);
++  CPPINTEROP_API JitCall MakeFunctionCallable(TCppConstFunction_t func);
+ 
+   /// Checks if a function declared is of const type or not.
+-  bool IsConstMethod(TCppFunction_t method);
++  CPPINTEROP_API bool IsConstMethod(TCppFunction_t method);
+ 
+   ///\returns the default argument value as string.
+-  std::string GetFunctionArgDefault(TCppFunction_t func, TCppIndex_t param_index);
++  CPPINTEROP_API std::string GetFunctionArgDefault(TCppFunction_t func,
++                                                   TCppIndex_t param_index);
+ 
+   ///\returns the argument name of function as string.
+-  std::string GetFunctionArgName(TCppFunction_t func, TCppIndex_t param_index);
++  CPPINTEROP_API std::string GetFunctionArgName(TCppFunction_t func,
++                                                TCppIndex_t param_index);
+ 
+   /// Creates an instance of the interpreter we need for the various interop
+   /// services.
+   ///\param[in] Args - the list of arguments for interpreter constructor.
+   ///\param[in] CPPINTEROP_EXTRA_INTERPRETER_ARGS - an env variable, if defined,
+   ///           adds additional arguments to the interpreter.
+-  extern "C" TInterp_t
++  extern "C" CPPINTEROP_API TInterp_t
+   CreateInterpreter(const std::vector<const char*>& Args = {},
+                     const std::vector<const char*>& GpuArgs = {});
+ 
+@@ -436,44 +451,47 @@ namespace Cpp {
+   /// Clang-REPL, etcetera). In practice, the selected interpreter should not
+   /// matter, since the library will function in the same way.
+   ///\returns the current interpreter instance, if any.
+-  TInterp_t GetInterpreter();
++  CPPINTEROP_API TInterp_t GetInterpreter();
+ 
+   /// Adds a Search Path for the Interpreter to get the libraries.
+-  void AddSearchPath(const char *dir, bool isUser = true, bool prepend = false);
++  CPPINTEROP_API void AddSearchPath(const char* dir, bool isUser = true,
++                                    bool prepend = false);
+ 
+   /// Returns the resource-dir path (for headers).
+-  const char* GetResourceDir();
++  CPPINTEROP_API const char* GetResourceDir();
+ 
+   /// Uses the underlying clang compiler to detect the resource directory.
+   /// In essence calling clang -print-resource-dir and checks if it ends with
+   /// a compatible to CppInterOp version.
+   ///\param[in] ClangBinaryName - the name (or the full path) of the compiler
+   ///                             to ask.
+-  std::string DetectResourceDir(const char* ClangBinaryName = "clang");
++  CPPINTEROP_API std::string
++  DetectResourceDir(const char* ClangBinaryName = "clang");
+ 
+   /// Asks the system compiler for its default include paths.
+   ///\param[out] Paths - the list of include paths returned by eg.
+   ///                     `c++ -xc++ -E -v /dev/null 2>&1`
+   ///\param[in] CompilerName - the name (or the full path) of the compiler
+   ///                          binary file.
+-  void DetectSystemCompilerIncludePaths(std::vector<std::string>& Paths,
+-                                        const char* CompilerName = "c++");
++  CPPINTEROP_API void
++  DetectSystemCompilerIncludePaths(std::vector<std::string>& Paths,
++                                   const char* CompilerName = "c++");
+ 
+   /// Secondary search path for headers, if not found using the
+   /// GetResourceDir() function.
+-  void AddIncludePath(const char *dir);
++  CPPINTEROP_API void AddIncludePath(const char* dir);
+ 
+   /// Only Declares a code snippet in \c code and does not execute it.
+   ///\returns 0 on success
+-  int Declare(const char* code, bool silent = false);
++  CPPINTEROP_API int Declare(const char* code, bool silent = false);
+ 
+   /// Declares and executes a code snippet in \c code.
+   ///\returns 0 on success
+-  int Process(const char *code);
++  CPPINTEROP_API int Process(const char* code);
+ 
+   /// Declares, executes and returns the execution result as a intptr_t.
+   ///\returns the expression results as a intptr_t.
+-  intptr_t Evaluate(const char *code, bool *HadError = nullptr);
++  CPPINTEROP_API intptr_t Evaluate(const char* code, bool* HadError = nullptr);
+ 
+   /// Looks up the library if access is enabled.
+   ///\returns the path to the library.
+@@ -482,18 +500,19 @@ namespace Cpp {
+   /// Finds \c lib_stem considering the list of search paths and loads it by
+   /// calling dlopen.
+   /// \returns true on success.
+-  bool LoadLibrary(const char* lib_stem, bool lookup = true);
++  CPPINTEROP_API bool LoadLibrary(const char* lib_stem, bool lookup = true);
+ 
+   /// Finds \c lib_stem considering the list of search paths and unloads it by
+   /// calling dlclose.
+   /// function.
+-  void UnloadLibrary(const char* lib_stem);
++  CPPINTEROP_API void UnloadLibrary(const char* lib_stem);
+ 
+   /// Scans all libraries on the library search path for a given potentially
+   /// mangled symbol name.
+   ///\returns the path to the first library that contains the symbol definition.
+-  std::string SearchLibrariesForSymbol(const char* mangled_name,
+-                                       bool search_system /*true*/);
++  CPPINTEROP_API std::string
++  SearchLibrariesForSymbol(const char* mangled_name,
++                           bool search_system /*true*/);
+ 
+   /// Inserts or replaces a symbol in the JIT with the one provided. This is
+   /// useful for providing our own implementations of facilities such as printf.
+@@ -503,11 +522,11 @@ namespace Cpp {
+   ///\param[in] address - the new address of the symbol.
+   ///
+   ///\returns true on failure.
+-  bool InsertOrReplaceJitSymbol(const char* linker_mangled_name,
+-                                uint64_t address);
++  CPPINTEROP_API bool InsertOrReplaceJitSymbol(const char* linker_mangled_name,
++                                               uint64_t address);
+ 
+   /// Tries to load provided objects in a string format (prettyprint).
+-  std::string ObjToString(const char *type, void *obj);
++  CPPINTEROP_API std::string ObjToString(const char* type, void* obj);
+ 
+   struct TemplateArgInfo {
+     TCppType_t m_Type;
+@@ -515,23 +534,24 @@ namespace Cpp {
+     TemplateArgInfo(TCppScope_t type, const char* integral_value = nullptr)
+       : m_Type(type), m_IntegralValue(integral_value) {}
+   };
+-  TCppScope_t InstantiateClassTemplate(TCppScope_t tmpl,
+-                                       TemplateArgInfo* template_args,
+-                                       size_t template_args_size);
++  CPPINTEROP_API TCppScope_t
++  InstantiateClassTemplate(TCppScope_t tmpl, TemplateArgInfo* template_args,
++                           size_t template_args_size);
+ 
+   /// Returns the class template instantiation arguments of \c templ_instance.
+-  void GetClassTemplateInstantiationArgs(TCppScope_t templ_instance,
+-                                         std::vector<TemplateArgInfo> &args);
++  CPPINTEROP_API void
++  GetClassTemplateInstantiationArgs(TCppScope_t templ_instance,
++                                    std::vector<TemplateArgInfo>& args);
+ 
+   /// Instantiates a function template from a given string representation. This
+   /// function also does overload resolution.
+   ///\returns the instantiated function template declaration.
+-  TCppFunction_t
++  CPPINTEROP_API TCppFunction_t
+   InstantiateTemplateFunctionFromString(const char* function_template);
+ 
+-  std::vector<std::string> GetAllCppNames(TCppScope_t scope);
++  CPPINTEROP_API std::vector<std::string> GetAllCppNames(TCppScope_t scope);
+ 
+-  void DumpScope(TCppScope_t scope);
++  CPPINTEROP_API void DumpScope(TCppScope_t scope);
+ 
+   namespace DimensionValue {
+     enum : long int {
+@@ -540,23 +560,23 @@ namespace Cpp {
+   }
+ 
+   /// Gets the size/dimensions of a multi-dimension array.
+-  std::vector<long int> GetDimensions(TCppType_t type);
++  CPPINTEROP_API std::vector<long int> GetDimensions(TCppType_t type);
+ 
+   /// Allocates memory for a given class.
+-  TCppObject_t Allocate(TCppScope_t scope);
++  CPPINTEROP_API TCppObject_t Allocate(TCppScope_t scope);
+ 
+   /// Deallocates memory for a given class.
+-  void Deallocate(TCppScope_t scope, TCppObject_t address);
++  CPPINTEROP_API void Deallocate(TCppScope_t scope, TCppObject_t address);
+ 
+   /// Creates an object of class \c scope and calls its default constructor. If
+   /// \c arena is set it uses placement new.
+-  TCppObject_t Construct(TCppScope_t scope,
+-                         void* arena = nullptr);
++  CPPINTEROP_API TCppObject_t Construct(TCppScope_t scope,
++                                        void* arena = nullptr);
+ 
+   /// Calls the destructor of object of type \c type. When withFree is true it
+   /// calls operator delete/free.
+-  void Destruct(TCppObject_t This, TCppScope_t type,
+-                bool withFree = true);
++  CPPINTEROP_API void Destruct(TCppObject_t This, TCppScope_t type,
++                               bool withFree = true);
+ 
+   /// @name Stream Redirection
+   ///
+@@ -571,10 +591,10 @@ namespace Cpp {
+ 
+   /// Begins recording the given standard stream.
+   ///\param[fd_kind] - The stream to be captured
+-  void BeginStdStreamCapture(CaptureStreamKind fd_kind);
++  CPPINTEROP_API void BeginStdStreamCapture(CaptureStreamKind fd_kind);
+ 
+   /// Ends recording the standard stream and returns the result as a string.
+-  std::string EndStdStreamCapture();
++  CPPINTEROP_API std::string EndStdStreamCapture();
+ 
+   ///@}
+ } // end namespace Cpp
+diff --git a/lib/Interpreter/CppInterOp.cpp b/lib/Interpreter/CppInterOp.cpp
+index 0b93bc8..578f388 100644
+--- a/lib/Interpreter/CppInterOp.cpp
++++ b/lib/Interpreter/CppInterOp.cpp
+@@ -2415,7 +2415,7 @@ namespace Cpp {
+     } // namespace
+       // End of JitCall Helper Functions
+ 
+-  JitCall MakeFunctionCallable(TCppConstFunction_t func) {
++  CPPINTEROP_API JitCall MakeFunctionCallable(TCppConstFunction_t func) {
+     auto* D = (const clang::Decl*)func;
+     if (!D)
+       return {};
+-- 
+2.37.1 (Apple Git-137.1)

--- a/recipes/recipes_emscripten/cppinterop/recipe.yaml
+++ b/recipes/recipes_emscripten/cppinterop/recipe.yaml
@@ -13,9 +13,11 @@ source:
     - patches/cppinterop/0002-cmake-CppInterOp-install-fix.patch
     - patches/cppinterop/0003-Implement-detection-of-resource-and-include-dirs.patch
     - patches/cppinterop/0004-cmake-config-fix-library-suffix-and-prefix.patch
+    - patches/cppinterop/0005-Fix-config-for-msvc.patch
+    - patches/cppinterop/0006-Export-symbols-in-Windows-DLL.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
Adds 0005-Fix-config-for-msvc.patch & 0006-Export-symbols-in-Windows-DLL.patch patches cppinterop