### PR TITLE
fix missing .wasm for lua binaries

### DIFF
--- a/recipes/recipes_emscripten/lua/CMakeLists.txt
+++ b/recipes/recipes_emscripten/lua/CMakeLists.txt
@@ -64,11 +64,13 @@ foreach(lua_binary ${lua_binaries})
   target_compile_definitions(${lua_binary} 
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
+      PUBLIC "SHELL: -s MODULARIZE=1"
   )
   # set target link options
   target_link_options(${lua_binary} 
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
+      PUBLIC "SHELL: -s MODULARIZE=1"
   )
 endforeach()
 

--- a/recipes/recipes_emscripten/lua/CMakeLists.txt
+++ b/recipes/recipes_emscripten/lua/CMakeLists.txt
@@ -64,13 +64,13 @@ foreach(lua_binary ${lua_binaries})
   target_compile_definitions(${lua_binary} 
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
-      PUBLIC "SHELL: -s MODULARIZE=1"
+      # PUBLIC "SHELL: -s MODULARIZE=1"
   )
   # set target link options
   target_link_options(${lua_binary} 
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
-      PUBLIC "SHELL: -s MODULARIZE=1"
+      # PUBLIC "SHELL: -s MODULARIZE=1"
   )
 endforeach()
 

--- a/recipes/recipes_emscripten/lua/CMakeLists.txt
+++ b/recipes/recipes_emscripten/lua/CMakeLists.txt
@@ -48,11 +48,33 @@ if(BUILD_SHARED_LIBS)
   target_compile_definitions(liblua PRIVATE LUA_BUILD_AS_DLL)
 endif()
 
+
+
+
 add_executable(lua src/lua.c ${LUA_LIB_SRCS})
 target_link_libraries(lua)
-
 add_executable(luac src/luac.c ${LUA_LIB_SRCS})
 target_link_libraries(luac)
+
+
+set(lua_binaries lua luac)
+
+foreach(lua_binary ${lua_binaries})
+  # set target compile options
+  target_compile_definitions(${lua_binary} 
+      PUBLIC "SHELL: -s FORCE_FILESYSTEM"
+      PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
+  )
+  # set target link options
+  target_link_options(${lua_binary} 
+      PUBLIC "SHELL: -s FORCE_FILESYSTEM"
+      PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
+  )
+endforeach()
+
+
+
+
 
 install(TARGETS liblua
         ARCHIVE DESTINATION lib
@@ -60,6 +82,16 @@ install(TARGETS liblua
         RUNTIME DESTINATION bin)
 
 install(TARGETS lua luac DESTINATION bin)
+
+
+
+install(FILES
+        "$<TARGET_FILE_DIR:lua>/lua.wasm"
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(FILES
+        "$<TARGET_FILE_DIR:luac>/luac.wasm"
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+
 
 set(LUA_PUBLIC_INCLUDES
     src/lauxlib.h

--- a/recipes/recipes_emscripten/lua/build.sh
+++ b/recipes/recipes_emscripten/lua/build.sh
@@ -11,7 +11,6 @@ cd build
 
 # Configure step
 cmake ${CMAKE_ARGS} ..             \
-    -GNinja                        \
     -DCMAKE_BUILD_TYPE=Release     \
     -DCMAKE_PREFIX_PATH=$PREFIX    \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
@@ -19,5 +18,9 @@ cmake ${CMAKE_ARGS} ..             \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_C_FLAGS="-DLUA_USER_DEFAULT_PATH='\"$PREFIX/\"'" \
 
+# build step
+make -j${CPU_COUNT}
+
+
 # Build step
-ninja install
+make -j${CPU_COUNT} install

--- a/recipes/recipes_emscripten/lua/recipe.yaml
+++ b/recipes/recipes_emscripten/lua/recipe.yaml
@@ -10,26 +10,35 @@ source:
 - url: http://www.lua.org/ftp/lua-${{ version }}.tar.gz
   sha256: 7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
   patches:
-      # Enables Lua to look for packages on a relative path
-  - luaconf.patch
-      # Build as a shared library
-  - liblua.so.patch
-      # Enables readline on linux
-  - Makefile.patch
+    # Enables Lua to look for packages on a relative path
+    - luaconf.patch
+        # Build as a shared library
+    - liblua.so.patch
+    #     # Enables readline on linux
+    # - Makefile.patch
+
+
 - path: CMakeLists.txt
 
 build:
-  number: 5
-
-
+  number: 6
 
 requirements:
   build:
   - ${{ compiler('c') }}
-  - ninja
   - cmake
   - make
 
+
+tests:
+  - script: node $PREFIX/bin/lua.js -e "a=1+1;print(a)"
+    requirements:
+      build:
+        - nodejs
+  - script: node $PREFIX/bin/luac.js -v
+    requirements:
+      build:
+        - nodejs
 
 about:
   summary: Lua is a powerful, fast, lightweight, embeddable scripting language


### PR DESCRIPTION
Added missing *.wasm file for the lua binaries (lua,luac).
It might be nice to try the Lua binary in cockle @ianthomas23