### PR TITLE
M4 3.1.73

### DIFF
--- a/recipes/recipes_emscripten/m4/build.sh
+++ b/recipes/recipes_emscripten/m4/build.sh
@@ -1,0 +1,11 @@
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/libtool/build-aux/config.* build-aux/
+
+# ensure _OBSTACK_NO_ERROR_HANDLER is defined
+
+# export CFLAGS="${CFLAGS} -D_OBSTACK_NO_ERROR_HANDLER"
+
+
+./configure --prefix=${PREFIX} --host=${HOST}  ac_cv_have_decl_alarm=no gl_cv_func_sleep_works=yes
+make -j${CPU_COUNT}
+make install

--- a/recipes/recipes_emscripten/m4/build.sh
+++ b/recipes/recipes_emscripten/m4/build.sh
@@ -1,11 +1,4 @@
-# Get an updated config.sub and config.guess
-cp $BUILD_PREFIX/share/libtool/build-aux/config.* build-aux/
-
-# ensure _OBSTACK_NO_ERROR_HANDLER is defined
-
-# export CFLAGS="${CFLAGS} -D_OBSTACK_NO_ERROR_HANDLER"
-
-
-./configure --prefix=${PREFIX} --host=${HOST}  ac_cv_have_decl_alarm=no gl_cv_func_sleep_works=yes
-make -j${CPU_COUNT}
-make install
+autoreconf -f
+emconfigure ./configure --prefix=${PREFIX} --host=${HOST}  ac_cv_have_decl_alarm=no gl_cv_func_sleep_works=yes MAKEINFO=true
+emmake make -j${CPU_COUNT}
+emmake make install

--- a/recipes/recipes_emscripten/m4/obstack_alloc_fail.patch
+++ b/recipes/recipes_emscripten/m4/obstack_alloc_fail.patch
@@ -1,0 +1,54 @@
+From 1d3f4daa3a9a357612cdd2dbc6e22f6f73d1173f Mon Sep 17 00:00:00 2001
+From: Sam Gardner <sam@wx4stg.com>
+Date: Wed, 19 Feb 2025 19:27:18 -0600
+Subject: [PATCH] patches for emscripten-forge build
+
+---
+ lib/obstack.c | 10 ++++++++--
+ lib/obstack.h |  6 +++++-
+ 2 files changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/lib/obstack.c b/lib/obstack.c
+index 6e7b52c..66b4f1f 100644
+--- a/lib/obstack.c
++++ b/lib/obstack.c
+@@ -76,6 +76,12 @@
+                                MAX (sizeof (uintmax_t),			      \
+                                     sizeof (void *)))
+ 
++__attribute__((noreturn)) void obstack_default_failed_handler(void) {
++    abort();
++}
++
++__attribute__((noreturn)) void (*obstack_alloc_failed_handler)(void) = obstack_default_failed_handler;
++
+ /* Call functions with either the traditional malloc/free calling
+    interface, or the mmalloc/mfree interface (that adds an extra first
+    argument), based on the value of use_extra_arg.  */
+@@ -348,7 +354,7 @@ print_and_abort (void)
+    abort gracefully or use longjump - but shouldn't return.  This
+    variable by default points to the internal function
+    'print_and_abort'.  */
+-__attribute_noreturn__ void (*obstack_alloc_failed_handler) (void)
+-  = print_and_abort;
++// __attribute_noreturn__ void (*obstack_alloc_failed_handler) (void)
++//   = print_and_abort;
+ # endif /* !_OBSTACK_NO_ERROR_HANDLER */
+ #endif /* !_OBSTACK_ELIDE_CODE */
+diff --git a/lib/obstack.h b/lib/obstack.h
+index e558133..f9033b3 100644
+--- a/lib/obstack.h
++++ b/lib/obstack.h
+@@ -227,7 +227,11 @@ extern _OBSTACK_SIZE_T _obstack_memory_used (struct obstack *)
+    more memory.  This can be set to a user defined function which
+    should either abort gracefully or use longjump - but shouldn't
+    return.  The default action is to print a message and abort.  */
+-extern __attribute_noreturn__ void (*obstack_alloc_failed_handler) (void);
++//extern __attribute_noreturn__ void (*obstack_alloc_failed_handler) (void);
++#ifndef obstack_alloc_failed_handler
++extern __attribute__((noreturn)) void (*obstack_alloc_failed_handler)(void);
++#endif
++
+ 
+ /* Exit value used when 'print_and_abort' is used.  */
+ extern int obstack_exit_failure;

--- a/recipes/recipes_emscripten/m4/recipe.yaml
+++ b/recipes/recipes_emscripten/m4/recipe.yaml
@@ -6,10 +6,10 @@ package:
   version: ${{ version }}
 
 source:
-  git: https://github.com/DerThorsten/gnu-m4
-  branch: master
-  # url: http://ftp.gnu.org/gnu/m4/m4-${{ version }}.tar.gz
-  # sha256: ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab
+  url: http://ftp.gnu.org/gnu/m4/m4-${{ version }}.tar.gz
+  sha256: ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab
+  patches:
+    - obstack_alloc_fail.patch
 build:
   number: 0
 

--- a/recipes/recipes_emscripten/m4/recipe.yaml
+++ b/recipes/recipes_emscripten/m4/recipe.yaml
@@ -20,8 +20,6 @@ requirements:
     - libtool
     - autoconf
     - automake
-    - autotools
-
 
 about:
   homepage: http://www.gnu.org/software/m4/

--- a/recipes/recipes_emscripten/m4/recipe.yaml
+++ b/recipes/recipes_emscripten/m4/recipe.yaml
@@ -1,0 +1,31 @@
+context:
+  version: "1.4.18"
+  name: "m4"
+package:
+  name: ${{name}}
+  version: ${{ version }}
+
+source:
+  git: https://github.com/DerThorsten/gnu-m4
+  branch: master
+  # url: http://ftp.gnu.org/gnu/m4/m4-${{ version }}.tar.gz
+  # sha256: ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab
+build:
+  number: 0
+
+requirements:
+  build:
+    - "${{ compiler('c') }}"
+    - make
+    - libtool
+    - autoconf
+    - automake
+    - autotools
+
+
+about:
+  homepage: http://www.gnu.org/software/m4/
+  license: LGPL-3.0
+  license_file: COPYING
+  summary:  'Implementation of the traditional Unix macro processor.'
+ 


### PR DESCRIPTION
This PR (hopefully, assuming it builds in GH actions) supersedes #1898 and #1897. Adds GNU m4 to emscripten-forge. Thanks @DerThorsten 