### PR TITLE
emscripten 3.1.64

### DIFF
--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -1,9 +1,9 @@
 context:
   name: emscripten_emscripten-wasm32
-  version: 3.1.45
+  version: 3.1.64
 
 build:
-  number: 29
+  number: 0
 
 outputs:
   - package:


### PR DESCRIPTION
Emscripten 3.1.64 

Note that we will still use 3.1.45 since its pinned here:

https://github.com/emscripten-forge/recipes/blob/main/conda_build_config.yaml#L28
https://github.com/emscripten-forge/recipes/blob/main/conda_build_config.yaml#L40