### PR TITLE
Update vim to emscripten 3.1.73

### DIFF
--- a/recipes/recipes_emscripten/vim/build.sh
+++ b/recipes/recipes_emscripten/vim/build.sh
@@ -1,0 +1,60 @@
+export NCURSES_CFLAGS=$($PREFIX/bin/ncurses6-config --cflags)
+export NCURSES_LDFLAGS=$($PREFIX/bin/ncurses6-config --libs-only-L)
+export XTERM_256COLOR=$PREFIX/share/terminfo/78/xterm-256color
+export VIMRC=$PWD/vimrc
+
+echo $NCURSES_CFLAGS
+echo $NCURSES_LDFLAGS
+ls -l $XTERM_256COLOR
+
+export CONFIG_CFLAGS="\
+    $NCURSES_CFLAGS \
+    -Os \
+    "
+export CONFIG_LDFLAGS="\
+    $NCURSES_LDFLAGS \
+    -Os \
+    --minify=0 \
+    -sALLOW_MEMORY_GROWTH=1 \
+    -sEXIT_RUNTIME=1 \
+    -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY \
+    -sFORCE_FILESYSTEM=1 \
+    -sMODULARIZE=1 \
+    -sLZ4 \
+    "
+
+emconfigure ./configure \
+    --disable-nls \
+    --disable-xattr \
+    --host=wasm32-unknown-emscripten \
+    --with-compiledby=emscripten-forge \
+    --with-features=normal \
+    --with-tlib=tinfo \
+    CFLAGS="$CFLAGS $CONFIG_CFLAGS" \
+    LDFLAGS="$LDFLAGS $CONFIG_LDFLAGS" \
+    ac_cv_sizeof_int=4 \
+    ac_cv_sizeof_long=8 \
+    ac_cv_sizeof_off_t=4 \
+    ac_cv_sizeof_time_t=4
+
+# Use /etc/vimrc for system vimrc file and turn some features on.
+sed -ri "s/.*(#define SYS_VIMRC_FILE\s.*)/\1/" src/feature.h
+echo "syntax on" > $VIMRC
+echo "set termguicolors" >> $VIMRC
+
+# Installs runtime config files under $PWD/usr/local/share/vim
+DESTDIR=$PWD make -C src installruntime
+
+emmake make EXEEXT=.js -j4 LDFLAGS=" \
+    $LDFLAGS \
+    $CONFIG_LDFLAGS \
+    --preload-file $PWD/usr/local/share/vim/vim91@/usr/local/share/vim/vim91 \
+    --exclude-file $PWD/usr/local/share/vim/vim91/lang \
+    --exclude-file $PWD/usr/local/share/vim/vim91/doc \
+    --exclude-file $PWD/usr/local/share/vim/vim91/tutor \
+    --preload-file $XTERM_256COLOR@/usr/local/share/terminfo/78/xterm-256color \
+    --preload-file $VIMRC@/etc/vimrc \
+    "
+
+mkdir -p $PREFIX/bin
+cp src/vim.{data,js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/vim/patches/0001-const-char-args.patch
+++ b/recipes/recipes_emscripten/vim/patches/0001-const-char-args.patch
@@ -1,0 +1,33 @@
+From 4b15585fef39d5a662056d7ac522a9b29a957498 Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Mon, 2 Dec 2024 11:28:39 +0000
+Subject: [PATCH] Use const char* args to OS term functions
+
+---
+ src/osdef2.h.in | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/osdef2.h.in b/src/osdef2.h.in
+index f29451ddf..88d9af20d 100644
+--- a/src/osdef2.h.in
++++ b/src/osdef2.h.in
+@@ -57,11 +57,11 @@ extern int	link(const char *, const char *);
+ extern int	mkdir(const char *, mode_t);
+ extern int	rmdir(const char *);
+
+-extern int	tgetent(char *, char *);
+-extern int	tgetnum(char *);
+-extern int	tgetflag(char *);
+-extern char	*tgoto(char *, int, int);
+-extern int	tputs(char *, int, int (*)(int));
++extern int	tgetent(char *, const char *);
++extern int	tgetnum(const char *);
++extern int	tgetflag(const char *);
++extern char	*tgoto(const char *, int, int);
++extern int	tputs(const char *, int, int (*)(int));
+
+ #ifdef HAVE_TERMIOS_H
+ struct termios;		/* for tcgetattr() */
+--
+2.43.0
+

--- a/recipes/recipes_emscripten/vim/recipe.yaml
+++ b/recipes/recipes_emscripten/vim/recipe.yaml
@@ -1,0 +1,45 @@
+context:
+  version: 9.1.0917
+
+package:
+  name: vim
+  version: ${{ version }}
+
+source:
+  url: https://github.com/vim/vim/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: a5cdcfcfeb13dc4deddcba461d40234dbf47e61941cb7170c9ebe147357bb62d
+  patches:
+    - patches/0001-const-char-args.patch
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+  host:
+    - ncurses
+
+tests:
+  - script:
+    - test -f $PREFIX/bin/vim.data
+    - test -f $PREFIX/bin/vim.js
+    - test -f $PREFIX/bin/vim.wasm
+  - script: |
+      # Limit output to exclude compilation date and time.
+      OUTPUT=$(run_modularized $PREFIX/bin/vim.js --version | head -1 | cut -c -22)
+      if [[ "$OUTPUT" != "VIM - Vi IMproved 9.1 " ]]; then
+        echo "Unexpected output: $OUTPUT"
+        exit 1
+      fi
+    requirements:
+      build:
+        - run_modularized >= 0.1.2
+
+about:
+  license: Vim
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - ianthomas23


### PR DESCRIPTION
Update `vim` to emscripten 3.1.73. These are new files rather than file changes as the original recipe was added to the `3.1.58` branch not `main`.