### PR TITLE
Update numpy to 1.26.3

### DIFF
--- a/recipes/recipes_emscripten/numpy/recipe.yaml
+++ b/recipes/recipes_emscripten/numpy/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 1.26.2
+  version: 1.26.3
   cross_target_plattform: emscripten-wasm32
   target_plattform: emscripten-wasm32
 
@@ -9,7 +9,7 @@ package:
 source:
   url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{
     version }}.tar.gz
-  sha256: f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea
+  sha256: 697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4
 build:
   number: 0
 


### PR DESCRIPTION
Update numpy to 1.26.3. Simple bump of version number and tarball hash.