### PR TITLE
Use locateFile in run_modularized

### DIFF
--- a/recipes/recipes/run_modularized/recipe.yaml
+++ b/recipes/recipes/run_modularized/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:

--- a/recipes/recipes/run_modularized/run_modularized.js
+++ b/recipes/recipes/run_modularized/run_modularized.js
@@ -8,6 +8,12 @@ async function my_main(){
     const ModuleF = require(binary_js_runner);
     const Module = await ModuleF({
         arguments: process.argv,
+        locateFile: (filename) => {
+            // .wasm and .data files are in the same directory as the module .js file
+            const path = require('path');
+            const directory = path.dirname(binary_js_runner);
+            return path.join(directory, filename);
+        },
         quit: (status, toThrow) => {
             if (already_called) {
                 return;


### PR DESCRIPTION
This changes `run_modularized` to specifically look in the same directory for `*.wasm` and `*.data` files as it does for their `*.js` wrappers. This has not been a problem until now as this is the default behaviour for `*.wasm` files, but with the addition of the upcoming `vim` recipe it is not enough. `vim` ships with a set of runtime config files that are [packaged](https://emscripten.org/docs/porting/files/packaging_files.html) in a standard way in a `vim.data` file, and is loaded in a slightly different way by `vim.js` which the default behaviour doesn't cover when running in a `node` context as `run_modularized` does.

So here `locateFile` is specified when loading the wasm package so that `*.data` and `*.wasm` are correctly loaded. This is the same solution as used in `cockle`:
https://github.com/jupyterlite/cockle/blob/430ad63653e7c4a3ad9beb7267a7f4dc2c3176a9/src/commands/wasm_command_runner.ts#L104
except that the base path/URL is specified externally in `cockle` and here it is determined by the local path to the `*.js` file.