### PR TITLE
Fix Undefined Symbols while building llvm

### DIFF
--- a/recipes/recipes_emscripten/llvm/build.sh
+++ b/recipes/recipes_emscripten/llvm/build.sh
@@ -20,10 +20,9 @@ emcmake cmake ${CMAKE_ARGS} -S ../llvm -B .         \
     -DLLVM_INCLUDE_TESTS=OFF                        \
     -DLLVM_ENABLE_LIBEDIT=OFF                       \
     -DLLVM_ENABLE_PROJECTS="clang;lld"              \
-    -DCMAKE_CXX_FLAGS="-Dwait4=__syscall_wait4"     \
     -DCMAKE_VERBOSE_MAKEFILE=ON                     \
     -DLLVM_ENABLE_THREADS=OFF                       \
-    -DCMAKE_CXX_FLAGS="-isystem $EMSCRIPTEN_FORGE_EMSDK_DIR/upstream/emscripten/cache/sysroot/include/c++/v1"
+    -DCMAKE_CXX_FLAGS="-Dwait4=__syscall_wait4 -isystem $EMSCRIPTEN_FORGE_EMSDK_DIR/upstream/emscripten/cache/sysroot/include/c++/v1"
 
 # Build step
 emmake make -j1

--- a/recipes/recipes_emscripten/llvm/build.sh
+++ b/recipes/recipes_emscripten/llvm/build.sh
@@ -26,7 +26,7 @@ emcmake cmake ${CMAKE_ARGS} -S ../llvm -B .         \
     -DCMAKE_CXX_FLAGS="-isystem $EMSCRIPTEN_FORGE_EMSDK_DIR/upstream/emscripten/cache/sysroot/include/c++/v1"
 
 # Build step
-EMCC_CFLAGS='-sERROR_ON_UNDEFINED_SYMBOLS=0' emmake make -j1
+emmake make -j1
 
 # Install step
 emmake make install

--- a/recipes/recipes_emscripten/llvm/patches/lldwasm_link.patch
+++ b/recipes/recipes_emscripten/llvm/patches/lldwasm_link.patch
@@ -1,0 +1,20 @@
+diff --git a/clang/lib/Interpreter/CMakeLists.txt b/clang/lib/Interpreter/CMakeLists.txt
+index 2cc7c59b61d3..d5ffe78251d2 100644
+--- a/clang/lib/Interpreter/CMakeLists.txt
++++ b/clang/lib/Interpreter/CMakeLists.txt
+@@ -14,6 +14,7 @@ set(LLVM_LINK_COMPONENTS
+ 
+ if (EMSCRIPTEN AND "lld" IN_LIST LLVM_ENABLE_PROJECTS)
+   set(WASM_SRC Wasm.cpp)
++  set(WASM_LINK lldWasm)
+ endif()
+ 
+ add_clang_library(clangInterpreter
+@@ -44,6 +45,7 @@ add_clang_library(clangInterpreter
+   clangParse
+   clangSema
+   clangSerialization
++  ${WASM_LINK}
+   )
+ 
+ if ((MINGW OR CYGWIN) AND BUILD_SHARED_LIBS)

--- a/recipes/recipes_emscripten/llvm/recipe.yaml
+++ b/recipes/recipes_emscripten/llvm/recipe.yaml
@@ -11,6 +11,7 @@ source:
   sha256: 622cb6c5e95a3bb7e9876c4696a65671f235bd836cfd0c096b272f6c2ada41e7
   patches:
   - patches/cross_compile.patch
+  - patches/lldwasm_link.patch
 
 build:
   number: 1

--- a/recipes/recipes_emscripten/llvm/recipe.yaml
+++ b/recipes/recipes_emscripten/llvm/recipe.yaml
@@ -13,7 +13,7 @@ source:
   - patches/cross_compile.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Not sure why the upload to Quetz failed on all 3 previous updates on llvm 

1) https://github.com/emscripten-forge/recipes/actions/runs/11376454739/job/31648960141
2) https://github.com/emscripten-forge/recipes/actions/runs/11209653508/job/31155192548
3) https://github.com/emscripten-forge/recipes/actions/runs/11052231541/job/30703847510

Need this for CppInterOp