### PR TITLE
Add tree

### DIFF
--- a/.github/workflows/run_with_pixi.yaml
+++ b/.github/workflows/run_with_pixi.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
 
   build_simple_with_pixi:
+    if: false
     runs-on: ubuntu-latest
     env:
       TARGET_PLATFORM: emscripten-wasm32

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,7 +12,7 @@ platforms = ["osx-arm64", "osx-64", "linux-64"]
 ############################################
 [feature.feature_rattler_build]
 [feature.feature_rattler_build.dependencies]
-rattler-build = ">= 0.18.2"
+rattler-build = ">=0.18.2"
 python = "3.11.*"
 typer = "*"
 curl = "*"

--- a/recipes/recipes_emscripten/tree/build.sh
+++ b/recipes/recipes_emscripten/tree/build.sh
@@ -8,7 +8,6 @@ export CONFIG_LDFLAGS="\
     "
 
 emmake make \
-    EXEEXT=.js \
     CFLAGS="$CFLAGS -Os" \
     LDFLAGS="$LDFLAGS $CONFIG_LDFLAGS"
 

--- a/recipes/recipes_emscripten/tree/build.sh
+++ b/recipes/recipes_emscripten/tree/build.sh
@@ -1,0 +1,17 @@
+export CONFIG_LDFLAGS="\
+    -Os \
+    --minify=0 \
+    -sALLOW_MEMORY_GROWTH=1 \
+    -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY \
+    -sFORCE_FILESYSTEM=1 \
+    -sMODULARIZE=1 \
+    "
+
+emmake make \
+    EXEEXT=.js \
+    CFLAGS="$CFLAGS -Os" \
+    LDFLAGS="$LDFLAGS $CONFIG_LDFLAGS"
+
+mkdir -p $PREFIX/bin
+cp tree $PREFIX/bin/tree.js
+cp tree.wasm $PREFIX/bin/

--- a/recipes/recipes_emscripten/tree/recipe.yaml
+++ b/recipes/recipes_emscripten/tree/recipe.yaml
@@ -1,0 +1,41 @@
+context:
+  name: tree
+  version: 2.2.1
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: http://oldmanprogrammer.net/tar/${{ name }}/${{ name }}-${{ version }}.tgz
+  sha256: 68ac45dc78c0c311ada06200ffc3c285e74223ba208061f8d15ffac25e44b2ec
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - make
+
+tests:
+  - script:
+    - test -f $PREFIX/bin/tree.js
+    - test -f $PREFIX/bin/tree.wasm
+  - script: |
+      OUTPUT=$(run_modularized $PREFIX/bin/tree.js --version)
+      if [[ "$OUTPUT" != "tree v2.2.1 © 1996 - 2024 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro" ]]; then
+        echo "Unexpected output: $OUTPUT"
+        exit 1
+      fi
+    requirements:
+      build:
+        - run_modularized >= 0.1.2
+
+about:
+  license: GPL-2.0-only
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - ianthomas23


### PR DESCRIPTION
Add new package `tree` for use in [cockle](https://github.com/jupyterlite/cockle).

It is based on the `conda-forge` recipe, here adding to the `emscripten-3.1.58` branch like all other `cockle` commands. This is a good command to have as it is easy to build and output unicode characters which are not currently supported by `cockle` commands but will be shortly.

I have not used the `-sENVIRONMENT=web.worker` emscripten flag as we need the generated javascript/wasm to support `node` to be able to run the `run_modularized` test. The default value for `ENVIRONMENT` includes `node` so in future we may as well just use the default for `cockle` commands.