### PR TITLE
Update cockle packages to use emscripten 3.1.58

### DIFF
--- a/recipes/recipes_emscripten/cockle_fs/build.sh
+++ b/recipes/recipes_emscripten/cockle_fs/build.sh
@@ -5,9 +5,8 @@ emcc fs.c -o fs.js \
     -sEXPORTED_RUNTIME_METHODS=FS,PATH,ERRNO_CODES,PROXYFS \
     -sFORCE_FILESYSTEM=1 \
     -sMODULARIZE=1 \
-    -sSINGLE_FILE=1 \
     -lproxyfs.js
 
 
 mkdir -p $PREFIX/bin
-cp fs.js $PREFIX/bin/fs.js
+cp fs.{js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/cockle_fs/recipe.yaml
+++ b/recipes/recipes_emscripten/cockle_fs/recipe.yaml
@@ -7,7 +7,7 @@ package:
 
 
 build:
-  number: 1
+  number: 3
 
 requirements:
   build:
@@ -17,6 +17,7 @@ requirements:
 tests:
   - script:
     - test -f $PREFIX/bin/fs.js
+    - test -f $PREFIX/bin/fs.wasm
 
 about:
   homepage: https://github.com/jupyterlite/cockle

--- a/recipes/recipes_emscripten/coreutils/build.sh
+++ b/recipes/recipes_emscripten/coreutils/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "lets go"
-ls 
+ls
 ./bootstrap --skip-po
 emconfigure ./configure \
       --enable-single-binary \
@@ -13,9 +13,9 @@ emconfigure ./configure \
       gl_cv_func_sleep_works=yes
 
 
-echo "sed"      
+echo "sed"
 sed -i 's|$(MAKE) src/make-prime-list$(EXEEXT)|gcc src/make-prime-list.c -o src/make-prime-list$(EXEEXT) -Ilib/|' Makefile
-export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sINVOKE_RUN=0 -sMODULARIZE=1 -sSINGLE_FILE=1"
+export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sMODULARIZE=1"
 
 make EXEEXT=.js CFLAGS="$CFLAGS" -k -j4 || true
 
@@ -24,4 +24,4 @@ ls
 ls src/coreutils.js
 
 mkdir -p $PREFIX/bin
-cp src/coreutils.js $PREFIX/bin/coreutils.js
+cp src/coreutils.{js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/coreutils/recipe.yaml
+++ b/recipes/recipes_emscripten/coreutils/recipe.yaml
@@ -12,7 +12,7 @@ source:
   git: https://github.com/coreutils/coreutils
   tag: v9.5
 build:
-  number: 3
+  number: 5
 
 requirements:
   build:
@@ -31,6 +31,7 @@ requirements:
 tests:
   - script:
     - test -f $PREFIX/bin/coreutils.js
+    - test -f $PREFIX/bin/coreutils.wasm
 
 about:
   license: 	GPL-3.0-only
@@ -40,6 +41,3 @@ about:
 extra:
   recipe-maintainers:
     - DerThorsten
-
-
-

--- a/recipes/recipes_emscripten/grep/build.sh
+++ b/recipes/recipes_emscripten/grep/build.sh
@@ -29,10 +29,10 @@ emconfigure ./configure \
       ac_cv_have_decl_alarm=no \
       gl_cv_func_sleep_works=yes
 
-export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sINVOKE_RUN=0 -sMODULARIZE=1 -sSINGLE_FILE=1 -sERROR_ON_UNDEFINED_SYMBOLS=0"
-emmake make all CFLAGS="$CFLAGS" EXEEXT=.js 
+export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sMODULARIZE=1 -sERROR_ON_UNDEFINED_SYMBOLS=0"
+emmake make all CFLAGS="$CFLAGS" EXEEXT=.js
 
 ls
 
 mkdir -p $PREFIX/bin
-cp src/grep.js $PREFIX/bin/grep.js
+cp src/grep.{js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/grep/recipe.yaml
+++ b/recipes/recipes_emscripten/grep/recipe.yaml
@@ -10,9 +10,9 @@ package:
 #   url: https://ftp.gnu.org/gnu/grep/grep-3.11.tar.xz
 #   sha256: 1db2aedde89d0dea42b16d9528f894c8d15dae4e190b59aecc78f5a951276eab
 #   url: https://github.com/Distrotech/grep
-#   branch: 
+#   branch:
 build:
-  number: 3
+  number: 5
 
 requirements:
   build:
@@ -32,6 +32,7 @@ requirements:
 tests:
   - script:
     - test -f $PREFIX/bin/grep.js
+    - test -f $PREFIX/bin/grep.wasm
 
 about:
   license: 	GPL-3.0-only

--- a/recipes/recipes_emscripten/lua/CMakeLists.txt
+++ b/recipes/recipes_emscripten/lua/CMakeLists.txt
@@ -61,19 +61,19 @@ set(lua_binaries lua luac)
 
 foreach(lua_binary ${lua_binaries})
   # set target compile options
-  target_compile_definitions(${lua_binary} 
+  target_compile_definitions(${lua_binary}
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
       PUBLIC "SHELL: -s ENVIRONMENT=web,worker,node"
-      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY"
+      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY"
       PUBLIC "SHELL: -s MODULARIZE=1"
   )
   # set target link options
-  target_link_options(${lua_binary} 
+  target_link_options(${lua_binary}
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
       PUBLIC "SHELL: -s ENVIRONMENT=web,worker,node"
-      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=callMain,FS,ENV,getEnvStrings,TTY"
+      PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY"
       PUBLIC "SHELL: -s MODULARIZE=1"
   )
 endforeach()

--- a/recipes/recipes_emscripten/lua/recipe.yaml
+++ b/recipes/recipes_emscripten/lua/recipe.yaml
@@ -21,7 +21,7 @@ source:
 - path: CMakeLists.txt
 
 build:
-  number: 11
+  number: 13
 
 requirements:
   build:
@@ -39,17 +39,16 @@ tests:
       fi
     requirements:
       build:
-        - run_modularized
+        - run_modularized >= 0.1.2
   - script: |
       OUTPUT=$(run_modularized $PREFIX/bin/luac.js -v)
       if [[ "$OUTPUT" != "Lua 5.4.6  Copyright (C) 1994-2023 Lua.org, PUC-Rio" ]]; then
         echo "Unexpected output: $OUTPUT"
         exit 1
       fi
-
     requirements:
       build:
-        - run_modularized
+        - run_modularized >= 0.1.2
 
 about:
   summary: Lua is a powerful, fast, lightweight, embeddable scripting language


### PR DESCRIPTION
Update cockle packages to use emscripten 3.1.58. The packages are `cockle_fs`, `coreutils`, `grep` and `lua`. The changes comprise cherry-picking the appropriate changes from the `main` branch onto this `emscripten-3.1.58` branch and bumping the build numbers to be one larger than the previous builds.