### PR TITLE
Update R packages

### DIFF
--- a/recipes/recipes_emscripten/r-base64enc/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base64enc/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-base64enc
   version: 0.1-3
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version|replace('-', '_') }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: 6d856d8a364bcdc499a0bf38bfd283b7c743d08f0b288174fba7dbf0a04b688d
 
 build:
-  number: 4
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 5
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version|replace('-', '_') }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: http://www.rforge.net/base64enc

--- a/recipes/recipes_emscripten/r-cli/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cli/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   version: 3.6.3
   name: r-cli
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: 4295085f11221c54b1dd2b1d39a675a85dfd9f900294297567e1d36f65ac4841
 
 build:
-  number: 1
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 2
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://cli.r-lib.org

--- a/recipes/recipes_emscripten/r-colorspace/recipe.yaml
+++ b/recipes/recipes_emscripten/r-colorspace/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   version: 2.1-1
   name: r-colorspace
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version|replace('-', '_') }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: e721cee5f4d6e4b0fc8eb18265e316b4f856fd3be02f0775a26032663758cd0b
 
 build:
-  number: 1
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 2
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version|replace('-', '_') }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: http://colorspace.R-Forge.R-project.org

--- a/recipes/recipes_emscripten/r-digest/recipe.yaml
+++ b/recipes/recipes_emscripten/r-digest/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-digest
   version: 0.6.37
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,28 +10,30 @@ source:
   sha256: 82c4d149994b8a4a9af930f5a8e47420829935abed41f3f9030e94b6a48f0321
 
 build:
-  number: 3
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 4
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-    - ${{ compiler('cxx') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+      - ${{ compiler('cxx') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://dirk.eddelbuettel.com/code/digest.html
@@ -43,7 +41,7 @@ about:
   license: GPL-2.0
   license_family: GPL2
   license_file: GPL-2
-  summary: Compact hash representations of arbritrary R objects.
+  summary: Compact hash representations of arbitrary R objects.
 
 extra:
   recipe-maintainers:

--- a/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-ellipsis
   version: 0.3.2
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,30 +10,32 @@ source:
   sha256: a90266e5eb59c7f419774d5c6d6bd5e09701a26c9218c5933c9bce6765aa1558
 
 build:
-  number: 1
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 2
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-  - cross-r-base >= ${{ r_base_version }}
-  - r-rlang
-  - ${{ compiler('c') }}
-  host:
-  - r-base >= ${{ r_base_version }}
-  - r-rlang
-  run:
-  - r-base >= ${{ r_base_version }}
-  - r-rlang
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+    - cross-r-base >= ${{ r_base_version }}
+    - r-rlang
+    - ${{ compiler('c') }}
+    host:
+    - r-base >= ${{ r_base_version }}
+    - r-rlang
+    run:
+    - r-base >= ${{ r_base_version }}
+    - r-rlang
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://ellipsis.r-lib.org

--- a/recipes/recipes_emscripten/r-fansi/patches/0001-Ignore-custom-limit-checks.patch
+++ b/recipes/recipes_emscripten/r-fansi/patches/0001-Ignore-custom-limit-checks.patch
@@ -1,0 +1,23 @@
+From 246a64768dd17781fb68c0d6ed7e698225dd7ca1 Mon Sep 17 00:00:00 2001
+From: Isabel Paredes <isabel.paredes@quantstack.net>
+Date: Fri, 13 Dec 2024 23:34:11 +0100
+Subject: [PATCH] Ignore custom limit checks
+
+FIXME: this is not the proper solution but it works for xeus-r
+---
+ src/assumptions.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/assumptions.c b/src/assumptions.c
+index 1187151..5df0773 100644
+--- a/src/assumptions.c
++++ b/src/assumptions.c
+@@ -37,7 +37,7 @@ static void check_limits(void) {
+     // Unsigned
+     FANSI_lim.lim_size_t.max < 1U || FANSI_lim.lim_size_t.min != 0U
+   )
+-    error("Invalid custom limit; contact maintainer.");  // nocov
++    printf("ERROR: Invalid custom limit; contact maintainer.");  // nocov
+ }
+ // nocov start
+ // by definition none of the errors should be thrown, so no sense in

--- a/recipes/recipes_emscripten/r-fansi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fansi/recipe.yaml
@@ -3,38 +3,38 @@ context:
   version: 1.0.6
   r_base_version: 4.4.1
 
-package:
-  name: ${{ name }}
-  version: ${{ version }}
-
 source:
   url:
     - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
     - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: ea9dc690dfe50a7fad7c5eb863c157d70385512173574c56f4253b6dfe431863
+  patches:
+    - patches/0001-Ignore-custom-limit-checks.patch
 
 build:
-  number: 3
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 4
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://github.com/brodieG/fansi

--- a/recipes/recipes_emscripten/r-fansi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fansi/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: r-fansi
   version: 1.0.6
-  r_base_version: 4.4.1
+  r_base_version: 4.4.2
 
 source:
   url:

--- a/recipes/recipes_emscripten/r-farver/recipe.yaml
+++ b/recipes/recipes_emscripten/r-farver/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-farver
   version: 2.1.2
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: 528823b95daab4566137711f1c842027a952bea1b2ae6ff098e2ca512b17fe25
 
 build:
-  number: 1
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 2
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('cxx') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('cxx') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://farver.data-imaginist.com/

--- a/recipes/recipes_emscripten/r-fastmap/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fastmap/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-fastmap
   version: 1.2.0
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,28 +10,30 @@ source:
   sha256: b1da04a2915d1d057f3c2525e295ef15016a64e6667eac83a14641bbd83b9246
 
 build:
-  number: 3
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 4
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-    - ${{ compiler('cxx') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+      - ${{ compiler('cxx') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://r-lib.github.io/fastmap/

--- a/recipes/recipes_emscripten/r-glue/recipe.yaml
+++ b/recipes/recipes_emscripten/r-glue/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-glue
   version: 1.7.0
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -15,27 +11,29 @@ source:
   sha256: 1af51b51f52c1aeb3bfe9349f55896dd78b5542ffdd5654e432e4d646e4a86dc
 
 build:
-  number: 3
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 4
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://github.com/tidyverse/glue

--- a/recipes/recipes_emscripten/r-isoband/recipe.yaml
+++ b/recipes/recipes_emscripten/r-isoband/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-isoband
   version: 0.2.7
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,28 +10,30 @@ source:
   sha256: 7693223343b45b86de2b5b638ff148f0dafa6d7b1237e822c5272902f79cdf61
 
 build:
-  number: 3
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 4
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-    - ${{ compiler('cxx') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+      - ${{ compiler('cxx') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://isoband.r-lib.org/

--- a/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
+++ b/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-jsonlite
   version: 1.8.9
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: 89f130e0e1163328c01decd54e7712b5ebf3d0a667da0052833722cb9a6e90b0
 
 build:
-  number: 1
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 2
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-  - cross-r-base >= ${{ r_base_version }}
-  - ${{ compiler('c') }}
-  host:
-  - r-base >= ${{ r_base_version }}
-  run:
-  - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+    - cross-r-base >= ${{ r_base_version }}
+    - ${{ compiler('c') }}
+    host:
+    - r-base >= ${{ r_base_version }}
+    run:
+    - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://arxiv.org/abs/1403.2805, https://www.opencpu.org/posts/jsonlite-a-smarter-json-encoder

--- a/recipes/recipes_emscripten/r-lattice/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lattice/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-lattice
   version: 0.22-6
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version|replace('-', '_') }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: 4b377211e472ece7872b9d6759f9b9c660b09594500462eb6146312a1d4d00f7
 
 build:
-  number: 2
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 3
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version|replace('-', '_') }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://lattice.r-forge.r-project.org/

--- a/recipes/recipes_emscripten/r-magrittr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-magrittr/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-magrittr
   version: 2.0.3
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: a2bff83f792a1acb801bfe6330bb62724c74d5308832f2cb6a6178336ace55d2
 
 build:
-  number: 1
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 2
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://magrittr.tidyverse.org/

--- a/recipes/recipes_emscripten/r-mass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mass/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-mass
   version: 7.3-61
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version|replace('-', '_') }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: 3144c8bf579dd7b7c47c259728c27f53f53e294e7ed307da434dfd144e800a90
 
 build:
-  number: 4
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 5
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version|replace('-', '_') }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] | upper }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] | upper }}/libs/${{ name[2:] | upper }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] | upper }}/libs/${{ name[2:] | upper }}.so
 
 about:
   homepage: http://www.stats.ox.ac.uk/pub/MASS4/

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-nlme
   version: 3.1-166
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version|replace('-', '_') }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,25 +10,32 @@ source:
   sha256: 237a14ee8d78755b11a7efe234b95be40b46fbdd1b4aaf463f6d532be1909762
 
 build:
-  number: 1
+  number: 2
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version|replace('-', '_') }}
   build:
-  - cross-r-base >= ${{ r_base_version }}
-  - r-lattice
-  - ${{ compiler('c') }}
-  host:
-  - r-base >= ${{ r_base_version }}
-  - r-lattice
-  - libflang                  # for FortranRuntime
-  run:
-  - r-base >= ${{ r_base_version }}
-  - r-lattice
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+    - cross-r-base >= ${{ r_base_version }}
+    - r-lattice
+    - ${{ compiler('c') }}
+    host:
+    - r-base >= ${{ r_base_version }}
+    - r-lattice
+    - libflang                  # for FortranRuntime
+    run:
+    - r-base >= ${{ r_base_version }}
+    - r-lattice
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://svn.r-project.org/R-packages/trunk/nlme

--- a/recipes/recipes_emscripten/r-rlang/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rlang/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   version: 1.1.4
   name: r-rlang
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: f2d74527508bf3287102470beb27de0d234c3cbba399c28d3312f2c83c64a6e1
 
 build:
-  number: 2
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 3
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: http://rlang.r-lib.org

--- a/recipes/recipes_emscripten/r-utf8/recipe.yaml
+++ b/recipes/recipes_emscripten/r-utf8/recipe.yaml
@@ -1,11 +1,7 @@
 context:
   name: r-utf8
   version: 1.2.4
-  r_base_version: 4.4.1
-
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+  r_base_version: 4.4.2
 
 source:
   url:
@@ -14,27 +10,29 @@ source:
   sha256: 418f824bbd9cd868d2d8a0d4345545c62151d321224cdffca8b1ffd98a167b7d
 
 build:
-  number: 3
-  script:
-    - $R CMD INSTALL $R_ARGS --no-byte-compile .
-    - rm $PREFIX/lib/R/library/grDevices/libs/cairo.so
-    - rm $PREFIX/lib/R/library/tcltk/libs/tcltk.so
-    # The activation script of cross-r-base copies cairo and tcltk from
-    # the build environment.
+  number: 4
+  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
 
-requirements:
+outputs:
+- package:
+    name: ${{ name }}
+    version: ${{ version }}
   build:
-    - cross-r-base >= ${{ r_base_version }}
-    - ${{ compiler('c') }}
-  host:
-    - r-base >= ${{ r_base_version }}
-  run:
-    - r-base >= ${{ r_base_version }}
+    files:
+      - lib/R/library/${{ name[2:] }}/*
+  requirements:
+    build:
+      - cross-r-base >= ${{ r_base_version }}
+      - ${{ compiler('c') }}
+    host:
+      - r-base >= ${{ r_base_version }}
+    run:
+      - r-base >= ${{ r_base_version }}
 
-tests:
-- package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+  tests:
+  - package_contents:
+      lib:
+      - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://ptrckprry.com/r-utf8/


### PR DESCRIPTION
Along with #1460, this updates the remaining R packages.

There is still an issue with incorrect flags coming from `r-base` Makeconf file, but that shall be addressed in another rebuild of all packages.