### PR TITLE
Add more WASM_BIGINT to r-base

### DIFF
--- a/recipes/recipes_emscripten/r-base/config.site
+++ b/recipes/recipes_emscripten/r-base/config.site
@@ -212,7 +212,7 @@ SHLIB_LDFLAGS="-sSIDE_MODULE=1 -sWASM_BIGINT"
 ## on macOS systems using Fink with root '/sw'.
 ## On some Linux 64-bit systems its default is -L/usr/local/lib64.
 ## If LIBnn is set it defaults to -L/usr/local/$LIBnn.
-LDFLAGS="-L$PREFIX/lib"
+LDFLAGS="-L$PREFIX/lib -sWASM_BIGINT"
 
 
 ## The command which runs the C++ compiler.

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -26,7 +26,7 @@ source:
     - patches/0014-Set-cairo-as-default-bitmap-type.patch
 
 build:
-  number: 9
+  number: 10
 
 requirements:
   build:


### PR DESCRIPTION
This is to ensure downstream R packages are built with `WASM_BIGINT`