### PR TITLE
Update r-base version in conda_build_config

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -601,8 +601,7 @@ ruby:
   - 2.5
   - 2.6
 r_base:
-  - 4.0
-  - 4.1
+  - 4.4.1
 scotch:
   - 6.0.9
 ptscotch:


### PR DESCRIPTION
This is to match the `r-base` version packaged on emscripten-forge, which is `v4.4.1`.