### PR TITLE
Attempt to fix output duplication through clang-repl

### DIFF
--- a/recipes/recipes_emscripten/llvm/patches/skip_undefined_symbols_at_link_step.patch
+++ b/recipes/recipes_emscripten/llvm/patches/skip_undefined_symbols_at_link_step.patch
@@ -11,25 +11,27 @@ index 7954cde36588..dbd61f0b8b1e 100644
    llvm::Expected<llvm::orc::ExecutorAddr>
    getSymbolAddress(llvm::StringRef Name, SymbolNameKind NameKind) const;
  
-diff --git a/clang/lib/Interpreter/Interpreter.cpp b/clang/lib/Interpreter/Interpreter.cpp
-index b4882ab5d223..985d0b7c0ef3 100644
---- a/clang/lib/Interpreter/Interpreter.cpp
-+++ b/clang/lib/Interpreter/Interpreter.cpp
-@@ -192,8 +192,8 @@ IncrementalCompilerBuilder::CreateCpp() {
- #ifdef __EMSCRIPTEN__
-   Argv.push_back("-target");
-   Argv.push_back("wasm32-unknown-emscripten");
--  Argv.push_back("-pie");
-   Argv.push_back("-shared");
-+  Argv.push_back("-fvisibility=default");
- #endif
-   Argv.insert(Argv.end(), UserArgs.begin(), UserArgs.end());
- 
 diff --git a/clang/lib/Interpreter/Wasm.cpp b/clang/lib/Interpreter/Wasm.cpp
-index 1001410aa0f2..56d215d00f58 100644
+index 1001410aa0f2..c0297e0d3a05 100644
 --- a/clang/lib/Interpreter/Wasm.cpp
 +++ b/clang/lib/Interpreter/Wasm.cpp
-@@ -72,13 +72,12 @@ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
+@@ -37,6 +37,15 @@ WasmIncrementalExecutor::WasmIncrementalExecutor(
+     llvm::orc::ThreadSafeContext &TSC)
+     : IncrementalExecutor(TSC) {}
+ 
++void removeGlobalInit(llvm::Module *M) {
++  std::string targetName = "_GLOBAL__sub_I_" + M->getName().str();
++  for (auto &Func : *M) {
++    if (Func.hasName() && Func.getName().str() == targetName) {
++      Func.deleteBody();
++    }
++  }
++}
++
+ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
+   std::string ErrorString;
+ 
+@@ -72,13 +81,13 @@ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
    OutputFile.close();
  
    std::vector<const char *> LinkerArgs = {"wasm-ld",
@@ -37,7 +39,7 @@ index 1001410aa0f2..56d215d00f58 100644
 +                                          "-shared",
                                            "--import-memory",
                                            "--no-entry",
--                                          "--export-all",
+                                           "--export-all",
                                            "--experimental-pic",
 -                                          "--no-export-dynamic",
                                            "--stack-first",
@@ -45,7 +47,16 @@ index 1001410aa0f2..56d215d00f58 100644
                                            OutputFileName.c_str(),
                                            "-o",
                                            OutputFileName.c_str()};
-@@ -109,6 +108,10 @@ llvm::Error WasmIncrementalExecutor::runCtors() const {
+@@ -96,6 +105,8 @@ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
+         "Failed to load incremental module", llvm::inconvertibleErrorCode());
+   }
+ 
++  removeGlobalInit(PTU.TheModule.get());
++
+   return llvm::Error::success();
+ }
+ 
+@@ -109,6 +120,10 @@ llvm::Error WasmIncrementalExecutor::runCtors() const {
    return llvm::Error::success();
  }
  

--- a/recipes/recipes_emscripten/llvm/recipe.yaml
+++ b/recipes/recipes_emscripten/llvm/recipe.yaml
@@ -14,7 +14,7 @@ source:
   - patches/skip_undefined_symbols_at_link_step.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Currently we see duplication of output while running xeus-cpp-lite (or rather clang-repl in the browser )
![image](https://github.com/user-attachments/assets/8429e46f-3248-44ce-bd0a-75767f9416e8)

