### PR TITLE
Remove pre.js in r-base

### DIFF
--- a/recipes/recipes_emscripten/r-base/config.site
+++ b/recipes/recipes_emscripten/r-base/config.site
@@ -152,8 +152,7 @@ FFLAGS="-g --target=wasm32-unknown-emscripten"
 ## is given.
 ## For example, one can set flags for profiling here.
 ## NOTE: These apply to R.bin
-MAIN_LDFLAGS="--pre-js ${RECIPE_DIR}/pre.js \
--sWASM_BIGINT \
+MAIN_LDFLAGS="-sWASM_BIGINT \
 -sMAIN_MODULE=1 \
 -sSTACK_SIZE=5MB \
 -sALLOW_MEMORY_GROWTH=1 \

--- a/recipes/recipes_emscripten/r-base/pre.js
+++ b/recipes/recipes_emscripten/r-base/pre.js
@@ -1,6 +1,0 @@
-Module['preRun'] = () => {
-    ENV['R_HOME'] = '/lib/R';
-    ENV['R_ENABLE_JIT'] = '0';
-    ENV['R_DEFAULT_PACKAGES'] = 'NULL';
-    ENV["EDITOR"] = "vim";
-};

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -26,7 +26,7 @@ source:
     - patches/0014-Set-cairo-as-default-bitmap-type.patch
 
 build:
-  number: 10
+  number: 11
 
 requirements:
   build:


### PR DESCRIPTION
The `--pre-js` flag gets added to the R `LDFLAGS` and this causes issues in downstream packages that depend on `r-base` because they cannot find the original `pre.js` file which only exists when building `r-base`. The file is not necessary and its contents should be overwritten depending on the use case. In `xeus-r`, this is handled by [`env_vars.js`](https://github.com/jupyter-xeus/xeus-r/blob/c3d0af4447bd3cda65b2c66ccb245b3a749d996b/wasm_patches/env_vars.js).