### PR TITLE
Build symengine as a shared object

### DIFF
--- a/recipes/recipes_emscripten/symengine/build.sh
+++ b/recipes/recipes_emscripten/symengine/build.sh
@@ -19,6 +19,6 @@ emcmake cmake \
     -DWITH_MPFR=OFF \
     -DWITH_MPC=OFF \
     -DWITH_OPENMP=OFF \
-    ..
+    ../
 
 emmake make install -j8

--- a/recipes/recipes_emscripten/symengine/build.sh
+++ b/recipes/recipes_emscripten/symengine/build.sh
@@ -19,6 +19,7 @@ emcmake cmake \
     -DWITH_MPFR=OFF \
     -DWITH_MPC=OFF \
     -DWITH_OPENMP=OFF \
-    ../
+    -S . \
+    -B build
 
-emmake make install -j8
+emmake cmake --build build --target install

--- a/recipes/recipes_emscripten/symengine/build.sh
+++ b/recipes/recipes_emscripten/symengine/build.sh
@@ -5,12 +5,12 @@ emcmake cmake \
     -DBUILD_BENCHMARKS=OFF \
     -DINTEGER_CLASS=boostmp \
     -DWITH_BOOST=ON \
+    -DBoost_INCLUDE_DIR=$PREFIX/include \
+    -DBUILD_SHARED_LIBS=ON \
     -DCMAKE_PREFIX_PATH=$PREFIX \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DBUILD_FOR_DISTRIBUTION=yes \
-    -DBUILD_SHARED_LIBS=no \
-    -DBoost_INCLUDE_DIR=$PREFIX/include \
     -DWITH_SYMENGINE_THREAD_SAFE=ON \
     -DWITH_SYMENGINE_RCP=ON \
     -DWITH_FLINT=OFF \
@@ -19,7 +19,6 @@ emcmake cmake \
     -DWITH_MPFR=OFF \
     -DWITH_MPC=OFF \
     -DWITH_OPENMP=OFF \
-    -S . \
-    -B build
+    ..
 
-emmake cmake --build build --target install
+emmake make install -j8

--- a/recipes/recipes_emscripten/symengine/patches/shared.patch
+++ b/recipes/recipes_emscripten/symengine/patches/shared.patch
@@ -1,0 +1,72 @@
+diff --git a/symengine/CMakeLists.txt b/symengine/CMakeLists.txt
+index 2ae82f97..2ecc489f 100644
+--- a/symengine/CMakeLists.txt
++++ b/symengine/CMakeLists.txt
+@@ -1,3 +1,8 @@
++set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
++set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-s SIDE_MODULE=1")
++set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-s SIDE_MODULE=1")
++set(CMAKE_STRIP FALSE)
++
+ if (WITH_SYMENGINE_TEUCHOS)
+     add_subdirectory(utilities/teuchos)
+     # Include Teuchos headers:
+@@ -275,6 +280,9 @@ include(GNUInstallDirs)
+ # Configure SymEngine using our CMake options:
+ set(SYMENGINE_CLING_LIBRARY_DIR "\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}\"")
+ 
++set(SYMENGINE_CPPINTEROP_LIBRARY_PATH "\"/lib/${CMAKE_SHARED_LIBRARY_PREFIX}symengine${CMAKE_SHARED_LIBRARY_SUFFIX}\"")
++message(STATUS "SYMENGINE_CPPINTEROP_LIBRARY_PATH = ${SYMENGINE_CPPINTEROP_LIBRARY_PATH}")
++
+ configure_file(symengine_config.h.in symengine_config.h)
+ configure_file(symengine_config_cling.h.in symengine_config_cling.h)
+ 
+@@ -283,7 +291,9 @@ include_directories(BEFORE ${symengine_BINARY_DIR})
+ # Include the source directory
+ include_directories(BEFORE ${symengine_SOURCE_DIR})
+ 
+-add_library(symengine ${SRC})
++add_library(symengine SHARED
++${SRC}
++)
+ 
+ include(GenerateExportHeader)
+ generate_export_header(symengine)
+@@ -321,6 +331,7 @@ if (WITH_SYMENGINE_TEUCHOS)
+     target_link_libraries(symengine teuchos)
+ endif()
+ target_link_libraries(symengine ${LIBS})
++set_target_properties(symengine PROPERTIES NO_SONAME 1)
+ 
+ if (WITH_LLVM AND NOT SYMENGINE_LLVM_LINK_DOWNSTREAM AND NOT WITH_SYMENGINE_TEUCHOS)
+     if (${EXCLUDE_LIBS})
+diff --git a/symengine/symengine_config.h.in b/symengine/symengine_config.h.in
+index a4f406cf..bbcf55b2 100644
+--- a/symengine/symengine_config.h.in
++++ b/symengine/symengine_config.h.in
+@@ -90,7 +90,7 @@
+ 
+ #include <symengine/symengine_export.h>
+ 
+-#ifdef __CLING__
++#if defined(__CLANG_REPL__) && defined(__EMSCRIPTEN__)
+ #include "symengine/symengine_config_cling.h"
+ #endif
+ 
+diff --git a/symengine/symengine_config_cling.h.in b/symengine/symengine_config_cling.h.in
+index bf99d723..91ea1042 100644
+--- a/symengine/symengine_config_cling.h.in
++++ b/symengine/symengine_config_cling.h.in
+@@ -1,7 +1,10 @@
+ #ifndef SYMENGINE_CONFIG_CLING_HPP
+ #define SYMENGINE_CONFIG_CLING_HPP
+ 
+-#pragma cling add_library_path(@SYMENGINE_CLING_LIBRARY_DIR@)
+-#pragma cling load("@CMAKE_SHARED_LIBRARY_PREFIX@symengine")
++#include "clang/Interpreter/CppInterOp.h"
++static bool _symengine_loaded = []() {
++    Cpp::LoadLibrary(@SYMENGINE_CPPINTEROP_LIBRARY_PATH@);
++    return true;
++}();
+ 
+ #endif

--- a/recipes/recipes_emscripten/symengine/recipe.yaml
+++ b/recipes/recipes_emscripten/symengine/recipe.yaml
@@ -10,9 +10,11 @@ source:
   sha256: 11c5f64e9eec998152437f288b8429ec001168277d55f3f5f1df78e3cf129707
   url: https://github.com/symengine/symengine/releases/download/v${{ version }}/symengine-${{
     version }}.tar.gz
+  patches:
+  - patches/shared.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
This should help us load symengine at runtime when used with xeus-cpp-lite