### PR TITLE
Update numpy to 1.26.2

### DIFF
--- a/recipes/recipes_emscripten/numpy/recipe.yaml
+++ b/recipes/recipes_emscripten/numpy/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 1.26.0
+  version: 1.26.2
   cross_target_plattform: emscripten-wasm32
   target_plattform: emscripten-wasm32
 
@@ -9,7 +9,7 @@ package:
 source:
   url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{
     version }}.tar.gz
-  sha256: f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf
+  sha256: f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea
 build:
   number: 0
 


### PR DESCRIPTION
The latest numpy we have is 1.26.0. The build for numpy 1.26.1 (#2786) doesn't work for me locally or in CI, but the trivial bumping of the tarball version in this PR works for me locally and the same goes for later 1.26.x releases, so perhaps if this works in CI we can just skip 1.26.1.