### PR TITLE
Update dependencies for LFortran

### DIFF
--- a/recipes/recipes_emscripten/lfortran/recipe.yaml
+++ b/recipes/recipes_emscripten/lfortran/recipe.yaml
@@ -19,11 +19,18 @@ requirements:
     - "{{ compiler('cxx') }}"
     - cmake
     - make   # [unix]
-    - zlib =1.2.13
-    - lfortran =0.34.0
+    - zlib=1.2.13
+    - lfortran=0.34.0
+    # - xeus =3.0.5       # [build_platform != target_platform]
+    # - xeus-zmq =1.0.2   # [build_platform != target_platform]
+    # - llvmdev =16.0.6   # [build_platform != target_platform]
+    # - xtl               # [build_platform != target_platform]
+    # - nlohmann_json =3.11.2     # [build_platform != target_platform]
+    # - cppzmq            # [build_platform != target_platform]
+    # - zlib              # [build_platform != target_platform]
+    # - zstd-static =1.5.5  # [build_platform != target_platform]
   host:
-    - llvm =16.0.6
-    - zlib =1.2.13
+    - zlib
 
 about:
   home: https://lfortran.org

--- a/recipes/recipes_emscripten/lfortran/recipe.yaml
+++ b/recipes/recipes_emscripten/lfortran/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d62ddefc3a5e62babdc753400d6733292971db00a7f15456fa74445d8e195433
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -19,29 +19,11 @@ requirements:
     - "{{ compiler('cxx') }}"
     - cmake
     - make   # [unix]
-    - ninja
-    - bison=3.4
-    - re2c
-    - python
-    - toml
     - zlib=1.2.13
     - lfortran=0.34.0
-    # - xeus =3.0.5       # [build_platform != target_platform]
-    # - xeus-zmq =1.0.2   # [build_platform != target_platform]
-    # - llvmdev =16.0.6   # [build_platform != target_platform]
-    # - xtl               # [build_platform != target_platform]
-    # - nlohmann_json =3.11.2     # [build_platform != target_platform]
-    # - cppzmq            # [build_platform != target_platform]
-    # - zlib              # [build_platform != target_platform]
-    # - zstd-static =1.5.5  # [build_platform != target_platform]
   host:
-    - nlohmann_json
-    - xeus-lite
-    - xeus >=3.0.5,<4.0
-    - xtl >=0.7,<0.8
     - llvm =16.0.6
-    # - cppzmq
-    - zlib
+    - zlib=1.2.13
 
 about:
   home: https://lfortran.org

--- a/recipes/recipes_emscripten/lfortran/recipe.yaml
+++ b/recipes/recipes_emscripten/lfortran/recipe.yaml
@@ -19,11 +19,11 @@ requirements:
     - "{{ compiler('cxx') }}"
     - cmake
     - make   # [unix]
-    - zlib=1.2.13
-    - lfortran=0.34.0
+    - zlib =1.2.13
+    - lfortran =0.34.0
   host:
     - llvm =16.0.6
-    - zlib=1.2.13
+    - zlib =1.2.13
 
 about:
   home: https://lfortran.org


### PR DESCRIPTION
`bison `: required by `build0.sh`. We have a tarball so this should not be needed
`re2c`: required by `build0.sh`. We have a tarball so this should not be needed
`python`: again should not be needed. Used by `build0.sh`
`toml`: we do not run tests for the wasm build, so should not be needed.

Also I think when we have the `LFortran_Build_to_wasm `as `ON`, we naturally have the `WITH_XEUS `option as `OFF`, so in that case we would not need any of `nlohmann_json`, `xeus-lite`, `xeus`, `cppzmq`