### PR TITLE
DO NOT MERGE: Debug matplotlib 3.9.4 on 3.1.73

### DIFF
--- a/recipes/recipes_emscripten/matplotlib/recipe.yaml
+++ b/recipes/recipes_emscripten/matplotlib/recipe.yaml
@@ -1,15 +1,15 @@
 context:
   name: matplotlib
-  version: 3.10.0
+  version: 3.9.4
 
 source:
 - url: https://github.com/matplotlib/matplotlib/archive/v${{ version }}.tar.gz
-  sha256: 825919da8957bbc19cec35caf8663b734d34af72a0b040c43b7d8c1b76fdcab7
+  sha256: a29f8bab72f81df9077480e6b55394a17effd329d0ff1524bb5bc570734e7c54
   patches:
   - patches/fix-threading-and-font-cache.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
 - package:


### PR DESCRIPTION
Trying a rebuild of Matplotlib 3.9.4 on the emscripten 3.1.73 branch to see if it still builds and passes tests OK after the recent changes to `pytester` and so on. Hopefully it will help us narrow down the problem with #1764.