### PR TITLE
Build expat with fPIC

### DIFF
--- a/recipes/recipes_emscripten/expat/build.sh
+++ b/recipes/recipes_emscripten/expat/build.sh
@@ -2,16 +2,14 @@
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/libtool/build-aux/config.* ./conftools
 
+export CFLAGS="-fPIC"
+
 emconfigure ./configure --prefix=$PREFIX \
-            --host=${HOST} \
-            --build=${BUILD} \
             --enable-static \
             --disable-shared
 
-make -j${CPU_COUNT} ${VERBOSE_AT}
-
-# if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
-#       make check
-# fi
+make -j${CPU_COUNT}
 
 make install
+
+cp xmlwf/xmlwf.wasm $PREFIX/bin/

--- a/recipes/recipes_emscripten/expat/recipe.yaml
+++ b/recipes/recipes_emscripten/expat/recipe.yaml
@@ -45,6 +45,7 @@ about:
   license_file: COPYING
   summary: Expat XML parser library in C
   homepage: http://expat.sourceforge.net/
+  repository: https://github.com/libexpat/libexpat
 
 extra:
   recipe-maintainers:

--- a/recipes/recipes_emscripten/expat/recipe.yaml
+++ b/recipes/recipes_emscripten/expat/recipe.yaml
@@ -1,9 +1,10 @@
 context:
+  name: expat
   version: 2.4.8
   ver: ${{ version|replace('.', '_') }}
 
 package:
-  name: expat
+  name: ${{ name }}
   version: ${{ version }}
 
 source:
@@ -12,34 +13,40 @@ source:
   sha256: a247a7f6bbb21cf2ca81ea4cbb916bfb9717ca523631675f99b3d4a5678dcd16
 
 build:
-  number: 0
-  # run_exports:
-  #   # changes soname at major versions, default settings OK
-  #   # https://abi-laboratory.pro/tracker/timeline/expat/
-  #   - {{ pin_subpackage('expat') }}
+  number: 1
 
 requirements:
   build:
-    # - cmake
   - ninja
-  - make    # [unix]
-  - libtool    # [unix]
+  - make
+  - automake<1.17
+  - libtool
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
-  # host:
-    # - msinttypes  # [win and vc<14]
 
-# test:
-#   commands:
-#     - xmlwf -h
+tests:
+- package_contents:
+    bin:
+    - xmlwf.wasm
+    lib:
+    - libexpat.a
+    include:
+    - expat.h
+- script:
+    - node $PREFIX/bin/xmlwf -h
+  requirements:
+    build:
+      - nodejs
+
 
 about:
   license: MIT
   license_family: MIT
   license_file: COPYING
   summary: Expat XML parser library in C
-
   homepage: http://expat.sourceforge.net/
+
 extra:
   recipe-maintainers:
   - wolfv
+  - IsabelParedes


### PR DESCRIPTION
Required to build the *cairo.so* module in `r-base`.