### PR TITLE
Debug libflang

### DIFF
--- a/recipes/recipes_emscripten/libflang/build.sh
+++ b/recipes/recipes_emscripten/libflang/build.sh
@@ -14,4 +14,4 @@ cd _fbuild_runtime
 ninja -v
 ninja install
 
-emcc $PREFIX/lib/libFortranRuntime.a -o tst.so -sSIDE_MODULE=1 -sWASM_BIGINT
+emcc $PREFIX/lib/libFortranRuntime.a -o tst.so -sSIDE_MODULE=1 

--- a/recipes/recipes_emscripten/libflang/build.sh
+++ b/recipes/recipes_emscripten/libflang/build.sh
@@ -9,5 +9,9 @@ export CXXFLAGS="-fPIC"
 emcmake cmake -S flang/runtime -B _fbuild_runtime -GNinja \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX
-$(which cmake) --build _fbuild_runtime
-$(which cmake) --build _fbuild_runtime --target install
+
+cd _fbuild_runtime
+ninja -v
+ninja install
+
+emcc $PREFIX/lib/libFortranRuntime.a -o tst.so -sSIDE_MODULE=1 -sWASM_BIGINT

--- a/recipes/recipes_emscripten/libflang/build.sh
+++ b/recipes/recipes_emscripten/libflang/build.sh
@@ -2,16 +2,26 @@
 
 set -ex
 
-export CFLAGS="-fPIC"
-export CXXFLAGS="-fPIC"
+export CFLAGS="-fPIC $EM_FORGE_SIDE_MODULE_LDFLAGS"
+export CXXFLAGS="-fPIC $EM_FORGE_SIDE_MODULE_LDFLAGS"
+export LDFLAGS="$EM_FORGE_SIDE_MODULE_LDFLAGS"
+
+export AR="emar"
+export ARFLAGS="$EM_FORGE_SIDE_MODULE_LDFLAGS"
+export ARCH="emar"
 
 # See https://github.com/serge-sans-paille/llvm-project/blob/feature/flang-wasm/README.wasm.md
 emcmake cmake -S flang/runtime -B _fbuild_runtime -GNinja \
                 -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_INSTALL_PREFIX=$PREFIX
+                -DCMAKE_INSTALL_PREFIX=$PREFIX \
+                -DCMAKE_C_FLAGS="$CFLAGS" \
+                -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+                -DCMAKE_ARFLAGS="$ARFLAGS" \
+                -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS" \
+                -DBUILD_SHARED_LIBS=ON
 
 cd _fbuild_runtime
 ninja -v
 ninja install
 
-emcc $PREFIX/lib/libFortranRuntime.a -o tst.so -sSIDE_MODULE=1 
+emcc $PREFIX/lib/libFortranRuntime.a -o tst.so -sSIDE_MODULE=1

--- a/recipes/recipes_emscripten/libflang/recipe.yaml
+++ b/recipes/recipes_emscripten/libflang/recipe.yaml
@@ -23,13 +23,15 @@ source:
     - patches/0007-Patches-to-build-flang-runtime-with-emcc.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}
     - ninja
+    - cmake
+    - make
 
 tests:
 - package_contents:


### PR DESCRIPTION
Error when linking `libFortranRuntime.a`

```sh
emcc $PREFIX/lib/libFortranRuntime.a -o tst.so -sSIDE_MODULE=1 -sWASM_BIGINT
```

```diff
- $BUILD_PREFIX/bin/llvm-objcopy: error: 'tst.so': invalid TableNumber
```