### PR TITLE
fix: astropy recipe add missing mandatory dependency

### DIFF
--- a/recipes/recipes_emscripten/astropy/recipe.yaml
+++ b/recipes/recipes_emscripten/astropy/recipe.yaml
@@ -12,7 +12,7 @@ source:
   # - patches/skip_ep.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/astropy/recipe.yaml
+++ b/recipes/recipes_emscripten/astropy/recipe.yaml
@@ -33,6 +33,7 @@ requirements:
   - pyerfa
   - pyyaml
   - packaging
+  - astropy-iers-data>=0.2024.7.1.0.34.3
 
 tests:
 - script: pytester

--- a/recipes/recipes_emscripten/astropy/test_astropy.py
+++ b/recipes/recipes_emscripten/astropy/test_astropy.py
@@ -1,2 +1,4 @@
 def test_import_astropy():
     import astropy.units as u
+    from astropy.coordinates import SkyCoord
+    import astropy.io.ascii


### PR DESCRIPTION
Hi here!
There is a missing mandatory dependency in the recipe. I'm not sure whether it's as simple as adding it here?

This should fix https://github.com/astropy/astropy/issues/16739 and https://github.com/emscripten-forge/recipes/issues/1226