### PR TITLE
Update ContourPy to 1.2.0

### DIFF
--- a/recipes/recipes_emscripten/contourpy/build.sh
+++ b/recipes/recipes_emscripten/contourpy/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# Removing this warning will not be needed after the next pybind11 release
-export CPPFLAGS="-Wno-deprecated-literal-operator"
+cp $RECIPE_DIR/emscripten.meson.cross $SRC_DIR
+echo "python = '${PYTHON}'" >> $SRC_DIR/emscripten.meson.cross
 
-${PYTHON} -m pip install . -vvv --no-deps
+${PYTHON} -m pip install . -vvv --no-deps --no-build-isolation \
+    -Csetup-args="--cross-file=$SRC_DIR/emscripten.meson.cross"

--- a/recipes/recipes_emscripten/contourpy/emscripten.meson.cross
+++ b/recipes/recipes_emscripten/contourpy/emscripten.meson.cross
@@ -1,0 +1,16 @@
+# binaries section is at the end as may want to append python binary.
+
+[properties]
+needs_exe_wrapper = true
+skip_sanity_check = true
+longdouble_format = 'IEEE_QUAD_LE' # for numpy
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm'
+endian = 'little'
+
+[binaries]
+exe_wrapper = 'node'
+pkgconfig = 'pkg-config'

--- a/recipes/recipes_emscripten/contourpy/recipe.yaml
+++ b/recipes/recipes_emscripten/contourpy/recipe.yaml
@@ -1,16 +1,14 @@
 context:
   name: contourpy
-  version: 1.0.7
+  version: 1.2.0
 
 package:
   name: ${{ name|lower }}
   version: ${{ version }}
 
 source:
-- url: 
-    https://files.pythonhosted.org/packages/b4/9b/6edb9d3e334a70a212f66a844188fcb57ddbd528cbc3b1fe7abfc317ddd7/contourpy-${{
-    version }}.tar.gz
-  sha256: d8165a088d31798b59e91117d1f5fc3df8168d8b48c4acc10fc0df0d0bdbcc5e
+- url: https://pypi.io/packages/source/c/contourpy/contourpy-${{ version }}.tar.gz
+  sha256: 171f311cb758de7da13fc53af221ae47a5877be5a0843a9fe150818c51ed276a
 
 build:
   number: 0
@@ -18,7 +16,9 @@ build:
 requirements:
   build:
   - ${{ compiler('cxx') }}
-  - cross-python_emscripten-wasm32
+  - cross-python_${{target_platform}}
+  - meson-python
+  - pip >=24
   - pybind11
   host:
   - python

--- a/recipes/recipes_emscripten/contourpy/test_contourpy.py
+++ b/recipes/recipes_emscripten/contourpy/test_contourpy.py
@@ -15,12 +15,12 @@ def test_import():
         ("serial", "SeparateCode"),
         ("serial", "ChunkCombinedCode"),
         ("serial", "ChunkCombinedOffset"),
-        #("serial", "ChunkCombinedNan"),  # Needs contourpy >= 1.2.0
+        ("serial", "ChunkCombinedNan"),
         ("threaded", "Separate"),
         ("threaded", "SeparateCode"),
         ("threaded", "ChunkCombinedCode"),
         ("threaded", "ChunkCombinedOffset"),
-        #("threaded", "ChunkCombinedNan"),  # Needs contourpy >= 1.2.0
+        ("threaded", "ChunkCombinedNan"),
     ],
 )
 def test_line(name, line_type):


### PR DESCRIPTION
Update ContourPy from 1.0.7 to 1.2.0.

This is the second recipe to use `meson`, using a cross-compilation file that is very similar to NumPy's.