### PR TITLE
Revert "Emscripten 3.1.73"

### DIFF
--- a/recipes/recipes/emscripten_emscripten-wasm32/patches/0001-Add-back-fs.findObject-and-fs.readFile-in-loadLibDat.patch
+++ b/recipes/recipes/emscripten_emscripten-wasm32/patches/0001-Add-back-fs.findObject-and-fs.readFile-in-loadLibDat.patch
@@ -1,8 +1,19 @@
+From 0170462a78e86de9ee95017bfa7e4a3dd620a375 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Fri, 2 Jun 2023 11:59:32 -0700
+Subject: [PATCH] Add back fs.findObject and fs.readFile in loadLibData
+
+See upstream PR:
+https://github.com/emscripten-core/emscripten/pull/19513
+---
+ src/library_dylink.js | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
 diff --git a/src/library_dylink.js b/src/library_dylink.js
-index 748468aae..c540877b3 100644
+index d7676cdc2..f616d230d 100644
 --- a/src/library_dylink.js
 +++ b/src/library_dylink.js
-@@ -1013,15 +1013,23 @@ var LibraryDylink = {
+@@ -993,14 +993,23 @@ var LibraryDylink = {
  #endif
  
        // for wasm, we can use fetch for async, but for fs mode we can only imitate it
@@ -16,7 +27,6 @@ index 748468aae..c540877b3 100644
 +          libData = HEAP8.slice(data, data + dataSize);
          }
        }
--
 +      if (!libData && flags.fs && flags.fs.findObject(libName)) {
 +        libData = flags.fs.readFile(libName, {encoding: 'binary'});
 +        if (!(libData instanceof Uint8Array)) {
@@ -26,6 +36,9 @@ index 748468aae..c540877b3 100644
 +      if (libData) {
 +        return flags.loadAsync ? Promise.resolve(libData) : libData;
 +      }
+ 
        var libFile = locateFile(libName);
        if (flags.loadAsync) {
-         return asyncLoad(libFile);
+-- 
+2.25.1
+

--- a/recipes/recipes/emscripten_emscripten-wasm32/patches/0001-Add-useful-error-when-symbol-resolution-fails.patch
+++ b/recipes/recipes/emscripten_emscripten-wasm32/patches/0001-Add-useful-error-when-symbol-resolution-fails.patch
@@ -1,0 +1,37 @@
+From a8bdb50a29062ee70c8667e4fd94dde47917f8fa Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Fri, 19 May 2023 12:19:00 -0700
+Subject: [PATCH] Add useful error when symbol resolution fails
+
+Currently if symbol resolution fails, we get:
+```js
+TypeError: Cannot read properties of undefined (reading 'apply')
+```
+It is very hard for newcomers to Emscripten to recognize this as a
+symbol resolution error. Even for people experienced with this message,
+it has the annoyance that it doesn't give any hint as to which symbol
+went missing.
+
+This adds a descriptive error message with the name of the missing
+symbol.
+---
+ src/library_dylink.js | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/library_dylink.js b/src/library_dylink.js
+index d96e6b425..7f63b5c5e 100644
+--- a/src/library_dylink.js
++++ b/src/library_dylink.js
+@@ -727,6 +727,9 @@ var LibraryDylink = {
+             var resolved;
+             stubs[prop] = function() {
+               if (!resolved) resolved = resolveSymbol(prop);
++              if (!resolved) {
++                throw new Error(`Dynamic linking error: cannot resolve symbol ${prop}`);
++              }
+               return resolved.apply(null, arguments);
+             };
+           }
+-- 
+2.25.1
+

--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -1,9 +1,9 @@
 context:
   name: emscripten_emscripten-wasm32
-  version: 3.1.73
+  version: 3.1.45
 
 build:
-  number: 0
+  number: 30
 
 outputs:
   - package:


### PR DESCRIPTION
* we just use the 3.1.73 change to trigger the build of that versiob
* we revert this since we want to keep the 3.1.45 compiler on main