### PR TITLE
Build pugixml with emsdk 3.1.73

### DIFF
--- a/recipes/recipes_emscripten/pugixml/recipe.yaml
+++ b/recipes/recipes_emscripten/pugixml/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b39647064d9e28297a34278bfb897092bf33b7c487906ddfc094c9e8868bddcb
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This PR is needed so I can progress with a PR in xeus-cpp https://github.com/compiler-research/xeus-cpp/pull/252/checks#step:5:35 . pugixml on the main channel is not available with emsdk=3.1.73 