### PR TITLE
Add cross-r-base package for emscripten

### DIFF
--- a/recipes/recipes/cross-r-base_emscripten-wasm32/LICENSE
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Isabel Paredes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/recipes/cross-r-base_emscripten-wasm32/activate-cross-r-base.sh
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/activate-cross-r-base.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "R_HOME=${BUILD_PREFIX}/lib/R" > "${BUILD_PREFIX}/lib/R/etc/Makeconf"
+cat "${PREFIX}/lib/R/etc/Makeconf" >> "${BUILD_PREFIX}/lib/R/etc/Makeconf"
+
+export R="${BUILD_PREFIX}/bin/R"
+export R_ARGS="--no-byte-compile --no-test-load --library=$PREFIX/lib/R/library"

--- a/recipes/recipes/cross-r-base_emscripten-wasm32/build.sh
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eux
+
+mkdir -p ${PREFIX}/etc/conda/activate.d
+mkdir -p ${PREFIX}/etc/conda/deactivate.d
+
+cp "${RECIPE_DIR}"/activate-cross-r-base.sh ${PREFIX}/etc/conda/activate.d/
+cp "${RECIPE_DIR}"/deactivate-cross-r-base.sh ${PREFIX}/etc/conda/deactivate.d/

--- a/recipes/recipes/cross-r-base_emscripten-wasm32/deactivate-cross-r-base.sh
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/deactivate-cross-r-base.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ "${CONDA_BUILD:-0}" == "1" && "${CONDA_BUILD_STATE}" != "TEST" ]]; then
+  unset R
+  unset R_ARGS
+  unset R_HOME
+fi

--- a/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
@@ -1,0 +1,23 @@
+context:
+  name: cross-r-base_emscripten-wasm32
+  version: 0.0.1
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - r-base
+
+about:
+  summary: Package to cross-compile R packages to WebAssembly using Emscripten.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - IsabelParedes

--- a/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
@@ -12,6 +12,7 @@ build:
 requirements:
   run:
     - r-base
+    - emscripten_emscripten-wasm32
 
 about:
   summary: Package to cross-compile R packages to WebAssembly using Emscripten.


### PR DESCRIPTION
This will substitute the `cross-r-base` package from `conda-forge` used to compile R packages, and it will make it easier to build packages such as `hera` in `xeus-r`.

The downside of using `cross-r-base` from `conda-forge` is that it syncs the contents from the `BUILD_PREFIX` into `PREFIX`. This is problematic because the R packages do not get restored to their original state. With this new package, everything should remain in the `BUILD_PREFIX` and we would still be able to cross-compile R packages.