### PR TITLE
Added recipes for curl (libcurl-static)

### DIFF
--- a/recipes/recipes_emscripten/curl/build.sh
+++ b/recipes/recipes_emscripten/curl/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+
+emconfigure ./configure \
+    --prefix=${PREFIX} \
+    --build="x86_64-conda-linux-gnu" \
+    --host="wasm32-unknown-emscripten" \
+    --disable-shared \
+    --enable-static \
+    --disable-symbol-hiding \
+    --disable-ldap \
+    --disable-threaded-resolver \
+    --disable-ipv6 \
+    --disable-tftp \
+    --with-openssl=${PREFIX} \
+    --with-zlib=${PREFIX} \
+    --with-zstd=${PREFIX} \
+    --without-libpsl \
+
+emmake make -j${CPU_COUNT} ${VERBOSE_AT}
+
+emmake make install

--- a/recipes/recipes_emscripten/curl/recipe.yaml
+++ b/recipes/recipes_emscripten/curl/recipe.yaml
@@ -1,0 +1,47 @@
+context:
+  name: curl
+  version: 8.10.1
+
+source:
+  url: http://curl.haxx.se/download/${{name }}-${{ version }}.tar.bz2
+  sha256: 3763cd97aae41dcf41950d23e87ae23b2edb2ce3a5b0cf678af058c391b6ae31
+
+build:
+  number: 0
+
+outputs:
+- package:
+    name: libcurl-static
+    version: ${{ version }}
+  build:
+    files:
+      - include/curl/*
+      - lib/libcurl.a
+      - lib/pkgconfig/libcurl.pc
+      - bin/curl
+      - bin/curl-config
+  requirements:
+    build:
+      - ${{ compiler("c") }}
+      - cmake
+      - make
+      - libtool
+      - pkg-config
+    host:
+      - zlib
+      - zstd  # [unix]
+      - openssl   # [unix]
+  tests:
+  - script: test -f $PREFIX/lib/libcurl.a
+
+about:
+  homepage: http://curl.haxx.se/
+  license: curl
+  license_family: MIT
+  license_file: COPYING
+  summary: tool and library for transferring data with URL syntax
+
+extra:
+  recipe-maintainers:
+  - DerThorsten
+  - anutosh491

--- a/recipes/recipes_emscripten/curl/recipe.yaml
+++ b/recipes/recipes_emscripten/curl/recipe.yaml
@@ -18,8 +18,6 @@ outputs:
       - include/curl/*
       - lib/libcurl.a
       - lib/pkgconfig/libcurl.pc
-      - bin/curl
-      - bin/curl-config
   requirements:
     build:
       - ${{ compiler("c") }}
@@ -29,10 +27,12 @@ outputs:
       - pkg-config
     host:
       - zlib
-      - zstd  # [unix]
-      - openssl   # [unix]
+      - zstd
+      - openssl
   tests:
-  - script: test -f $PREFIX/lib/libcurl.a
+  - package_contents:
+      files:
+        - lib/libcurl.a
 
 about:
   homepage: http://curl.haxx.se/
@@ -44,4 +44,5 @@ about:
 extra:
   recipe-maintainers:
   - DerThorsten
+  - IsabelParedes
   - anutosh491


### PR DESCRIPTION
We can have 3 outputs here (curl, libcurl and libcurl-static). I guess we would not need the first two.