### PR TITLE
Create typescript definition file for cockle_fs

### DIFF
--- a/recipes/recipes_emscripten/cockle_fs/build.sh
+++ b/recipes/recipes_emscripten/cockle_fs/build.sh
@@ -1,10 +1,15 @@
+# Need tsc installed and available in PATH to use --emit-tsd
+npm install typescript
+export PATH=$SRC_DIR/node_modules/typescript/bin:$PATH
+
 touch fs.c
 emcc fs.c -o fs.js \
     -sALLOW_MEMORY_GROWTH=1 \
     -sEXPORTED_RUNTIME_METHODS=FS,PATH,ERRNO_CODES,PROXYFS \
     -sFORCE_FILESYSTEM=1 \
     -sMODULARIZE=1 \
-    -lproxyfs.js
+    -lproxyfs.js \
+    --emit-tsd fs.d.ts
 
 mkdir -p $PREFIX/bin
-cp fs.{js,wasm} $PREFIX/bin/
+cp fs.{d.ts,js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/cockle_fs/recipe.yaml
+++ b/recipes/recipes_emscripten/cockle_fs/recipe.yaml
@@ -6,12 +6,13 @@ package:
   version: ${{ version }}
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:
     - ${{ compiler("c") }}
     - cmake
+    - nodejs
 
 tests:
   - script:


### PR DESCRIPTION
Create typescript definition file for `cockle_fs`. This will be used in `cockle` to correctly check types of the loaded wasm module rather than use `any` for everything.