### PR TITLE
Update lua to emscripten 3.1.73

### DIFF
--- a/recipes/recipes_emscripten/lua/CMakeLists.txt
+++ b/recipes/recipes_emscripten/lua/CMakeLists.txt
@@ -64,7 +64,7 @@ foreach(lua_binary ${lua_binaries})
   target_compile_definitions(${lua_binary}
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
-      PUBLIC "SHELL: -s ENVIRONMENT=web,worker,node"
+      PUBLIC "SHELL: -s EXIT_RUNTIME=1"
       PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY"
       PUBLIC "SHELL: -s MODULARIZE=1"
   )
@@ -72,7 +72,7 @@ foreach(lua_binary ${lua_binaries})
   target_link_options(${lua_binary}
       PUBLIC "SHELL: -s FORCE_FILESYSTEM"
       PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
-      PUBLIC "SHELL: -s ENVIRONMENT=web,worker,node"
+      PUBLIC "SHELL: -s EXIT_RUNTIME=1"
       PUBLIC "SHELL: -s EXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY"
       PUBLIC "SHELL: -s MODULARIZE=1"
   )

--- a/recipes/recipes_emscripten/lua/recipe.yaml
+++ b/recipes/recipes_emscripten/lua/recipe.yaml
@@ -21,7 +21,7 @@ source:
 - path: CMakeLists.txt
 
 build:
-  number: 12
+  number: 14
 
 requirements:
   build:


### PR DESCRIPTION
Update `lua` command package to emscripten 3.1.73. The key change is the addition of `-sEXIT_RUNTIME=1` to return an exit code. Also removed explicit declaration of `ENVIRONMENT` in line with other recipes as now using the defaullt value.

This should use the newly-built `run_modularized` to test the `onExit` callback.