### PR TITLE
Update docs and platforms

### DIFF
--- a/docs/development/local_builds.md
+++ b/docs/development/local_builds.md
@@ -45,13 +45,13 @@ I.e. if you open a new terminal, you have to activate the environment again with
 This is only needed for MacOS. On Linux, the compiler packages are already built and available in the `emscripten-forge` channel.
 
 ```bash
-rattler-build build --recipe recipes/recipes/emscripten_emscripten-wasm32/rattler_recipe.yaml   -c https://repo.mamba.pm/emscripten-forge -c conda-forge -c microsoft -m conda_build_config.yaml
-rattler-build build --recipe recipes/recipes/cross-python_emscripten-wasm32/rattler_recipe.yaml -c https://repo.mamba.pm/emscripten-forge -c conda-forge -c microsoft -m conda_build_config.yaml
-rattler-build build --recipe recipes/recipes/pytester/rattler_recipe.yaml                       -c https://repo.mamba.pm/emscripten-forge -c conda-forge -c microsoft -m conda_build_config.yaml
+rattler-build build --recipe recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml   -c https://repo.mamba.pm/emscripten-forge -c conda-forge -c microsoft -m conda_build_config.yaml
+rattler-build build --recipe recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml -c https://repo.mamba.pm/emscripten-forge -c conda-forge -c microsoft -m conda_build_config.yaml
+rattler-build build --recipe recipes/recipes/pytester/recipe.yaml                       -c https://repo.mamba.pm/emscripten-forge -c conda-forge -c microsoft -m conda_build_config.yaml
 ```
 
 ### Build packages with `rattler-build`:
 
 ```bash
-rattler-build build  --recipe recipes/recipes_emscripten/regex/rattler_recipe.yaml  --target-platform=emscripten-wasm32 -c https://repo.mamba.pm/emscripten-forge -c conda-forge -c microsoft -m conda_build_config.yaml
+rattler-build build  --recipe recipes/recipes_emscripten/regex/recipe.yaml  --target-platform=emscripten-wasm32 -c https://repo.mamba.pm/emscripten-forge -c conda-forge -c microsoft -m conda_build_config.yaml
 ```

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "The emscripten-forge for emscripten-wasm32- builds."
 authors = ["DerThorsten <derthorstenbeier@gmail.com>"]
 channels = ["conda-forge"]
-platforms = ["osx-arm64", "linux-64"]
+platforms = ["osx-arm64", "osx-64", "linux-64"]
 
 
 ############################################


### PR DESCRIPTION
Minor updates:
- Rename rattler_recipe.yaml to recipe.yaml
- Add `osx-64` platform