### PR TITLE
Do not delete $PREFIX's site packages

### DIFF
--- a/recipes/recipes/cross-python_emscripten-wasm32/activate-cross-python.sh
+++ b/recipes/recipes/cross-python_emscripten-wasm32/activate-cross-python.sh
@@ -84,11 +84,7 @@ if [[ "${CONDA_BUILD:-0}" == "1" && "${CONDA_BUILD_STATE}" != "TEST" ]]; then
 
     rm -rf $BUILD_PREFIX/venv/cross
     if [[ -d "$PREFIX/lib/python$PY_VER/site-packages/" ]]; then
-      find $PREFIX/lib/python$PY_VER/site-packages/ -name "*.so" -exec rm {} \;
-      find $PREFIX/lib/python$PY_VER/site-packages/ -name "*.dylib" -exec rm {} \;
-      rsync -a -I $PREFIX/lib/python$PY_VER/site-packages/ $BUILD_PREFIX/lib/python$PY_VER/site-packages/
-      rm -rf $PREFIX/lib/python$PY_VER/site-packages
-      mkdir $PREFIX/lib/python$PY_VER/site-packages
+      rsync -a --exclude="*.so" --exclude="*.dylib" -I $PREFIX/lib/python$PY_VER/site-packages/ $BUILD_PREFIX/lib/python$PY_VER/site-packages/
     fi
     rm -rf $BUILD_PREFIX/venv/lib/python$PY_VER/site-packages
     ln -s $BUILD_PREFIX/lib/python$PY_VER/site-packages $BUILD_PREFIX/venv/lib/python$PY_VER/site-packages

--- a/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 11
+  number: 12
 
 requirements:
 


### PR DESCRIPTION
See conda-forge/cross-python-feedstock#24 and conda-forge/cross-python-feedstock#69 for relevant conda-forge issues.

Without this change, the ROS2WASM compilation fails for downstream packages of rosidl-default-generators:
```
 │ ╭─ Running build script
 │ │ Not activating ROS when cross-compiling
 │ │ Setting up cross-python
 │ │ Not activating ROS when cross-compiling
 │ │ + /home/nmarticorena/Documents/pixi_project/ros-humble/recipes/ros-humble-lifecycle-msgs/build_ament_cmake.sh
 │ │ USING PYTHON_EXECUTABLE=$BUILD_PREFIX/bin/python
 │ │ USING PKG_CONFIG_EXECUTABLE=$BUILD_PREFIX/bin/pkg-config
 │ │ Using Python 3.11
 │ │ Using PYTHON_INSTALL_DIR: lib/python3.11/site-packages
 │ │ configure: cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX -DAMENT_PREFIX_PATH=$PREFIX -DCMA
 │ │ KE_INSTALL_LIBDIR=lib -DPYTHON_EXECUTABLE=$BUILD_PREFIX/bin/python3.11 -DPython_EXECUTABLE=$BUILD_PREFIX/bin/python3.11 -DPython3_EXECUTABLE=$B
 │ │ UILD_PREFIX/bin/python3.11 -DPython3_FIND_STRATEGY=LOCATION -DPKG_CONFIG_EXECUTABLE=$BUILD_PREFIX/bin/pkg-config -DPYTHON_INSTALL_DIR=lib/pytho
 │ │ n3.11/site-packages -DSETUPTOOLS_DEB_LAYOUT=OFF -DCATKIN_SKIP_TESTING= -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True -DBUILD_SHARED_LIBS=ON -DB
 │ │ UILD_TESTING=OFF -DCMAKE_IGNORE_PREFIX_PATH=/opt/homebrew;/usr/local/homebrew -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 --compile-no-warning-as-error 
 │ │ -DPYTHON_SOABI=cpython-311-wasm32-emscripten -DRMW_IMPLEMENTATION=rmw_wasm_cpp -DCMAKE_FIND_ROOT_PATH=$PREFIX -DCMAKE_POSITION_INDEPENDENT_CODE
 │ │ =TRUE -DCMAKE_PROJECT_INCLUDE=$SRC_DIR/__vinca_shared_lib_patch.cmake $SRC_DIR/ros-humble-lifecycle-msgs/src/work -DCMAKE_TOOLCHAIN_FILE=$BUILD
 │ │ _PREFIX/opt/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake -DCMAKE_CROSSCOMPILING_EMULATOR=$BUILD_PREFIX/bin/node
 │ │ CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
 │ │   Compatibility with CMake < 3.10 will be removed from a future version of
 │ │ Ignoring COMPILE_WARNING_AS_ERROR target property and CMAKE_COMPILE_WARNING_AS_ERROR variable.
 │ │   CMake.
 │ │   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
 │ │   to tell CMake that the project requires at least <min> but has been updated
 │ │   to work with policies introduced by <max> or earlier.
 │ │ -- Found ament_cmake: 1.3.11 ($PREFIX/share/ament_cmake/cmake)
 │ │ -- Found Python3: $BUILD_PREFIX/bin/python3.11 (found version "3.11.0") found components: Interpreter
 │ │ -- Found rosidl_default_generators: 1.2.0 ($PREFIX/share/rosidl_default_generators/cmake)
 │ │ -- Using all available rosidl_typesupport_c: rosidl_typesupport_fastrtps_c;rosidl_typesupport_introspection_c
 │ │ -- Found rosidl_adapter: 3.1.6 ($PREFIX/share/rosidl_adapter/cmake)
 │ │ CMake Warning at $PREFIX/share/rcutils/cmake/ament_cmake_export_libraries-extras.cmake:116 (message):
 │ │   Package 'rcutils' exports library 'rt' which couldn't be found
 │ │ Call Stack (most recent call first):
 │ │   $PREFIX/share/rcutils/cmake/rcutilsConfig.cmake:41 (include)
 │ │   $PREFIX/share/rosidl_runtime_c/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package)
 │ │   $PREFIX/share/rosidl_runtime_c/cmake/rosidl_runtime_cConfig.cmake:41 (include)
 │ │   $PREFIX/share/rosidl_typesupport_fastrtps_c/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package)
 │ │   $PREFIX/share/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_cConfig.cmake:41 (include)
 │ │   $PREFIX/share/rosidl_typesupport_c/cmake/rosidl_typesupport_c-extras.cmake:13 (find_package)
 │ │   $PREFIX/share/rosidl_typesupport_c/cmake/rosidl_typesupport_cConfig.cmake:41 (include)
 │ │   $PREFIX/share/rosidl_default_generators/cmake/rosidl_default_generators-extras.cmake:21 (find_package)
 │ │   $PREFIX/share/rosidl_default_generators/cmake/rosidl_default_generatorsConfig.cmake:41 (include)
 │ │   CMakeLists.txt:14 (find_package)
 │ │ -- Using all available rosidl_typesupport_cpp: rosidl_typesupport_fastrtps_cpp;rosidl_typesupport_introspection_cpp
 │ │ CMake Error at $PREFIX/share/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake:69 (message):
 │ │   Target dependency
 │ │ -- Configuring incomplete, errors occurred!
 │ │   '$PREFIX/share/rosidl_generator_c/cmake/../../../lib/python3.11/site-packages/rosidl_generator_c/__init__.py'
 │ │   does not exist
```

This is resolved with the change. Note that the change has been merged in the conda-forge equivalent activation script.

Follow up to https://github.com/emscripten-forge/recipes/pull/1525 where this change was removed to simplify the merging process.