### PR TITLE
Fix signature mismatches in r-stringi

### DIFF
--- a/recipes/recipes_emscripten/r-stringi/build.sh
+++ b/recipes/recipes_emscripten/r-stringi/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# build and host are needed to enable cross-compilation
+# The environment LDFLAGS are ignored by the configure script
+export CONFIG_ARGS="--prefix=$PREFIX --build=x86_64-conda-linux-gnu --host=wasm32-unknown-emscripten --with-extra-ldflags=-sWASM_BIGINT"
+
+R CMD INSTALL $R_ARGS --configure-args="$CONFIG_ARGS" --no-byte-compile .

--- a/recipes/recipes_emscripten/r-stringi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-stringi/recipe.yaml
@@ -10,8 +10,7 @@ source:
   sha256: c219f8f64d1a2bfd4ca9528452d44d30db1899af14f4b9ef248412443bc669f3
 
 build:
-  number: 0
-  script: $R CMD INSTALL $R_ARGS --no-byte-compile .
+  number: 1
 
 outputs:
 - package:


### PR DESCRIPTION
The environment variable `LDFLAGS=-sWASM_BIGINT` is ignored by the configure script of `r-stringi`. This causes signature mismatches when loading *stringi.so* because it is not build with `WASM_BIGINT`. Thus, it must be explicitly added.