### PR TITLE
Update coreutils to emscripten 3.1.73

### DIFF
--- a/recipes/recipes_emscripten/coreutils/build.sh
+++ b/recipes/recipes_emscripten/coreutils/build.sh
@@ -1,24 +1,38 @@
-#!/bin/bash
-
-echo "lets go"
 ls
 ./bootstrap --skip-po
-emconfigure ./configure \
-      --enable-single-binary \
-      --disable-nls \
-      --disable-threads \
-      FORCE_UNSAFE_CONFIGURE=1 \
-      TIME_T_32_BIT_OK=yes \
-      ac_cv_have_decl_alarm=no \
-      gl_cv_func_sleep_works=yes
 
+export CONFIG_CFLAGS="\
+    -Os \
+    "
+export CONFIG_LDFLAGS="\
+    -Os \
+    --minify=0 \
+    -sALLOW_MEMORY_GROWTH=1 \
+    -sEXIT_RUNTIME=1 \
+    -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY \
+    -sFORCE_FILESYSTEM=1 \
+    -sMODULARIZE=1 \
+    "
+
+emconfigure ./configure \
+    --build=x86_64-linux-gnu \
+    --host=wasm32-unknown-emscripten \
+    --disable-acl \
+    --disable-nls \
+    --disable-threads \
+    --disable-xattr \
+    --enable-single-binary \
+    CFLAGS="$CFLAGS $CONFIG_CFLAGS" \
+    LDFLAGS="$LDFLAGS $CONFIG_LDFLAGS" \
+    FORCE_UNSAFE_CONFIGURE=1 \
+    TIME_T_32_BIT_OK=yes \
+    ac_cv_have_decl_alarm=no \
+    gl_cv_func_sleep_works=yes
 
 echo "sed"
 sed -i 's|$(MAKE) src/make-prime-list$(EXEEXT)|gcc src/make-prime-list.c -o src/make-prime-list$(EXEEXT) -Ilib/|' Makefile
-export CFLAGS="-O2 --minify=0 -sALLOW_MEMORY_GROWTH=1 -sENVIRONMENT=web,worker -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY -sFORCE_FILESYSTEM=1 -sMODULARIZE=1"
 
-make EXEEXT=.js CFLAGS="$CFLAGS" -k -j4 || true
-
+make EXEEXT=.js CFLAGS="$CFLAGS $CONFIG_CFLAGS" LDFLAGS="$LDFLAGS $CONFIG_LDFLAGS" -k -j$CPU_COUNT || true
 
 ls
 ls src/coreutils.js

--- a/recipes/recipes_emscripten/coreutils/recipe.yaml
+++ b/recipes/recipes_emscripten/coreutils/recipe.yaml
@@ -12,12 +12,11 @@ source:
   git: https://github.com/coreutils/coreutils
   tag: v9.5
 build:
-  number: 4
+  number: 6
 
 requirements:
   build:
     - ${{ compiler("c") }}
-    - ${{ compiler("cxx") }}
     - make  # [unix]
     - autoconf
     # - autopoint
@@ -31,15 +30,13 @@ requirements:
 tests:
   - script:
     - test -f $PREFIX/bin/coreutils.js
+    - test -f $PREFIX/bin/coreutils.wasm
 
 about:
   license: 	GPL-3.0-only
   license_file: COPYING
 
-
 extra:
   recipe-maintainers:
     - DerThorsten
-
-
-
+    - ianthomas23


### PR DESCRIPTION
Update `coreutils` to emscripten 3.1.73, for use in `cockle` and JupyterLite Terminal.

The addition of the new flag `-sEXIT_RUNTIME=1` is the only required change, but I have also refactored the recipe in line with other `cockle` recipes so that they will all be easier to maintain in the future.