### PR TITLE
Include pkgconfig file for lzo

### DIFF
--- a/recipes/recipes_emscripten/lzo/recipe.yaml
+++ b/recipes/recipes_emscripten/lzo/recipe.yaml
@@ -22,11 +22,10 @@ requirements:
 
 tests:
 - package_contents:
-    lib:
-    - liblzo2.a
-    - pkgconfig/lzo2.pc
-    include:
-    - lzo/lzoconf.h
+    files:
+    - lib/liblzo2.a
+    - lib/pkgconfig/lzo2.pc
+    - include/lzo/lzoconf.h
 
 about:
   homepage: http://www.oberhumer.com/opensource/lzo/

--- a/recipes/recipes_emscripten/lzo/recipe.yaml
+++ b/recipes/recipes_emscripten/lzo/recipe.yaml
@@ -21,9 +21,12 @@ requirements:
     - pkg-config
 
 tests:
-- script:
-    - test -f ${PREFIX}/include/lzo/lzoconf.h
-    - test -f ${PREFIX}/lib/liblzo2.a
+- package_contents:
+    lib:
+    - liblzo2.a
+    - pkgconfig/lzo2.pc
+    include:
+    - lzo/lzoconf.h
 
 about:
   homepage: http://www.oberhumer.com/opensource/lzo/

--- a/recipes/recipes_emscripten/lzo/recipe.yaml
+++ b/recipes/recipes_emscripten/lzo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  name: "lzo"
+  name: lzo
   version: 2.10
 
 package:
@@ -11,13 +11,14 @@ source:
   sha256: c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - ${{ compiler('c') }}
     - cmake
     - make
+    - pkg-config
 
 tests:
 - script:


### PR DESCRIPTION
The *lzo2.pc* file is needed in other packages (cairo) to find this library.