### PR TITLE
Update run_modularized to accept exit status via onExit

### DIFF
--- a/recipes/recipes/run_modularized/recipe.yaml
+++ b/recipes/recipes/run_modularized/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   run:

--- a/recipes/recipes/run_modularized/run_modularized.js
+++ b/recipes/recipes/run_modularized/run_modularized.js
@@ -6,6 +6,15 @@ let already_called = false;
 async function my_main(){
     let exitCode = 126;  // "Command invoked cannot execute"
     const ModuleF = require(binary_js_runner);
+
+    function setExitCode(status) {
+        if (already_called) {
+            return;
+        }
+        already_called = true;
+        exitCode = status;
+    }
+    
     const Module = await ModuleF({
         arguments: process.argv,
         locateFile: (filename) => {
@@ -14,13 +23,8 @@ async function my_main(){
             const directory = path.dirname(binary_js_runner);
             return path.join(directory, filename);
         },
-        quit: (status, toThrow) => {
-            if (already_called) {
-                return;
-            }
-            already_called = true;
-            exitCode = status;
-        }
+        onExit: (status) => setExitCode(status),
+        quit: (status, toThrow) => setExitCode(status)
     });
     return exitCode;
 }


### PR DESCRIPTION
Update `run_modularized` to accept exit status via `onExit`. This is needed by wasm command packages built using emscripten 3.1.73 and `-sEXIT_RUNTIME=1` flag. I have kept the existing codepath that accepts an exit code via the `quit` call for backward compatibility with recipes previously built using 3.1.58 and earlier.

This targets the `main` branch as it is independent of emscripten version.