### PR TITLE
force pyjs=2.0.0 in pytester, change channel order

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -24,8 +24,8 @@ cmd = [
     "--package-format", "tar-bz2",
     # channels
     "-c", "https://repo.mamba.pm/emscripten-forge",
-    "-c", "conda-forge",
     "-c", "microsoft",
+    "-c", "conda-forge",
     "--skip-existing", "local",
     "-m", "conda_build_config.yaml",
     "--recipe",
@@ -39,8 +39,8 @@ cmd = [
     "--package-format", "tar-bz2",
     # channels
     "-c", "https://repo.mamba.pm/emscripten-forge",
-    "-c", "conda-forge",
     "-c", "microsoft",
+    "-c", "conda-forge",
     "--skip-existing", "local",
     "-m", "conda_build_config.yaml",
     "--recipe",
@@ -54,8 +54,8 @@ cmd = [
     "--package-format", "tar-bz2",
     # channels
     "-c", "https://repo.mamba.pm/emscripten-forge",
-    "-c", "conda-forge",
     "-c", "microsoft",
+    "-c", "conda-forge",
     "--skip-existing", "local",
     "-m", "conda_build_config.yaml",
     "--recipe",
@@ -74,8 +74,8 @@ cmd = [
     "--package-format", "tar-bz2",
     # channels
     "-c", "https://repo.mamba.pm/emscripten-forge",
-    "-c", "conda-forge",
     "-c", "microsoft",
+    "-c", "conda-forge",
     "--target-platform", "emscripten-wasm32",
     "--skip-existing", "local",
     "-m", "conda_build_config.yaml",

--- a/pixi.toml
+++ b/pixi.toml
@@ -16,6 +16,7 @@ rattler-build = ">= 0.14.0"
 python = "3.11.*"
 typer = "*"
 
+
 [feature.feature_rattler_build.tasks.build-emscripten-compiler-pkg]
 cmd = [
     "rattler-build","build", 

--- a/recipes/recipes/pytester/recipe.yaml
+++ b/recipes/recipes/pytester/recipe.yaml
@@ -13,7 +13,7 @@ outputs:
       version: ${{ version }}
 
     build:
-      number: 6
+      number: 7
 
       noarch: python
 
@@ -34,7 +34,7 @@ outputs:
       name: pytester-run
       version: ${{ version }}
     build:
-      number: 6
+      number: 7
       noarch: generic
     requirements:
       run:

--- a/recipes/recipes/pytester/recipe.yaml
+++ b/recipes/recipes/pytester/recipe.yaml
@@ -38,7 +38,7 @@ outputs:
       noarch: generic
     requirements:
       run:
-        - pyjs
+        - pyjs == 2.0.0
         - pytest
  
 


### PR DESCRIPTION
trigger ci