### PR TITLE
fix broken emscripten-abi mutex strong-export generation

### DIFF
--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -3,7 +3,7 @@ context:
   version: 3.1.45
 
 build:
-  number: 30
+  number: 31
 
 outputs:
   - package:
@@ -28,7 +28,8 @@ outputs:
         - python
         - nodejs 16.*
       run_exports:
-        - ${{ pin_subpackage('emscripten-abi', lower_bound='x.x.x', upper_bound='x.x.x') }}
+        strong:
+          - ${{ pin_subpackage('emscripten-abi', lower_bound='x.x.x', upper_bound='x.x.x') }}
 
   - package:
       name: emscripten-abi


### PR DESCRIPTION
fix broken emscripten-abi mutex strong-export generation. We need **strong** run exports.
The problemn is that we now have a lot of uploaded packages without the emscripten-abi.
  