### PR TITLE
Use separate WASM and JS files for cockle

### DIFF
--- a/recipes/recipes_emscripten/cockle_fs/build.sh
+++ b/recipes/recipes_emscripten/cockle_fs/build.sh
@@ -5,9 +5,8 @@ emcc fs.c -o fs.js \
     -sEXPORTED_RUNTIME_METHODS=FS,PATH,ERRNO_CODES,PROXYFS \
     -sFORCE_FILESYSTEM=1 \
     -sMODULARIZE=1 \
-    -sSINGLE_FILE=1 \
     -lproxyfs.js
 
 
 mkdir -p $PREFIX/bin
-cp fs.js $PREFIX/bin/fs.js
+cp fs.{js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/cockle_fs/recipe.yaml
+++ b/recipes/recipes_emscripten/cockle_fs/recipe.yaml
@@ -7,7 +7,7 @@ package:
 
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/coreutils/build.sh
+++ b/recipes/recipes_emscripten/coreutils/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "lets go"
-ls 
+ls
 ./bootstrap --skip-po
 emconfigure ./configure \
       --enable-single-binary \
@@ -13,9 +13,9 @@ emconfigure ./configure \
       gl_cv_func_sleep_works=yes
 
 
-echo "sed"      
+echo "sed"
 sed -i 's|$(MAKE) src/make-prime-list$(EXEEXT)|gcc src/make-prime-list.c -o src/make-prime-list$(EXEEXT) -Ilib/|' Makefile
-export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sINVOKE_RUN=0 -sMODULARIZE=1 -sSINGLE_FILE=1"
+export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sMODULARIZE=1"
 
 make EXEEXT=.js CFLAGS="$CFLAGS" -k -j4 || true
 
@@ -24,4 +24,4 @@ ls
 ls src/coreutils.js
 
 mkdir -p $PREFIX/bin
-cp src/coreutils.js $PREFIX/bin/coreutils.js
+cp src/coreutils.{js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/coreutils/recipe.yaml
+++ b/recipes/recipes_emscripten/coreutils/recipe.yaml
@@ -12,7 +12,7 @@ source:
   git: https://github.com/coreutils/coreutils
   tag: v9.5
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/grep/build.sh
+++ b/recipes/recipes_emscripten/grep/build.sh
@@ -29,10 +29,10 @@ emconfigure ./configure \
       ac_cv_have_decl_alarm=no \
       gl_cv_func_sleep_works=yes
 
-export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sINVOKE_RUN=0 -sMODULARIZE=1 -sSINGLE_FILE=1 -sERROR_ON_UNDEFINED_SYMBOLS=0"
-emmake make all CFLAGS="$CFLAGS" EXEEXT=.js 
+export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sMODULARIZE=1 -sERROR_ON_UNDEFINED_SYMBOLS=0"
+emmake make all CFLAGS="$CFLAGS" EXEEXT=.js
 
 ls
 
 mkdir -p $PREFIX/bin
-cp src/grep.js $PREFIX/bin/grep.js
+cp src/grep.{js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/grep/recipe.yaml
+++ b/recipes/recipes_emscripten/grep/recipe.yaml
@@ -10,9 +10,9 @@ package:
 #   url: https://ftp.gnu.org/gnu/grep/grep-3.11.tar.xz
 #   sha256: 1db2aedde89d0dea42b16d9528f894c8d15dae4e190b59aecc78f5a951276eab
 #   url: https://github.com/Distrotech/grep
-#   branch: 
+#   branch:
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
[Cockle](https://github.com/jupyterlite/cockle) (JupyterLite terminal) now supports dynamic loading of Emscripten-built WASM modules provided the WASM is embedded in a JavaScript file. With just a few adjustments this should be able to support separate WASM and JS files. To complete that I need to build the 3 modules (`cockle_fs`, `coreutils` and `grep`) with the ~`-sMODULARIZE=1`~ `-sSINGLE_FILE=1` flag removed, which is what this PR does.

In addition, whilst we are rebuilding these recipes we can also simplify the recipes for WASM command modules (`coreutils` and `grep`) by removing the `-sINVOKE_RUN=0` flag and removing `callMain` from the list of exported runtime methods. This is because we no longer need to load the JS/WASM module in one step and then call it using `callMain` as we can load and call it automatically as part of the load.

These changes could also be attempted with more complicated modules like `lua`, but I will try that separately once this is proven to work.

(Edited to correct mistake)