### PR TITLE
Add recipe for nano to emscripten-3.1.73 branch

### DIFF
--- a/recipes/recipes_emscripten/nano/build.sh
+++ b/recipes/recipes_emscripten/nano/build.sh
@@ -1,0 +1,56 @@
+export NCURSES_CFLAGS=$($PREFIX/bin/ncurses6-config --cflags)
+export NCURSES_LDFLAGS=$($PREFIX/bin/ncurses6-config --libs)
+export TERMINFO=$($PREFIX/bin/ncurses6-config --terminfo)
+export XTERM_256COLOR=$TERMINFO/x/xterm-256color
+export NANORC=$PWD/nanorc
+
+export CONFIG_CFLAGS="\
+    $NCURSES_CFLAGS \
+    -Os \
+    "
+export CONFIG_LDFLAGS="\
+    $NCURSES_LDFLAGS \
+    -Os \
+    --minify=0 \
+    -sALLOW_MEMORY_GROWTH=1 \
+    -sEXIT_RUNTIME=1 \
+    -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY \
+    -sFORCE_FILESYSTEM=1 \
+    -sMODULARIZE=1 \
+    -sLZ4 \
+    "
+
+emconfigure ./configure \
+    --build=x86_64-linux-gnu \
+    --host=wasm32-unknown-emscripten \
+    --disable-browser \
+    --disable-dependency-tracking \
+    --disable-nls \
+    --disable-threads \
+    --enable-color \
+    --enable-multibuffer \
+    --enable-nanorc \
+    --sysconfdir=/etc \
+    CFLAGS="$CFLAGS $CONFIG_CFLAGS" \
+    LDFLAGS="$LDFLAGS $CONFIG_LDFLAGS" \
+    NCURSES_CFLAGS="$NCURSES_CFLAGS" \
+    NCURSES_LDFLAGS="$NCURSES_LDFLAGS" \
+    gl_cv_bitsizeof_ptrdiff_t=32 \
+    gl_cv_bitsizeof_sig_atomic_t=32 \
+    gl_cv_bitsizeof_size_t=32 \
+    gl_cv_bitsizeof_wchar_t=16 \
+    gl_cv_bitsizeof_wint_t=32
+
+# Basic nanorc file.
+echo 'include "/usr/local/share/nano/*.nanorc"' > $NANORC
+
+emmake make EXEEXT=.js -j$CPU_COUNT LDFLAGS=" \
+    $LDFLAGS \
+    $CONFIG_LDFLAGS \
+    --preload-file $XTERM_256COLOR@/usr/local/share/terminfo/x/xterm-256color \
+    --preload-file $PWD/syntax@/usr/local/share/nano \
+    --preload-file $NANORC@/etc/nanorc \
+    "
+
+mkdir -p $PREFIX/bin
+cp src/nano.{data,js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/nano/recipe.yaml
+++ b/recipes/recipes_emscripten/nano/recipe.yaml
@@ -1,0 +1,45 @@
+context:
+  version: 8.2
+  major_version: ${{ version | split('.') | first }}
+
+package:
+  name: nano
+  version: ${{ version }}
+
+source:
+  url: https://www.nano-editor.org/dist/v${{ major_version }}/nano-${{ version }}.tar.xz
+  sha256: d5ad07dd862facae03051c54c6535e54c7ed7407318783fcad1ad2d7076fffeb
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler("cxx") }}
+    - pkg-config
+    - texinfo
+  host:
+    - ncurses <6.5
+
+tests:
+  - script:
+    - test -f $PREFIX/bin/nano.data
+    - test -f $PREFIX/bin/nano.js
+    - test -f $PREFIX/bin/nano.wasm
+  - script: |
+      OUTPUT=$(run_modularized $PREFIX/bin/nano.js --version | head -1)
+      if [[ ! "$OUTPUT" =~ "GNU nano, version 8.2" ]]; then
+        echo "Incorrect output: $OUTPUT"
+        exit 1
+      fi
+    requirements:
+      build:
+        - run_modularized
+
+about:
+  license: GPL-3.0-or-later
+  license_file: COPYING
+
+extra:
+  recipe-maintainers:
+    - ianthomas23


### PR DESCRIPTION
Add recipe for `nano` editor to emscripten-3.1.73 branch, for use in `cockle`. Screenshot of it in action:

<img width="1032" alt="Screenshot 2025-03-06 at 15 48 47" src="https://github.com/user-attachments/assets/e674a96b-6a11-4818-8699-1912b3057aaf" />
