### PR TITLE
Export TTY in WASM modules for cockle

### DIFF
--- a/recipes/recipes_emscripten/coreutils/build.sh
+++ b/recipes/recipes_emscripten/coreutils/build.sh
@@ -15,7 +15,7 @@ emconfigure ./configure \
 
 echo "sed"      
 sed -i 's|$(MAKE) src/make-prime-list$(EXEEXT)|gcc src/make-prime-list.c -o src/make-prime-list$(EXEEXT) -Ilib/|' Makefile
-export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings -sFORCE_FILESYSTEM=1 -sINVOKE_RUN=0 -sMODULARIZE=1 -sSINGLE_FILE=1"
+export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sINVOKE_RUN=0 -sMODULARIZE=1 -sSINGLE_FILE=1"
 
 make EXEEXT=.js CFLAGS="$CFLAGS" -k -j4 || true
 

--- a/recipes/recipes_emscripten/coreutils/recipe.yaml
+++ b/recipes/recipes_emscripten/coreutils/recipe.yaml
@@ -12,7 +12,7 @@ source:
   git: https://github.com/coreutils/coreutils
   tag: v9.5
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/grep/build.sh
+++ b/recipes/recipes_emscripten/grep/build.sh
@@ -29,7 +29,7 @@ emconfigure ./configure \
       ac_cv_have_decl_alarm=no \
       gl_cv_func_sleep_works=yes
 
-export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings -sFORCE_FILESYSTEM=1 -sINVOKE_RUN=0 -sMODULARIZE=1 -sSINGLE_FILE=1 -sERROR_ON_UNDEFINED_SYMBOLS=0"
+export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sINVOKE_RUN=0 -sMODULARIZE=1 -sSINGLE_FILE=1 -sERROR_ON_UNDEFINED_SYMBOLS=0"
 emmake make all CFLAGS="$CFLAGS" EXEEXT=.js 
 
 ls

--- a/recipes/recipes_emscripten/grep/recipe.yaml
+++ b/recipes/recipes_emscripten/grep/recipe.yaml
@@ -12,7 +12,7 @@ package:
 #   url: https://github.com/Distrotech/grep
 #   branch: 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/lua/CMakeLists.txt
+++ b/recipes/recipes_emscripten/lua/CMakeLists.txt
@@ -65,7 +65,7 @@ foreach(lua_binary ${lua_binaries})
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
       PUBLIC "SHELL: -s ENVIRONMENT=web,worker,node"
-      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings"
+      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY"
       PUBLIC "SHELL: -s MODULARIZE=1"
   )
   # set target link options
@@ -73,7 +73,7 @@ foreach(lua_binary ${lua_binaries})
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
       PUBLIC "SHELL: -s ENVIRONMENT=web,worker,node"
-      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings"
+      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY"
       PUBLIC "SHELL: -s MODULARIZE=1"
   )
 endforeach()

--- a/recipes/recipes_emscripten/lua/recipe.yaml
+++ b/recipes/recipes_emscripten/lua/recipe.yaml
@@ -21,7 +21,7 @@ source:
 - path: CMakeLists.txt
 
 build:
-  number: 10
+  number: 11
 
 requirements:
   build:


### PR DESCRIPTION
WebAssembly modules used in [cockle](https://github.com/jupyterlite/cockle) need `TTY` exported since PR jupyterlite/cockle#23, and the lack of this is one of the causes of the CI failures in jupyterlite/cockle#25.

`cockle_fs` doesn't need it, so here adding to `coreutils` and `grep`. I'm also adding it to `lua` to help with our ongoing experiments with it.