### PR TITLE
netcdf4 and libnetcdf

### DIFF
--- a/recipes/recipes_emscripten/libnetcdf/build.sh
+++ b/recipes/recipes_emscripten/libnetcdf/build.sh
@@ -1,2 +1,2 @@
-emconfigure ./configure
+emconfigure ./configure --host=${HOST}
 emmake make

--- a/recipes/recipes_emscripten/libnetcdf/build.sh
+++ b/recipes/recipes_emscripten/libnetcdf/build.sh
@@ -1,2 +1,2 @@
-emconfigure ./configure --host=${HOST}
+emconfigure ./configure --host=$target_platform 
 emmake make

--- a/recipes/recipes_emscripten/libnetcdf/build.sh
+++ b/recipes/recipes_emscripten/libnetcdf/build.sh
@@ -1,0 +1,2 @@
+emconfigure ./configure
+emmake make

--- a/recipes/recipes_emscripten/libnetcdf/build.sh
+++ b/recipes/recipes_emscripten/libnetcdf/build.sh
@@ -1,2 +1,2 @@
-emconfigure ./configure --host=$target_platform 
+emconfigure ./configure --host=none 
 emmake make

--- a/recipes/recipes_emscripten/libnetcdf/recipe.yaml
+++ b/recipes/recipes_emscripten/libnetcdf/recipe.yaml
@@ -19,11 +19,11 @@ requirements:
     - cross-python_${{ target_platform }}
     - ${{ compiler('c') }}
     - pip
+  host:
+    - python
     - libxml2
     - hdf5
     - zlib
     - m4
-  host:
-    - python
   run:
     - python

--- a/recipes/recipes_emscripten/libnetcdf/recipe.yaml
+++ b/recipes/recipes_emscripten/libnetcdf/recipe.yaml
@@ -19,6 +19,10 @@ requirements:
     - cross-python_${{ target_platform }}
     - ${{ compiler('c') }}
     - pip
+    - libxml2
+    - hdf5
+    - zlib
+    - m4
   host:
     - python
   run:

--- a/recipes/recipes_emscripten/libnetcdf/recipe.yml
+++ b/recipes/recipes_emscripten/libnetcdf/recipe.yml
@@ -1,0 +1,25 @@
+context:
+  version: "4.9.3"
+  name: "libnetcdf"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.3.tar.gz
+  sha256: 990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - pip
+  host:
+    - python
+  run:
+    - python


### PR DESCRIPTION
Useful for meteorological and geographical datasets. I'm personally interested in having this built as I want to use xeus python jupyterlite for my library's documentation page. 

`netcdf4` is maintained by NSF Unidata. The [python bindings in `netcdf4`](https://github.com/Unidata/netcdf4-python) depend on the [underlying C library, `libnetcdf`](https://github.com/Unidata/netcdf-c).

I'm going to try my best with this... but realistically I'll probably need some help with this as I've never built anything for wasm before.

There's quite a few more deps in the tree which haven't been built for emscripten forge yet (most terrifyingly, python bindings for Open MPI). I have no idea if its mandatory to build all of them. Hopefully not.
<details>
<summary> repoquery depends netcdf4 </summary>

```

$ micromamba repoquery depends -t netcdf4 --remote
Getting repodata from channels...

conda-forge/linux-64                                        Using cache
conda-forge/noarch                                          Using cache
netcdf4[1.7.2]
  ├─ certifi[2025.1.31]
  │  └─ python[3.13.2]
  │     ├─ pip[25.0.1]
  │     ├─ tzdata[2025a]
  │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<<
  │     ├─ libgcc[14.2.0]
  │     │  ├─ _openmp_mutex[4.5]
  │     │  │  ├─ _libgcc_mutex[0.1]
  │     │  │  └─ libgomp[14.2.0]
  │     │  │     └─ _libgcc_mutex already visited
  │     │  └─ _libgcc_mutex already visited
  │     ├─ bzip2[1.0.8]
  │     │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     │  └─ libgcc-ng[14.2.0]
  │     │     └─ libgcc already visited
  │     ├─ libzlib[1.3.1]
  │     │  └─ libgcc-ng already visited
  │     ├─ readline[8.2]
  │     │  ├─ libgcc-ng already visited
  │     │  └─ ncurses[6.5]
  │     │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     │     └─ libgcc already visited
  │     ├─ ncurses already visited
  │     ├─ libuuid[2.38.1]
  │     │  └─ libgcc-ng already visited
  │     ├─ libffi[3.4.6]
  │     │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     │  └─ libgcc already visited
  │     ├─ libexpat[2.6.4]
  │     │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     │  └─ libgcc already visited
  │     ├─ tk[8.6.13]
  │     │  ├─ libgcc-ng already visited
  │     │  └─ libzlib already visited
  │     ├─ ld_impl_linux-64[2.43]
  │     │  └─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     ├─ liblzma[5.6.4]
  │     │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     │  └─ libgcc already visited
  │     ├─ libsqlite[3.48.0]
  │     │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     │  ├─ libgcc already visited
  │     │  └─ libzlib already visited
  │     ├─ openssl[3.4.1]
  │     │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     │  ├─ libgcc already visited
  │     │  └─ ca-certificates[2025.1.31]
  │     ├─ python_abi[3.13]
  │     └─ libmpdec[4.0.0]
  │        ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │        └─ libgcc-ng already visited
  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  ├─ libgcc already visited
  ├─ libzlib already visited
  ├─ cftime[1.6.4]
  │  ├─ libgcc-ng already visited
  │  ├─ python_abi[3.10]
  │  ├─ python[3.10.16]
  │  │  ├─ pip already visited
  │  │  ├─ tzdata already visited
  │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  ├─ libgcc already visited
  │  │  ├─ bzip2 already visited
  │  │  ├─ libzlib already visited
  │  │  ├─ readline already visited
  │  │  ├─ ncurses already visited
  │  │  ├─ libuuid already visited
  │  │  ├─ libffi already visited
  │  │  ├─ tk already visited
  │  │  ├─ ld_impl_linux-64 already visited
  │  │  ├─ liblzma already visited
  │  │  ├─ libsqlite already visited
  │  │  ├─ openssl already visited
  │  │  ├─ libxcrypt[4.4.36]
  │  │  │  └─ libgcc-ng already visited
  │  │  └─ libnsl[2.0.1]
  │  │     └─ libgcc-ng already visited
  │  └─ numpy[2.2.3]
  │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     ├─ libgcc already visited
  │     ├─ python_abi already visited
  │     ├─ python already visited
  │     ├─ libstdcxx[14.2.0]
  │     │  └─ libgcc already visited
  │     ├─ libblas[3.9.0]
  │     │  └─ blis[0.9.0]
  │     │     └─ libgcc-ng already visited
  │     ├─ liblapack[3.9.0]
  │     │  └─ libblas already visited
  │     └─ libcblas[3.9.0]
  │        └─ libblas already visited
  ├─ python_abi already visited
  ├─ python already visited
  ├─ numpy already visited
  ├─ hdf5[1.14.4]
  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  ├─ libgcc already visited
  │  ├─ libzlib already visited
  │  ├─ openssl already visited
  │  ├─ libstdcxx already visited
  │  ├─ libgfortran[14.2.0]
  │  │  └─ libgfortran5[14.2.0]
  │  │     └─ libgcc already visited
  │  ├─ libgfortran5 already visited
  │  ├─ mpich[4.3.0]
  │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  ├─ libgcc already visited
  │  │  ├─ libstdcxx already visited
  │  │  ├─ libgfortran already visited
  │  │  ├─ libgfortran5 already visited
  │  │  ├─ libfabric[2.0.0]
  │  │  │  └─ libfabric1[2.0.0]
  │  │  │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     ├─ libgcc already visited
  │  │  │     ├─ rdma-core[56.0]
  │  │  │     │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │  ├─ libgcc already visited
  │  │  │     │  ├─ libstdcxx already visited
  │  │  │     │  ├─ libnl[3.11.0]
  │  │  │     │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │  │  └─ libgcc already visited
  │  │  │     │  ├─ libudev1[257.3]
  │  │  │     │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │  │  ├─ libgcc already visited
  │  │  │     │  │  └─ libcap[2.71]
  │  │  │     │  │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │  │     ├─ libgcc already visited
  │  │  │     │  │     └─ attr[2.5.1]
  │  │  │     │  │        └─ libgcc-ng already visited
  │  │  │     │  └─ libsystemd0[257.3]
  │  │  │     │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │     ├─ libgcc already visited
  │  │  │     │     ├─ liblzma already visited
  │  │  │     │     ├─ libcap already visited
  │  │  │     │     ├─ zstd[1.5.6]
  │  │  │     │     │  ├─ libgcc-ng already visited
  │  │  │     │     │  ├─ libzlib already visited
  │  │  │     │     │  └─ libstdcxx-ng[14.2.0]
  │  │  │     │     │     └─ libstdcxx already visited
  │  │  │     │     ├─ lz4-c[1.10.0]
  │  │  │     │     │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │     │  ├─ libgcc already visited
  │  │  │     │     │  └─ libstdcxx already visited
  │  │  │     │     └─ libgcrypt-lib[1.11.0]
  │  │  │     │        ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │        ├─ libgcc already visited
  │  │  │     │        └─ libgpg-error[1.51]
  │  │  │     │           ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │           ├─ libgcc already visited
  │  │  │     │           ├─ libstdcxx already visited
  │  │  │     │           ├─ gettext[0.23.1]
  │  │  │     │           │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │           │  ├─ libgcc already visited
  │  │  │     │           │  ├─ libstdcxx already visited
  │  │  │     │           │  ├─ libasprintf[0.23.1]
  │  │  │     │           │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │           │  │  ├─ libgcc already visited
  │  │  │     │           │  │  └─ libstdcxx already visited
  │  │  │     │           │  ├─ libgettextpo[0.23.1]
  │  │  │     │           │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │           │  │  └─ libgcc already visited
  │  │  │     │           │  ├─ gettext-tools[0.23.1]
  │  │  │     │           │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │           │  │  └─ libgcc already visited
  │  │  │     │           │  ├─ libasprintf-devel[0.23.1]
  │  │  │     │           │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │           │  │  ├─ libgcc already visited
  │  │  │     │           │  │  └─ libasprintf already visited
  │  │  │     │           │  └─ libgettextpo-devel[0.23.1]
  │  │  │     │           │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │           │     ├─ libgcc already visited
  │  │  │     │           │     └─ libgettextpo already visited
  │  │  │     │           ├─ libasprintf already visited
  │  │  │     │           └─ libgettextpo already visited
  │  │  │     └─ libnl already visited
  │  │  ├─ libfabric1 already visited
  │  │  ├─ libhwloc[2.11.2]
  │  │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │  ├─ libgcc already visited
  │  │  │  ├─ libgcc-ng already visited
  │  │  │  ├─ libstdcxx already visited
  │  │  │  ├─ libstdcxx-ng already visited
  │  │  │  ├─ __cuda >>> NOT FOUND <<<
  │  │  │  ├─ cudatoolkit[11.8.0]
  │  │  │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │  │  ├─ libgcc-ng already visited
  │  │  │  │  └─ libstdcxx-ng already visited
  │  │  │  ├─ sysroot_linux-64[2.34]
  │  │  │  │  ├─ tzdata already visited
  │  │  │  │  └─ kernel-headers_linux-64[5.14.0]
  │  │  │  └─ libxml2[2.13.5]
  │  │  │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     ├─ libgcc already visited
  │  │  │     ├─ libzlib already visited
  │  │  │     ├─ xz[5.6.4]
  │  │  │     │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │  ├─ libgcc already visited
  │  │  │     │  ├─ liblzma already visited
  │  │  │     │  ├─ liblzma-devel[5.6.4]
  │  │  │     │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │  │  ├─ libgcc already visited
  │  │  │     │  │  └─ liblzma already visited
  │  │  │     │  ├─ xz-gpl-tools[5.6.4]
  │  │  │     │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │  │  ├─ libgcc already visited
  │  │  │     │  │  └─ liblzma already visited
  │  │  │     │  └─ xz-tools[5.6.4]
  │  │  │     │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │     │     ├─ libgcc already visited
  │  │  │     │     └─ liblzma already visited
  │  │  │     └─ libiconv[1.17]
  │  │  │        └─ libgcc-ng already visited
  │  │  ├─ ucx[1.18.0]
  │  │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │  ├─ libgcc already visited
  │  │  │  ├─ _openmp_mutex already visited
  │  │  │  ├─ libgcc-ng already visited
  │  │  │  ├─ libstdcxx already visited
  │  │  │  ├─ rdma-core already visited
  │  │  │  └─ libstdcxx-ng already visited
  │  │  └─ mpi[1.0.1]
  │  ├─ libcurl[8.12.1]
  │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  ├─ libgcc already visited
  │  │  ├─ libzlib already visited
  │  │  ├─ openssl already visited
  │  │  ├─ zstd already visited
  │  │  ├─ krb5[1.21.3]
  │  │  │  ├─ libgcc-ng already visited
  │  │  │  ├─ openssl already visited
  │  │  │  ├─ libstdcxx-ng already visited
  │  │  │  ├─ libedit[3.1.20250104]
  │  │  │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │  │  ├─ libgcc already visited
  │  │  │  │  └─ ncurses already visited
  │  │  │  └─ keyutils[1.6.1]
  │  │  │     └─ libgcc-ng already visited
  │  │  ├─ libssh2[1.11.1]
  │  │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  │  ├─ libgcc already visited
  │  │  │  ├─ libzlib already visited
  │  │  │  └─ openssl already visited
  │  │  └─ libnghttp2[1.64.0]
  │  │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │     ├─ libgcc already visited
  │  │     ├─ libzlib already visited
  │  │     ├─ openssl already visited
  │  │     ├─ libstdcxx already visited
  │  │     ├─ libev[4.33]
  │  │     │  └─ libgcc-ng already visited
  │  │     └─ c-ares[1.34.4]
  │  │        ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │        └─ libgcc already visited
  │  └─ libaec[1.1.3]
  │     ├─ libgcc-ng already visited
  │     └─ libstdcxx-ng already visited
  ├─ mpich already visited
  ├─ hdf5[1.14.3]
  │  ├─ libgcc-ng already visited
  │  ├─ libzlib already visited
  │  ├─ openssl already visited
  │  ├─ libgfortran5 already visited
  │  ├─ mpich already visited
  │  ├─ libstdcxx-ng already visited
  │  ├─ libcurl already visited
  │  ├─ libaec already visited
  │  └─ libgfortran-ng[14.2.0]
  │     └─ libgfortran already visited
  ├─ libnetcdf[4.9.2]
  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  ├─ libgcc already visited
  │  ├─ bzip2 already visited
  │  ├─ libzlib already visited
  │  ├─ openssl already visited
  │  ├─ libstdcxx already visited
  │  ├─ hdf5 already visited
  │  ├─ mpich already visited
  │  ├─ zstd already visited
  │  ├─ libxml2 already visited
  │  ├─ libcurl already visited
  │  ├─ libaec already visited
  │  ├─ zlib[1.3.1]
  │  │  ├─ libgcc-ng already visited
  │  │  └─ libzlib already visited
  │  ├─ hdf4[4.2.15]
  │  │  ├─ libgcc-ng already visited
  │  │  ├─ libzlib already visited
  │  │  ├─ libstdcxx-ng already visited
  │  │  └─ libjpeg-turbo[3.0.0]
  │  │     └─ libgcc-ng already visited
  │  ├─ blosc[1.21.6]
  │  │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │  ├─ libgcc already visited
  │  │  ├─ libzlib already visited
  │  │  ├─ libstdcxx already visited
  │  │  ├─ zstd already visited
  │  │  ├─ lz4-c already visited
  │  │  └─ snappy[1.2.1]
  │  │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │  │     ├─ libgcc already visited
  │  │     └─ libstdcxx already visited
  │  ├─ libpnetcdf[1.13.0]
  │  │  ├─ libgcc-ng already visited
  │  │  ├─ libgfortran5 already visited
  │  │  ├─ mpich already visited
  │  │  ├─ libstdcxx-ng already visited
  │  │  └─ libgfortran-ng already visited
  │  └─ libzip[1.11.2]
  │     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
  │     ├─ libgcc already visited
  │     ├─ bzip2 already visited
  │     ├─ libzlib already visited
  │     └─ openssl already visited
  └─ mpi4py[4.0.3]
     ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
     ├─ libgcc already visited
     ├─ python_abi already visited
     ├─ python already visited
     └─ openmpi[5.0.6]
        ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
        ├─ libgcc already visited
        ├─ libgcc-ng already visited
        ├─ libzlib already visited
        ├─ libstdcxx already visited
        ├─ libgfortran already visited
        ├─ libgfortran5 already visited
        ├─ libfabric already visited
        ├─ libfabric1 already visited
        ├─ libstdcxx-ng already visited
        ├─ libhwloc already visited
        ├─ libgfortran-ng already visited
        ├─ libevent[2.1.12]
        │  ├─ libgcc-ng already visited
        │  └─ openssl already visited
        ├─ ucx[1.17.0]
        │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
        │  ├─ _openmp_mutex already visited
        │  ├─ libgcc-ng already visited
        │  ├─ rdma-core already visited
        │  └─ libstdcxx-ng already visited
        ├─ mpi[1.0]
        ├─ ucc[1.3.0]
        │  ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
        │  ├─ libgcc already visited
        │  └─ ucx already visited
        └─ libpmix[5.0.6]
           ├─ __glibc >=2.17,<3.0.a0 >>> NOT FOUND <<< already visited
           ├─ libgcc already visited
           ├─ libzlib already visited
           ├─ libhwloc already visited
           └─ libevent already visited
```
</details>