### PR TITLE
Remove use of callMain in lua

### DIFF
--- a/recipes/recipes/run_modularized/recipe.yaml
+++ b/recipes/recipes/run_modularized/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: run_modularized
-  version: "0.1.0"
+  version: "0.1.1"
 
 package:
   name: ${{ name|lower }}
@@ -11,7 +11,7 @@ build:
 
 requirements:
   run:
-    - nodejs 
+    - nodejs
 
 about:
   license: BSD-3-Clause

--- a/recipes/recipes/run_modularized/run_modularized.js
+++ b/recipes/recipes/run_modularized/run_modularized.js
@@ -3,13 +3,15 @@
 const binary_js_runner = process.argv[2];
 process.argv = process.argv.slice(3);
 async function my_main(){
+    let exitCode = 126;  // "Command invoked cannot execute"
     const ModuleF = require(binary_js_runner);
     const Module = await ModuleF({
-        noInitialRun: true,
         // arguments: args_without_js_path
+        quit: (status, toThrow) => {
+            exitCode = status;
+        }
     });
-    const ret = Module.callMain(process.argv);
-    return ret;
+    return exitCode;
 }
 (async function() {
     const exitCode = await my_main();

--- a/recipes/recipes/run_modularized/run_modularized.js
+++ b/recipes/recipes/run_modularized/run_modularized.js
@@ -6,7 +6,7 @@ async function my_main(){
     let exitCode = 126;  // "Command invoked cannot execute"
     const ModuleF = require(binary_js_runner);
     const Module = await ModuleF({
-        // arguments: args_without_js_path
+        arguments: process.argv,
         quit: (status, toThrow) => {
             exitCode = status;
         }

--- a/recipes/recipes_emscripten/lua/CMakeLists.txt
+++ b/recipes/recipes_emscripten/lua/CMakeLists.txt
@@ -61,19 +61,19 @@ set(lua_binaries lua luac)
 
 foreach(lua_binary ${lua_binaries})
   # set target compile options
-  target_compile_definitions(${lua_binary} 
+  target_compile_definitions(${lua_binary}
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
       PUBLIC "SHELL: -s ENVIRONMENT=web,worker,node"
-      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY"
+      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY"
       PUBLIC "SHELL: -s MODULARIZE=1"
   )
   # set target link options
-  target_link_options(${lua_binary} 
+  target_link_options(${lua_binary}
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
       PUBLIC "SHELL: -s ENVIRONMENT=web,worker,node"
-      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY"
+      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY"
       PUBLIC "SHELL: -s MODULARIZE=1"
   )
 endforeach()

--- a/recipes/recipes_emscripten/lua/recipe.yaml
+++ b/recipes/recipes_emscripten/lua/recipe.yaml
@@ -21,7 +21,7 @@ source:
 - path: CMakeLists.txt
 
 build:
-  number: 11
+  number: 12
 
 requirements:
   build:
@@ -39,7 +39,7 @@ tests:
       fi
     requirements:
       build:
-        - run_modularized
+        - run_modularized >= 0.1.1
   - script: |
       OUTPUT=$(run_modularized $PREFIX/bin/luac.js -v)
       if [[ "$OUTPUT" != "Lua 5.4.6  Copyright (C) 1994-2023 Lua.org, PUC-Rio" ]]; then

--- a/recipes/recipes_emscripten/lua/recipe.yaml
+++ b/recipes/recipes_emscripten/lua/recipe.yaml
@@ -46,10 +46,9 @@ tests:
         echo "Unexpected output: $OUTPUT"
         exit 1
       fi
-
     requirements:
       build:
-        - run_modularized
+        - run_modularized >= 0.1.1
 
 about:
   summary: Lua is a powerful, fast, lightweight, embeddable scripting language


### PR DESCRIPTION
This PR removes the use of `callMain` in the `lua` build to bring it into line with `coreutils` and `grep` so that it will be usable in `cockle`.