### PR TITLE
scipy lapack

### DIFF
--- a/recipes/recipes_emscripten/scipy/build.sh
+++ b/recipes/recipes_emscripten/scipy/build.sh
@@ -63,7 +63,7 @@ sed -i '/char chla_transtype(int \*trans)/d' scipy/linalg/cython_lapack_signatur
 
 #  replace  dependencies: [lapack_dep, blas_dep, fortranobject_dep], with dependencies: [lapack, lapack_dep, blas_dep, fortranobject_dep],
 
-sed -i 's/dependencies: \[lapack_dep, blas_dep, fortranobject_dep\]/dependencies: \[lapack, blas_dep, fortranobject_dep\]/g' scipy/integrate/meson.build
+# sed -i 's/dependencies: \[lapack_dep, blas_dep, fortranobject_dep\]/dependencies: \[lapack, blas_dep, fortranobject_dep\]/g' scipy/integrate/meson.build
 
 
 

--- a/recipes/recipes_emscripten/scipy/build.sh
+++ b/recipes/recipes_emscripten/scipy/build.sh
@@ -59,6 +59,16 @@ echo "" > scipy/sparse/linalg/_dsolve/SuperLU/SRC/input_error.c
 
 sed -i '/char chla_transtype(int \*trans)/d' scipy/linalg/cython_lapack_signatures.txt
 
+
+
+#  replace  dependencies: [lapack_dep, blas_dep, fortranobject_dep], with dependencies: [lapack, lapack_dep, blas_dep, fortranobject_dep],
+
+sed -i 's/dependencies: \[lapack_dep, blas_dep, fortranobject_dep\]/dependencies: \[lapack, lapack_dep, blas_dep, fortranobject_dep\]/g' scipy/integrate/meson.build
+
+
+
+
+
 # https://github.com/mesonbuild/meson/blob/e542901af6e30865715d3c3c18f703910a096ec0/mesonbuild/backend/ninjabackend.py#L94
 # Prevent from using response file. The response file that meson generates is not compatible to pyodide-build
 export MESON_RSP_THRESHOLD=131072

--- a/recipes/recipes_emscripten/scipy/build.sh
+++ b/recipes/recipes_emscripten/scipy/build.sh
@@ -63,7 +63,7 @@ sed -i '/char chla_transtype(int \*trans)/d' scipy/linalg/cython_lapack_signatur
 
 #  replace  dependencies: [lapack_dep, blas_dep, fortranobject_dep], with dependencies: [lapack, lapack_dep, blas_dep, fortranobject_dep],
 
-sed -i 's/dependencies: \[lapack_dep, blas_dep, fortranobject_dep\]/dependencies: \[lapack, lapack_dep, blas_dep, fortranobject_dep\]/g' scipy/integrate/meson.build
+sed -i 's/dependencies: \[lapack_dep, blas_dep, fortranobject_dep\]/dependencies: \[lapack, blas_dep, fortranobject_dep\]/g' scipy/integrate/meson.build
 
 
 

--- a/recipes/recipes_emscripten/scipy/build.sh
+++ b/recipes/recipes_emscripten/scipy/build.sh
@@ -60,10 +60,7 @@ echo "" > scipy/sparse/linalg/_dsolve/SuperLU/SRC/input_error.c
 sed -i '/char chla_transtype(int \*trans)/d' scipy/linalg/cython_lapack_signatures.txt
 
 
-
-#  replace  dependencies: [lapack_dep, blas_dep, fortranobject_dep], with dependencies: [lapack, lapack_dep, blas_dep, fortranobject_dep],
-
-# sed -i 's/dependencies: \[lapack_dep, blas_dep, fortranobject_dep\]/dependencies: \[lapack, blas_dep, fortranobject_dep\]/g' scipy/integrate/meson.build
+sed -i 's/dependencies: \[lapack_dep, blas_dep, fortranobject_dep\]/dependencies: \[lapack_dep, lapack, blas_dep, fortranobject_dep\]/g' scipy/integrate/meson.build
 
 
 

--- a/recipes/recipes_emscripten/scipy/build.sh
+++ b/recipes/recipes_emscripten/scipy/build.sh
@@ -60,7 +60,7 @@ echo "" > scipy/sparse/linalg/_dsolve/SuperLU/SRC/input_error.c
 sed -i '/char chla_transtype(int \*trans)/d' scipy/linalg/cython_lapack_signatures.txt
 
 
-sed -i 's/dependencies: \[lapack_dep, blas_dep, fortranobject_dep\]/dependencies: \[lapack_dep, lapack, blas_dep, fortranobject_dep\]/g' scipy/integrate/meson.build
+# sed -i 's/dependencies: \[lapack_dep, blas_dep, fortranobject_dep\]/dependencies: \[lapack_dep, lapack, blas_dep, fortranobject_dep\]/g' scipy/integrate/meson.build
 
 
 

--- a/recipes/recipes_emscripten/scipy/recipe.yaml
+++ b/recipes/recipes_emscripten/scipy/recipe.yaml
@@ -43,7 +43,7 @@ source:
   #   target_directory: scipy/sparse/linalg/_propack/PROPACK
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/scipy/recipe.yaml
+++ b/recipes/recipes_emscripten/scipy/recipe.yaml
@@ -76,6 +76,7 @@ requirements:
   run:
     - python
     - numpy
+    - openblas
 
 tests:
 - script: pytester


### PR DESCRIPTION
debugging the error we see in the qutip build at runtime:
```
 error while evaluating main file: Error: Dynamic linking error: cannot resolve symbol i_sign in /lib/python3.13/site-packages/scipy/integrate/_vode.cpython-313-wasm32-emscripten.so
 ```
 That symbol is part of [libf2c](https://github.com/alphacep/clapack/blob/master/F2CLIBS/libf2c/i_sign.c).
This usually means we have to link the f2c symbols (ie lapack).
[This patch](https://github.com/emscripten-forge/recipes/blob/emscripten-3.1.73/recipes/recipes_emscripten/scipy/patches/0010-Link-openblas-with-modules-that-require-f2c.patch) is doing that: 

The confusing thing is that `vode` already links against `lapack_dep`.


Also confusing is that the build atm fails