### PR TITLE
Add Include/Exclude Patterns for `pint` Package to `empack_config`

### DIFF
--- a/empack_config.yaml
+++ b/empack_config.yaml
@@ -145,6 +145,14 @@ packages:
       - pattern: 'html/**'
       - pattern: 'external/**'
       - pattern: '**/*.dist-info/METADATA'
+  pint:
+    include_patterns:
+      - pattern: '*.so'
+      - pattern: '*.py'
+      - pattern: '*.txt'
+    exclude_patterns:
+      - pattern: '**/tests/**/*.py'
+      - pattern: '**/tests/**/*.so'
 default:
   include_patterns:
     - pattern: '*.so'


### PR DESCRIPTION
This follows advice by @martinRenou provided in 

https://github.com/jupyterlite/xeus-python-kernel/issues/79#issuecomment-1244990930

and should close 

https://github.com/jupyter-xeus/xeus-python/issues/603

(and by extension)

https://github.com/brightway-lca/brightway-live/issues/52