### PR TITLE
Re-add `gettext` to `emscripten_emscripten-wasm32` recipe

### DIFF
--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -23,6 +23,7 @@ outputs:
       build:
         - curl
         - python
+        - gettext
       run:
         - python
         - nodejs 16.*

--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -3,7 +3,7 @@ context:
   version: 3.1.45
 
 build:
-  number: 29
+  number: 30
 
 outputs:
   - package:

--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -23,7 +23,7 @@ outputs:
       build:
         - curl
         - python
-        - gettext
+        - gettext-tools
       run:
         - python
         - nodejs 16.*


### PR DESCRIPTION
Common entrypoints for building packages for `emscripten-forge` are:
- https://prefix.dev/blog/pixi_wasm
- https://emscripten-forge.org/development/local_builds/

In both of these, the workflow is described as:

1. Install pixi
2. `git clone https://github.com/emscripten-forge/recipes && cd recipes`
3. Initialize the environment with `pixi run setup` (referenced in the docs but not blog post).
4. Try a test build like `pixi run build-emscripten-wasm32-pkg recipes/recipes_emscripten/regex`

Right now, this fails on Macs (at least Apple Silicon?) because `rattler-build` fails to build `emscripten_emscripten-wasm32` in step 3 above (`pixi run setup`). Any subsequent build commands will also fail.

This is discussed in https://github.com/emscripten-forge/recipes/issues/1246.

The source error is actually this:

```
 │ │ + envsubst '$PKG_VERSION'
 │ │ /Users/talmo/recipes/output/bld/rattler-build_emscripten_emscripten-wasm32_1727593738/work/conda_build.sh: line 17: envsubst: comma
 │ │ nd not found
```

<details>
<summary>
Full logs
</summary>

```
(base) talmo@Talmos-MBP-M2 recipes % pixi run setup
✨ Pixi task (build-emscripten-compiler-pkg in rattler-build-env): rattler-build build --package-format tar-bz2 -c https://repo.mamba.pm/emscripten-forge -c microsoft -c conda-forge --skip-existing local -m conda_build_config.yaml --recipe recipes/recipes/emscripten_emscripten-wasm32

 ╭─ Finding outputs from recipe
 │ Found 2 variants
 │ Build variant: emscripten-abi-3.1.45-h267e887_29
 │ 
 │ ╭─────────────────┬──────────────────╮
 │ │ Variant         ┆ Version          │
 │ ╞═════════════════╪══════════════════╡
 │ │ channel_targets ┆ conda-forge main │
 │ │ target_platform ┆ noarch           │
 │ ╰─────────────────┴──────────────────╯
 │ Build variant: emscripten_emscripten-wasm32-3.1.45-py311h61838dd_29
 │ 
 │ ╭─────────────────┬──────────────────╮
 │ │ Variant         ┆ Version          │
 │ ╞═════════════════╪══════════════════╡
 │ │ channel_targets ┆ conda-forge main │
 │ │ curl            ┆ 7                │
 │ │ python          ┆ 3.11.* *_cpython │
 │ │ target_platform ┆ osx-arm64        │
 │ ╰─────────────────┴──────────────────╯
 │
 ╰─────────────────── (took 0 seconds)

 ╭─ Checking existing builds
 │ Skipping build for emscripten-abi-3.1.45-h267e887_29
 │
 ╰─────────────────── (took 0 seconds)

 ╭─ Running build for recipe: emscripten_emscripten-wasm32-3.1.45-py311h61838dd_29
 │
 │ ╭─ Fetching source code
 │ │ Fetching source from git repo: https://github.com/emscripten-core/emsdk.git
 │ │ Fetching repository from https://github.com/emscripten-core/emsdk.git at HEAD into /Users/talmo/recipes/output/src_cache/emsdk.git
From https://github.com/emscripten-core/emsdk
 * branch            HEAD       -> FETCH_HEAD
Your branch is up to date with 'origin/main'.
 │ │ Checked out revision: 'HEAD' at 'f809c11ce3ae5b8f0f5381edcbf428225cc1b9c6'
 │ │ Copied 162 files into isolated environment
 │ │
 │ ╰─────────────────── (took 1 second)
 │
 │ ╭─ Running cache build
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 │ ╭─ Resolving environments
 │ │ 
 │ │ Resolving build environment:
 │ │   Platform: osx-arm64 [__unix=0=0, __osx=14.6.1=0, __archspec=1=m2]
 │ │   Channels: 
 │ │    - file:///Users/talmo/recipes/output/
 │ │    - https://repo.mamba.pm/emscripten-forge/
 │ │    - microsoft
 │ │    - conda-forge
 │ │   Specs:
 │ │    - curl 7.*
 │ │    - python 3.11.* *_cpython
 │ │
 │ │ ╭─ Resolving environments
 │ │ │
 │ │ │ ╭─ Resolving environments
 │ │ │ │
 │ │ │ │ ╭─ Resolving environments
 │ │ │ │ │
 │ │ │ │ │ ╭─ Resolving environments
 │ │ │ │ │ │
 │ │ │ │ │ ╰─────────────────── (took 0 seconds)
 │ │ │ │ │
 │ │ │ │ ╰─────────────────── (took 0 seconds)
 │ │ │ │
 │ │ │ ╰─────────────────── (took 0 seconds)
 │ │ │
 │ │ ╰─────────────────── (took 0 seconds)
 │ │ 
 │ │ ╭─────────────────┬──────────────┬────────────────────┬─────────────┬────────────╮
 │ │ │ Package         ┆ Version      ┆ Build              ┆ Channel     ┆ Size       │
 │ │ ╞═════════════════╪══════════════╪════════════════════╪═════════════╪════════════╡
 │ │ │ bzip2           ┆ 1.0.8        ┆ h99b78c6_7         ┆ conda-forge ┆ 120.03 KiB │
 │ │ │ c-ares          ┆ 1.33.1       ┆ hd74edd7_0         ┆ conda-forge ┆ 155.65 KiB │
 │ │ │ ca-certificates ┆ 2024.8.30    ┆ hf0a4a13_0         ┆ conda-forge ┆ 154.77 KiB │
 │ │ │ curl            ┆ 7.88.1       ┆ h9049daf_1         ┆ conda-forge ┆ 138.92 KiB │
 │ │ │ krb5            ┆ 1.20.1       ┆ h69eda48_0         ┆ conda-forge ┆ 1.04 MiB   │
 │ │ │ libcurl         ┆ 7.88.1       ┆ h9049daf_1         ┆ conda-forge ┆ 315.21 KiB │
 │ │ │ libcxx          ┆ 19.1.0       ┆ ha82da77_0         ┆ conda-forge ┆ 508.56 KiB │
 │ │ │ libedit         ┆ 3.1.20191231 ┆ hc8eb9b7_2         ┆ conda-forge ┆ 94.34 KiB  │
 │ │ │ libev           ┆ 4.33         ┆ h93a5062_2         ┆ conda-forge ┆ 104.94 KiB │
 │ │ │ libexpat        ┆ 2.6.3        ┆ hf9b8971_0         ┆ conda-forge ┆ 62.40 KiB  │
 │ │ │ libffi          ┆ 3.4.2        ┆ h3422bc3_5         ┆ conda-forge ┆ 38.11 KiB  │
 │ │ │ libnghttp2      ┆ 1.58.0       ┆ ha4dd798_1         ┆ conda-forge ┆ 552.20 KiB │
 │ │ │ libsqlite       ┆ 3.46.1       ┆ hc14010f_0         ┆ conda-forge ┆ 810.06 KiB │
 │ │ │ libssh2         ┆ 1.11.0       ┆ h7a5bd25_0         ┆ conda-forge ┆ 249.62 KiB │
 │ │ │ libzlib         ┆ 1.3.1        ┆ hfb2fe0b_1         ┆ conda-forge ┆ 45.82 KiB  │
 │ │ │ ncurses         ┆ 6.5          ┆ h7bae524_1         ┆ conda-forge ┆ 783.52 KiB │
 │ │ │ openssl         ┆ 3.3.2        ┆ h8359307_0         ┆ conda-forge ┆ 2.75 MiB   │
 │ │ │ python          ┆ 3.11.10      ┆ h739c21a_1_cpython ┆ conda-forge ┆ 13.97 MiB  │
 │ │ │ readline        ┆ 8.2          ┆ h92ec313_1         ┆ conda-forge ┆ 244.48 KiB │
 │ │ │ tk              ┆ 8.6.13       ┆ h5083fa2_1         ┆ conda-forge ┆ 3.00 MiB   │
 │ │ │ tzdata          ┆ 2024a        ┆ h8827d51_1         ┆ conda-forge ┆ 121.25 KiB │
 │ │ │ xz              ┆ 5.2.6        ┆ h57fd34a_0         ┆ conda-forge ┆ 230.17 KiB │
 │ │ │ zstd            ┆ 1.5.6        ┆ hb46c0d2_0         ┆ conda-forge ┆ 395.59 KiB │
 │ │ ╰─────────────────┴──────────────┴────────────────────┴─────────────┴────────────╯
 │ │ 
 │ │ Finalized run dependencies:
 │ │ ╭──────────────────┬──────────────────────╮
 │ │ │ Name             ┆ Spec                 │
 │ │ ╞══════════════════╪══════════════════════╡
 │ │ │ Run dependencies ┆                      │
 │ │ │ python           ┆ 3.11.* *_cpython (V) │
 │ │ │ nodejs           ┆ 16.*                 │
 │ │ ╰──────────────────┴──────────────────────╯
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │ 
 │ Installing build environment
 │ ✔ Successfully updated the build environment
 │ 
 │ Installing host environment
 │ ✔ Successfully updated the host environment
 │
 │ ╭─ Running build script
 │ │ + for CHANGE in '"activate"' '"deactivate"'
 │ │ + mkdir -p $PREFIX/etc/conda/activate.d
 │ │ + envsubst '$PKG_VERSION'
 │ │ /Users/talmo/recipes/output/bld/rattler-build_emscripten_emscripten-wasm32_1727593738/work/conda_build.sh: line 17: envsubst: comma
 │ │ nd not found
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 ╰─────────────────── (took 4 seconds)
 × error Error building package: Script failed with status Some(127).
 × error Work directory: "/Users/talmo/recipes/output/bld/rattler-build_emscripten_emscripten-wasm32_1727593738/work"
 × error To debug the build, run it manually in the work directory (execute the `./conda_build.sh` or `conda_build.bat` script)
Error:   × Script failed with status Some(127).
  │ Work directory: "/Users/talmo/recipes/output/bld/rattler-build_emscripten_emscripten-wasm32_1727593738/work"
  │ To debug the build, run it manually in the work directory (execute the `./conda_build.sh` or `conda_build.bat` script)
```
</details>

This is because Macs don't ship with `envsubst`.

A previous PR (https://github.com/emscripten-forge/recipes/pull/451) had added `gettext` as a build dep for `emscripten_emscripten-wasm32` so this works on Macs, but it was removed in https://github.com/emscripten-forge/recipes/pull/1064.

This PR adds it back in, which allows `pixi run setup` to work on Macs.