### PR TITLE
Fix r-base xerbla error

### DIFF
--- a/recipes/recipes_emscripten/r-base/config.site
+++ b/recipes/recipes_emscripten/r-base/config.site
@@ -455,7 +455,7 @@ SHLIB_CXXLDFLAGS="-sSIDE_MODULE=1"
 ##   where int is used).
 ## Allow user to override the configure checks if they know what they
 ##   are doing (the value is unchecked).  Empty values are ignored.
-## FC_LEN_T=size_t
+FC_LEN_T=size_t
 
 ## C Stack Direction
 ## In case optimization defeats the configure test: 'down' (the usual) or 'up'

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -24,7 +24,7 @@ source:
     - patches/0012-Build-with-atomics-and-bulkmemory.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
This fixes
```diff
- LinkError: imported function 'env.xerbla_' signature mismatch
```
when loading *libRblas.so* because
```c
// r-base/src/main/print.c

#ifdef FC_LEN_T
NORET void F77_NAME(xerbla)(const char *srname, int *info,
			    const FC_LEN_T srname_len)
#else
NORET void F77_NAME(xerbla)(const char *srname, int *info)
#endif
```
([source](https://github.com/wch/r-source/blob/24e4ab74c81594bdbf9e05fd60b60cff2efe4215/src/main/print.c#L1200C1-L1205C7))