### PR TITLE
Build Cairo with freetype

### DIFF
--- a/recipes/recipes_emscripten/cairo/build.sh
+++ b/recipes/recipes_emscripten/cairo/build.sh
@@ -2,9 +2,15 @@
 
 set -ex
 
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$BUILD_PREFIX/lib/pkgconfig
+export PKG_CONFIG=$BUILD_PREFIX/bin/pkg-config
+
+export CFLAGS="${CFLAGS} -DCAIRO_NO_MUTEX=1"
+export LDFLAGS="${LDFLAGS} -lz"
+
 meson_config_args=(
     -Dfontconfig=enabled
-    -Dfreetype=disabled
+    -Dfreetype=enabled
     -Dglib=enabled
     -Dpng=disabled
     -Dxlib=disabled

--- a/recipes/recipes_emscripten/cairo/patches/cairo-wasm.patch
+++ b/recipes/recipes_emscripten/cairo/patches/cairo-wasm.patch
@@ -1,0 +1,13 @@
+diff --git a/src/cairo-ft-private.h b/src/cairo-ft-private.h
+index 836f7e523..6b0e30223 100644
+--- a/src/cairo-ft-private.h
++++ b/src/cairo-ft-private.h
+@@ -43,6 +43,8 @@
+ 
+ #if CAIRO_HAS_FT_FONT
+ 
++#include FT_COLOR_H
++
+ CAIRO_BEGIN_DECLS
+ 
+ typedef struct _cairo_ft_unscaled_font cairo_ft_unscaled_font_t;

--- a/recipes/recipes_emscripten/cairo/recipe.yaml
+++ b/recipes/recipes_emscripten/cairo/recipe.yaml
@@ -9,9 +9,11 @@ package:
 source:
   url: http://cairographics.org/releases/${{ name }}-${{ version }}.tar.xz
   sha256: 243a0736b978a33dee29f9cca7521733b78a65b5418206fef7bd1c3d4cf10b64
+  patches:
+  - patches/cairo-wasm.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -20,6 +22,7 @@ requirements:
     - meson
     - ninja
     - pkg-config
+    - gobject-introspection
   host:
     - freetype
     - fontconfig>=2.12

--- a/recipes/recipes_emscripten/cairo/recipe.yaml
+++ b/recipes/recipes_emscripten/cairo/recipe.yaml
@@ -53,3 +53,4 @@ about:
 extra:
   recipe-maintainers:
     - IsabelParedes
+    - anutosh491


### PR DESCRIPTION
Here are somethings I see

1) Building cairo locally as per the recipe on master fails
2) We need a patch that was realized by the maintainers of cairo too to compile it to emscripten (merged into master but not available in 1.18.0 so should be there till next release https://gitlab.freedesktop.org/cairo/cairo/-/issues/792)
3) I think pango expects cairo to be built with freetype and fontconfig if we want to include it as a dependency