### PR TITLE
Build libpng with fPIC

### DIFF
--- a/recipes/recipes_emscripten/libpng/build.sh
+++ b/recipes/recipes_emscripten/libpng/build.sh
@@ -5,7 +5,7 @@ rm $PREFIX/lib/libz.so*
 cp $BUILD_PREFIX/share/libtool/build-aux/config.* .
 
 # atomics and bulk-memory are required for cairo
-export CFLAGS="-I$PREFIX/include -matomics -mbulk-memory"
+export CFLAGS="-I$PREFIX/include -matomics -mbulk-memory -fPIC"
 export CPPFLAGS="-I$PREFIX/include"
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 
@@ -22,3 +22,7 @@ emmake make install
 
 # Not packaging any shared libraries
 rm $PREFIX/lib/libpng*.la
+
+# Copy wasm files
+cp pngfix.wasm $PREFIX/bin/
+cp png-fix-itxt.wasm $PREFIX/bin/

--- a/recipes/recipes_emscripten/libpng/recipe.yaml
+++ b/recipes/recipes_emscripten/libpng/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 8c25a7792099a0089fa1cc76c94260d0bb3f1ec52b93671b572f8bb61577b732
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -21,10 +21,16 @@ requirements:
   - zlib
 
 tests:
+- package_contents:
+    bin:
+    - pngfix.wasm
+    - png-fix-itxt.wasm
+    lib:
+    - libpng16.a
+    include:
+    - png.h
 - script:
-  - test -f ${PREFIX}/lib/libpng.a
-  - test -f ${PREFIX}/include/png.h
-  - libpng-config --version
+    - libpng-config --version
 
 about:
   license: zlib-acknowledgement


### PR DESCRIPTION
Required to build *cairo.so* module in `r-base`.