### PR TITLE
Rebuild ncurses against correct version

### DIFF
--- a/recipes/recipes_emscripten/ncurses/recipe.yaml
+++ b/recipes/recipes_emscripten/ncurses/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: e0f669ca923dfee33de25ede9de619a15671a07cdf9e530d742b22988e96ac1f
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -21,12 +21,13 @@ requirements:
     - make
     - libtool
     - coreutils
+    - ncurses <6.5
 
 tests:
 - script:
     - test -f ${PREFIX}/lib/libncurses.a
     - test -f ${PREFIX}/include/ncurses/curses.h
-    - test -f ${PREFIX}/share/terminfo/78/xterm-256color
+    - test -f ${PREFIX}/share/terminfo/x/xterm-256color
     - node ${PREFIX}/bin/clear -V -T $TERM # This should print the ncurses version
   requirements:
     build:


### PR DESCRIPTION
This is a rebuild of `ncurses` for 3.1.73 using the same version of `ncurses` in the `build` environment. Without this pin the `build` `ncurses` uses the latest 6.5 rather than the 6.4 here, and `xterminfo` has a different directory structure which eventually causes problems downstream in `vim`. Using the pin is the simplest solution here.

The only package affected by this is `vim`, for which I will submit a PR to update later today.