### PR TITLE
ncurses: include terminfo database in package

### DIFF
--- a/recipes/recipes_emscripten/ncurses/build.sh
+++ b/recipes/recipes_emscripten/ncurses/build.sh
@@ -11,6 +11,8 @@ export BUILD_CFLAGS="-Wno-sWASM_BIGINT"
 export BUILD_LDFLAGS="-Wno-sWASM_BIGINT"
 
 emconfigure ./configure \
+    --build=x86_64-linux-gnu \
+    --host=wasm32-unknown-emscripten \
     --prefix=$PREFIX \
     --without-debug \
     --without-ada \
@@ -25,7 +27,6 @@ emconfigure ./configure \
     --with-versioned-syms \
     --disable-widec \
     --disable-stripping \
-    --disable-database \
     --with-build-cc=${BUILD_CC} \
     --with-build-cflags=${BUILD_CFLAGS} \
     --with-build-ldflags=${BUILD_LDFLAGS}

--- a/recipes/recipes_emscripten/ncurses/recipe.yaml
+++ b/recipes/recipes_emscripten/ncurses/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: e0f669ca923dfee33de25ede9de619a15671a07cdf9e530d742b22988e96ac1f
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -26,6 +26,7 @@ tests:
 - script:
     - test -f ${PREFIX}/lib/libncurses.a
     - test -f ${PREFIX}/include/ncurses/curses.h
+    - test -f ${PREFIX}/share/terminfo/x/xterm-256color
     - node ${PREFIX}/bin/clear -V -T $TERM # This should print the ncurses version
   requirements:
     build:


### PR DESCRIPTION
This modifies the `ncurses` recipe to include terminal database information, in other words runtime configuration files, in the `share` directory. This is needed for the upcoming `vim` recipe which needs to use the `terminfo/x/xterm-256color` to operate correctly. Rather than just building and shipping that one file, I'm including all of the database files as I expect more will be needed at some point in the future.

The changes to the recipe are at the `configure` stage, removing the `--disable-database` flag and specifying the `--build` and `--host` platforms. The latter are needed to ensure that it knows it is cross-compiling so that it uses the build platform's tool (called `tic`) to build the `terminfo` rather than the host's.

The packages `bin` directory now includes a couple more utilities and a new `share` directory which is 7.2 MB.

As far as I can tell `ncurses` is only used in the `lua` recipe so I don't think the additions here will affect any other recipes. But it would be good to get a second opinion that these changes are OK.