### PR TITLE
Add Clarabel

### DIFF
--- a/recipes/recipes_emscripten/clarabel/build.sh
+++ b/recipes/recipes_emscripten/clarabel/build.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-export MATURIN_PYTHON_SYSCONFIGDATA_DIR=${PREFIX}/etc/conda/_sysconfigdata__emscripten_wasm32-emscripten.py
 ${PYTHON} -m pip  install . -vv

--- a/recipes/recipes_emscripten/clarabel/build.sh
+++ b/recipes/recipes_emscripten/clarabel/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+${PYTHON} -m pip  install . -vv

--- a/recipes/recipes_emscripten/clarabel/build.sh
+++ b/recipes/recipes_emscripten/clarabel/build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+export MATURIN_PYTHON_SYSCONFIGDATA_DIR=${PREFIX}/etc/conda/_sysconfigdata__emscripten_wasm32-emscripten.py
 ${PYTHON} -m pip  install . -vv

--- a/recipes/recipes_emscripten/clarabel/recipe.yaml
+++ b/recipes/recipes_emscripten/clarabel/recipe.yaml
@@ -1,0 +1,75 @@
+context:
+  name: clarabel
+  version: 0.7.1
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.python.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: a30ab135f475c5bc78329fd7df575291155e6055bcaf02124eb610b8ad176396
+
+build:
+  number: 0
+  #script:
+  #  - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  #  - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_${{ target_platform }}     # [build_platform != target_platform]
+    - python                                # [build_platform != target_platform]
+    - crossenv                              # [build_platform != target_platform]
+    - cross-python_${{ target_platform }}    # [build_platform != target_platform]
+    - maturin                               # [build_platform != target_platform]
+    - ${{ compiler('c') }}
+    - cargo-bundle-licenses
+    - rust
+    - cffi == 1.15.1
+    - setuptools-rust
+  host:
+    - python
+    - pip
+    - cffi == 1.15.1
+  run:
+    - python
+    - cffi == 1.15.1
+    - __osx >=${{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
+
+#test:
+#  files:
+#    - example_qp.py
+#    - example_sdp.py
+#  imports:
+#    - clarabel
+#  commands:
+#    - pip check
+#    - python example_qp.py
+#    - python example_sdp.py
+#  requires:
+#    - pip
+#    - numpy
+#    - scipy
+#    - python
+
+about:
+  homepage: https://oxfordcontrol.github.io/ClarabelDocs/
+  license: Apache-2.0
+  license_family: Apache
+  license_file:
+    - LICENSE.md
+    - THIRDPARTY.yml
+  summary: 'Python interface for Clarabel: Interior Point Conic Optimization Solver'
+  description: |
+    Clarabel is an interior point numerical solver for convex optimization problems implemented
+    in Rust.  It solves linear programs (LPs), quadratic programs (QPs), second-order cone programs 
+    (SOCPs) and semidefinite programs (SDPs). It also solves problems with exponential, power
+    cone and generalized power cone constraints.
+  documentation: https://oxfordcontrol.github.io/ClarabelDocs/
+  repository: https://github.com/oxfordcontrol/Clarabel.rs
+
+extra:
+  recipe-maintainers:
+    - KGB99

--- a/recipes/recipes_emscripten/clarabel/recipe.yaml
+++ b/recipes/recipes_emscripten/clarabel/recipe.yaml
@@ -18,12 +18,12 @@ requirements:
     - python                                
     - crossenv                              
     - cross-python_${{ target_platform }}   
-    - maturin                               
     - ${{ compiler('c') }}
     - cargo-bundle-licenses
     - rust
     - cffi == 1.15.1
     - setuptools-rust
+    - maturin
   host:
     - python
     - pip
@@ -31,6 +31,17 @@ requirements:
   run:
     - python
     - cffi == 1.15.1
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_clarabel.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
 
 about:
   homepage: https://oxfordcontrol.github.io/ClarabelDocs/

--- a/recipes/recipes_emscripten/clarabel/recipe.yaml
+++ b/recipes/recipes_emscripten/clarabel/recipe.yaml
@@ -41,7 +41,7 @@ tests:
     build:
     - pytester
     run:
-    - pytester-runi
+    - pytester-run
     - scipy
   
 about:

--- a/recipes/recipes_emscripten/clarabel/recipe.yaml
+++ b/recipes/recipes_emscripten/clarabel/recipe.yaml
@@ -12,18 +12,13 @@ source:
 
 build:
   number: 0
-  #script:
-  #  - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
-  #  - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_${{ target_platform }}     # [build_platform != target_platform]
-    - python                                # [build_platform != target_platform]
-    - crossenv                              # [build_platform != target_platform]
-    - cross-python_${{ target_platform }}    # [build_platform != target_platform]
-    - maturin                               # [build_platform != target_platform]
+    - python                                
+    - crossenv                              
+    - cross-python_${{ target_platform }}   
+    - maturin                               
     - ${{ compiler('c') }}
     - cargo-bundle-licenses
     - rust
@@ -36,23 +31,6 @@ requirements:
   run:
     - python
     - cffi == 1.15.1
-    - __osx >=${{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
-
-#test:
-#  files:
-#    - example_qp.py
-#    - example_sdp.py
-#  imports:
-#    - clarabel
-#  commands:
-#    - pip check
-#    - python example_qp.py
-#    - python example_sdp.py
-#  requires:
-#    - pip
-#    - numpy
-#    - scipy
-#    - python
 
 about:
   homepage: https://oxfordcontrol.github.io/ClarabelDocs/

--- a/recipes/recipes_emscripten/clarabel/recipe.yaml
+++ b/recipes/recipes_emscripten/clarabel/recipe.yaml
@@ -41,8 +41,9 @@ tests:
     build:
     - pytester
     run:
-    - pytester-run
-
+    - pytester-runi
+    - scipy
+  
 about:
   homepage: https://oxfordcontrol.github.io/ClarabelDocs/
   license: Apache-2.0

--- a/recipes/recipes_emscripten/clarabel/test_clarabel.py
+++ b/recipes/recipes_emscripten/clarabel/test_clarabel.py
@@ -1,0 +1,26 @@
+def test_clarabel():
+  import clarabel
+  import numpy as np
+  from scipy import sparse
+
+  # Define problem data
+  P = sparse.csc_matrix([[3., 0.], [0., 2.]])
+  P = sparse.triu(P).tocsc()
+
+  q = np.array([-1., -4.])
+
+  A = sparse.csc_matrix(
+      [[1., -2.],        # <-- LHS of equality constraint (lower bound)
+       [1.,  0.],        # <-- LHS of inequality constraint (upper bound)
+       [0.,  1.],        # <-- LHS of inequality constraint (upper bound)
+       [-1.,  0.],       # <-- LHS of inequality constraint (lower bound)
+       [0., -1.]])       # <-- LHS of inequality constraint (lower bound)
+
+  b = np.array([0., 1., 1., 1., 1.])
+
+  cones = [clarabel.ZeroConeT(1), clarabel.NonnegativeConeT(4)]
+  settings = clarabel.DefaultSettings()
+
+  solver = clarabel.DefaultSolver(P, q, A, b, cones, settings)
+  solution = solver.solve()
+  assert solution.status == clarabel.SolverStatus.Solved


### PR DESCRIPTION
Currently without tests integrated.
`pixi run build-emscripten-wasm32-pkg recipes/recipes_emscripten/clarabel`
returns a maturin failure where it says no python interpreter was found:
```
Running command Preparing metadata (pyproject.toml)
 │ │   📦 Including license file "/Users/kerimbirgi/dev/recipes/output/bld/rattler-build_clarabel_1718116264/work/LICENSE.md"
 │ │   🍹 Building a mixed python/rust project
 │ │   🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
 │ │   💥 maturin failed
 │ │     Caused by: $PREFIX/bin/python is not a valid python interpreter
 │ │     Caused by: Failed to get information from the python interpreter at $PREFIX/bin/python
 │ │     Caused by: platform.system() in python, unknown, and the rust target, Target { os: Macos, arch: X86_64, env: Unknown, triple: "x86_64-apple-darwin", cross_compiling: false, rustc_version: Version
 │ │ Meta { semver: Version { major: 1, minor: 77, patch: 2 }, commit_hash: Some("25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04"), commit_date: Some("2024-04-09"), build_date: None, channel: Stable, host: "x86
 │ │ _64-apple-darwin", short_version_string: "rustc 1.77.2 (25ef9e3d8 2024-04-09)", llvm_version: Some(LlvmVersion { major: 17, minor: 0 }) }, user_specified: false }, don't match ಠ_ಠ
 │ │   Error running maturin: Command '['maturin', 'pep517', 'write-dist-info', '--metadata-directory', '/private/var/folders/mt/hfrbrgm93kb4747gcgtc2l2c0000gn/T/pip-modern-metadata-q6r6o7fo', '--interpre
 │ │ ter', '$PREFIX/bin/python']' returned non-zero exit status 1.
```
When I then try to debug with conda_build.sh in the work directory it builds successfully by "not using a  specific python interpreter":
```
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
🐍 Not using a specific python interpreter
```