### PR TITLE
Update r-base

### DIFF
--- a/recipes/recipes_emscripten/r-base/patches/0014-Build-cairo-without-pthread.patch
+++ b/recipes/recipes_emscripten/r-base/patches/0014-Build-cairo-without-pthread.patch
@@ -1,0 +1,22 @@
+From c94f49cd8aa0d91b38cd0dc3872c42425822cbb0 Mon Sep 17 00:00:00 2001
+From: Isabel Paredes <isabel.paredes@quantstack.net>
+Date: Tue, 14 Jan 2025 19:49:23 +0100
+Subject: [PATCH] Build cairo without pthread
+
+---
+ configure | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure b/configure
+index 6d4d68d..83ce92a 100755
+--- a/configure
++++ b/configure
+@@ -50966,6 +50966,8 @@ printf "%s\n" "$as_me: using static pangocairo" >&6;}
+        CAIROX11_LIBS=`"${PKG_CONFIG}" --libs ${xmodlist}`
+     fi
+ 
++CAIRO_LIBS=$(echo $CAIRO_LIBS | sed 's/-pthread//g' | sed 's/-sPTHREAD_POOL_SIZE=4//g')
++
+     CPPFLAGS="${CPPFLAGS} ${CAIRO_CPPFLAGS}"
+     LIBS="${LIBS} ${CAIRO_LIBS}"
+ 

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -23,9 +23,10 @@ source:
     - patches/0011-Use-cross_libraries-script-when-cross-compiling.patch
     - patches/0012-Install-wasm-files.patch
     - patches/0013-Remove-png-lib-from-bitmap-libs.patch
+    - patches/0014-Build-cairo-without-pthread.patch
 
 build:
-  number: 5
+  number: 6
 
 requirements:
   build:


### PR DESCRIPTION
Building cairo without `-pthread` flags

```sh
emcc -sSIDE_MODULE=1 -sWASM_BIGINT -shared  -L$PREFIX/lib -o cairo.so cairoBM.o
../../../../../src/modules/X11/rbitmap.o -L$PREFIX/lib -ltiff  -L$PREFIX/lib
-lpangocairo-1.0 -lm -lpangoft2-1.0 -lm -lpango-1.0 -lm -lgio-2.0 -lgobject-2.0 -lffi
-lgmodule-2.0  -lfribidi -lharfbuzz   -lm -lglib-2.0 -lm  -lgraphite2 -lcairo -lm -ldl
-lfontconfig   -lexpat -lm -lfreetype -lpixman-1 -lm   -lpng16 -lz  -lm
```