### PR TITLE
Fix emcc.py symlink

### DIFF
--- a/recipes/recipes/emscripten_emscripten-wasm32/build_compiler_package.sh
+++ b/recipes/recipes/emscripten_emscripten-wasm32/build_compiler_package.sh
@@ -25,8 +25,8 @@ cat $RECIPE_DIR/patches/*.patch | patch -p1 --verbose
 popd    
 echo "...done"
 
-
-
+chmod +x $EMSDK/upstream/emscripten/emcc.py
+chmod +x $EMSDK/upstream/emscripten/emrun.py
 
 mkdir -p $PREFIX/opt/emsdk/
 cp -r $EMSDK/upstream $PREFIX/opt/emsdk/upstream

--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -3,7 +3,7 @@ context:
   version: 3.1.73
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - package:


### PR DESCRIPTION
The symlink to *emcc.py* is not included in the package because *emcc.py* and *emrun.py* seem to be the only files which do not have executable permissions.

```bash
# opt/emsdk/upstream/emscripten
.rwxr-xr-x  506   em++.py
.rwxr-xr-x  921   em-config.py
.rwxr-xr-x  405   emar.py
.rwxr-xr-x 9,5k   embuilder.py
.rw-r--r--  63k   emcc.py
.rwxr-xr-x 2,3k   emcmake.py
.rwxr-xr-x 1,8k   emconfigure.py
.rwxr-xr-x 2,0k   emmake.py
.rwxr-xr-x  507   emranlib.py
.rw-r--r--  79k   emrun.py
.rwxr-xr-x  790   emscons.py
.rwxr-xr-x 2,5k   emsize.py
.rwxr-xr-x  411   emstrip.py
.rwxr-xr-x 8,7k   emsymbolizer.py
```