### PR TITLE
enable UI on openssl

### DIFF
--- a/recipes/recipes_emscripten/openssl/build.sh
+++ b/recipes/recipes_emscripten/openssl/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-emconfigure ./Configure gcc -no-ui-console -DHAVE_FORK=0 -DOPENSSL_NO_SECURE_MEMORY -DNO_SYSLOG -fPIC -sWASM_BIGINT
+emconfigure ./Configure gcc -DHAVE_FORK=0 -DOPENSSL_NO_SECURE_MEMORY -DNO_SYSLOG -fPIC -sWASM_BIGINT
 
 # if on a mac
 if [[ $(uname) == Darwin ]]; then

--- a/recipes/recipes_emscripten/openssl/recipe.yaml
+++ b/recipes/recipes_emscripten/openssl/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/variant.yaml
+++ b/variant.yaml
@@ -540,7 +540,7 @@ openjpeg:
 openmpi:
   - 4
 openssl:
-  - 3.4.0
+  - 3.4.1
 openturns:
   - '1.18'
 orc:


### PR DESCRIPTION
for some reason, building libcurl requires the UI components of openSSL to be built:

```
 │ │ wasm-ld: error: ../lib/.libs/libcurl.a(libcurl_la-openssl.o): undefined symbol: UI_OpenSSL
 │ │ wasm-ld: error: ../lib/.libs/libcurl.a(libcurl_la-openssl.o): undefined symbol: UI_OpenSSL
 │ │ wasm-ld: error: ../lib/.libs/libcurl.a(libcurl_la-openssl.o): undefined symbol: UI_OpenSSL
 │ │ wasm-ld: error: ../lib/.libs/libcurl.a(libcurl_la-openssl.o): undefined symbol: UI_OpenSSL
```

this PR removes the flag to disable UI features. I'll submit another to build curl once this is approved and pixi stops trying to pull the non-UI openSSL (and maybe some other fixes).