### PR TITLE
Update qutip to 5.0.1

### DIFF
--- a/recipes/recipes_emscripten/qutip/recipe.yaml
+++ b/recipes/recipes_emscripten/qutip/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "5.0.0"
+  version: "5.0.1"
 
 package:
   name: qutip
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/qutip/qutip/archive/v{{ version }}.tar.gz
-  sha256: ab6b8a569d5511d5326a87d102e06b7887ab046afd08e6b0fc44bfd73c832ac5
+  sha256: 59517336571223266b7771db049769ac3a286fda5ae02d469885ec8c237a23b6
 
 build:
   number: 0

--- a/recipes/recipes_emscripten/qutip/recipe.yaml
+++ b/recipes/recipes_emscripten/qutip/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "4.7.5"
+  version: "5.0.0"
 
 package:
   name: qutip
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/qutip/qutip/archive/v{{ version }}.tar.gz
-  sha256: e03cd0d943e6d1b44010b6a0c92c2ea794b323b246f10bba67573534165c2de5
+  sha256: ab6b8a569d5511d5326a87d102e06b7887ab046afd08e6b0fc44bfd73c832ac5
 
 build:
   number: 0

--- a/recipes/recipes_emscripten/qutip/test_qutip.py
+++ b/recipes/recipes_emscripten/qutip/test_qutip.py
@@ -1,9 +1,12 @@
 """ Smoke tests for the built qutip package. """
 import pytest
 
-def assert_qobj_data(q, data):
+def assert_qobj_data(q, data, normalize_sign=False):
     """ Assert that a qobj has the given values. """
     import numpy as np
+    if normalize_sign:
+        sign = np.sign(q.full()[0, 0])
+        q = sign * q
     np.testing.assert_allclose(q.full(), data)
 
 
@@ -89,13 +92,13 @@ def test_qobj_methods():
     evals, [ev0, ev1] = op.eigenstates()
     assert_array_data(evals, [-0.56155281,  3.56155281])
     assert_qobj_data(ev0, [
-        [-0.78820544],
-        [-0.61541221j],
-    ])
+        [0.78820544],
+        [0.61541221j],
+    ], normalize_sign=True)
     assert_qobj_data(ev1, [
         [0.61541221],
         [-0.78820544j],
-    ])
+    ], normalize_sign=True  )
     assert_qobj_data(op.expm(), [
         [13.6924533, 16.80651518j],
         [-16.80651518j, 22.09571089],

--- a/recipes/recipes_emscripten/qutip/test_qutip.py
+++ b/recipes/recipes_emscripten/qutip/test_qutip.py
@@ -93,8 +93,8 @@ def test_qobj_methods():
         [-0.61541221j],
     ])
     assert_qobj_data(ev1, [
-        [-0.61541221],
-        [0.78820544j],
+        [0.61541221],
+        [-0.78820544j],
     ])
     assert_qobj_data(op.expm(), [
         [13.6924533, 16.80651518j],
@@ -138,10 +138,10 @@ def test_qobjevo_create():
     from qutip import QobjEvo, sigmax
     import numpy as np
 
-    q = QobjEvo([(sigmax(), "sin(w * t)")], args={"w": 0.5})
+    q = QobjEvo([[sigmax(), "sin(w * t)"]], args={"w": 0.5})
 
-    assert q.type == "string"
-    assert q.const is False
+    assert q.type == "oper"
+    assert q.isconstant is False
 
     assert_qobj_data(q(0), [
         [0, 0],
@@ -157,7 +157,7 @@ def test_qobjevo_arithmetic():
     from qutip import Qobj, QobjEvo, sigmax
     import numpy as np
 
-    op1 = QobjEvo([(sigmax(), "sin(w * t)")], args={"w": 0.5})
+    op1 = QobjEvo([[sigmax(), "sin(w * t)"]], args={"w": 0.5})
     op2 = Qobj([[1j, 0], [0, 1j]])
     psi = Qobj([[1], [2]])
 
@@ -192,7 +192,7 @@ def test_qobjevo_methods():
     import numpy as np
 
     q = Qobj([[1, 2j], [-2j, 2]])
-    op = QobjEvo([(q, "sin(w * t)")], args={"w": 0.5})
+    op = QobjEvo([[q, "sin(w * t)"]], args={"w": 0.5})
 
     assert_qobj_data(op.conj()(np.pi), [
         [1, -2j],


### PR DESCRIPTION
This updates the qutip recipe to build qutip 5.0.1.

In addition to updating the version number and the package hash, it also updates the tests.