### PR TITLE
Update xvega-bindings from 0.0.10 to 0.1.0

### DIFF
--- a/recipes/recipes_emscripten/xvega-bindings/build.sh
+++ b/recipes/recipes_emscripten/xvega-bindings/build.sh
@@ -7,9 +7,7 @@ cmake ${CMAKE_ARGS} ..             \
     -GNinja                        \
     -DCMAKE_BUILD_TYPE=Release     \
     -DCMAKE_PREFIX_PATH=$PREFIX    \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DXVEGA_DISABLE_ARCH_NATIVE=ON \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON 
-    
+    -DCMAKE_INSTALL_PREFIX=$PREFIX
+
 # Build step
 ninja install

--- a/recipes/recipes_emscripten/xvega-bindings/recipe.yaml
+++ b/recipes/recipes_emscripten/xvega-bindings/recipe.yaml
@@ -1,13 +1,14 @@
 context:
-  version: 0.0.10
+  name: xvega-bindings
+  version: 0.1.0
 
 package:
-  name: xvega-bindings
+  name: ${{ name }}
   version: ${{ version }}
 
 source:
-  git: https://github.com/DerThorsten/xvega-bindings.git
-  rev: no_var
+  url: https://github.com/jupyter-xeus/${{ name }}/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 0929eadf383971c32dbda67379c1cadddf232af70dca5584526b2c211c8876b7
 
 build:
   number: 0
@@ -19,16 +20,17 @@ requirements:
   - ninja
   host:
   - nlohmann_json
-  - xtl
   - xproperty
-  - xvega
+  - xvega >=0.1.0,<0.2
 
 about:
   license: BSD-3-Clause
   license_family: BSD-3
   license_file: LICENSE
-  summary: xvega-bindings
-  homepage: https://github.com/QuantStack/xvega
+  summary: Bindings from xvega to xeus.
+  homepage: https://github.com/jupyter-xeus/xvega-bindings
+  documentation: https://xeus-sqlite.readthedocs.io/en/latest/xvega_magic.html
+
 extra:
   recipe-maintainers:
   - DerThorsten

--- a/recipes/recipes_emscripten/xvega-bindings/recipe.yaml
+++ b/recipes/recipes_emscripten/xvega-bindings/recipe.yaml
@@ -19,7 +19,7 @@ requirements:
   - cmake
   - ninja
   host:
-  - nlohmann_json
+  - nlohmann_json = 3.11.3
   - xproperty
   - xvega >=0.1.0,<0.2
 


### PR DESCRIPTION
Requires a rebuild of `xvega` (See https://github.com/jupyter-xeus/xvega/pull/52).