### PR TITLE
add netcdf4, libnetcdf

### DIFF
--- a/recipes/recipes_emscripten/libnetcdf/build.sh
+++ b/recipes/recipes_emscripten/libnetcdf/build.sh
@@ -1,0 +1,3 @@
+emconfigure ./configure --host=none --disable-parallel4 --disable-dap --disable-dap-remote-tests --disable-nczarr --prefix=$PREFIX
+emmake make
+emmake make install

--- a/recipes/recipes_emscripten/libnetcdf/hdf5-parallel-disable.patch
+++ b/recipes/recipes_emscripten/libnetcdf/hdf5-parallel-disable.patch
@@ -1,0 +1,60 @@
+From 4957785c768d6f2816ae989a6acf6e6e84055da8 Mon Sep 17 00:00:00 2001
+From: Sam Gardner <sam@wx4stg.com>
+Date: Mon, 17 Mar 2025 03:27:16 -0500
+Subject: [PATCH] disable hdf5 parallelism
+
+---
+ libhdf5/hdf5create.c | 16 ++++++++--------
+ libhdf5/hdf5open.c   | 12 ++++++------
+ 2 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/libhdf5/hdf5create.c b/libhdf5/hdf5create.c
+index 02cd1b92ed..9a46c5192c 100644
+--- a/libhdf5/hdf5create.c
++++ b/libhdf5/hdf5create.c
+@@ -198,14 +198,14 @@ nc4_create_file(const char *path, int cmode, size_t initialsz,
+ 					       H5P_CRT_ORDER_INDEXED)) < 0)
+         BAIL(NC_EHDFERR);
+     }
+-#ifdef HDF5_HAS_COLL_METADATA_OPS
+-    /* If HDF5 supports collective metadata operations, turn them
+-     * on. This is only relevant for parallel I/O builds of HDF5. */
+-    if (H5Pset_all_coll_metadata_ops(fapl_id, 1) < 0)
+-        BAIL(NC_EHDFERR);
+-    if (H5Pset_coll_metadata_write(fapl_id, 1) < 0)
+-        BAIL(NC_EHDFERR);
+-#endif
++// #ifdef HDF5_HAS_COLL_METADATA_OPS
++//     /* If HDF5 supports collective metadata operations, turn them
++//      * on. This is only relevant for parallel I/O builds of HDF5. */
++//     if (H5Pset_all_coll_metadata_ops(fapl_id, 1) < 0)
++//         BAIL(NC_EHDFERR);
++//     if (H5Pset_coll_metadata_write(fapl_id, 1) < 0)
++//         BAIL(NC_EHDFERR);
++// #endif
+ 
+     if (cmode & NC_NODIMSCALE_ATTACH) {
+       /* See https://github.com/Unidata/netcdf-c/issues/2128 */
+diff --git a/libhdf5/hdf5open.c b/libhdf5/hdf5open.c
+index 082d528a0a..e2126cf4c6 100644
+--- a/libhdf5/hdf5open.c
++++ b/libhdf5/hdf5open.c
+@@ -810,12 +810,12 @@ nc4_open_file(const char *path, int mode, void* parameters, int ncid)
+         }
+     }
+ 
+-#ifdef HDF5_HAS_COLL_METADATA_OPS
+-    /* If collective metadata operations are available in HDF5, turn
+-     * them on. */
+-    if (H5Pset_all_coll_metadata_ops(fapl_id, 1) < 0)
+-        BAIL(NC_EPARINIT);
+-#endif /* HDF5_HAS_COLL_METADATA_OPS */
++// #ifdef HDF5_HAS_COLL_METADATA_OPS
++//     /* If collective metadata operations are available in HDF5, turn
++//      * them on. */
++//     if (H5Pset_all_coll_metadata_ops(fapl_id, 1) < 0)
++//         BAIL(NC_EPARINIT);
++// #endif /* HDF5_HAS_COLL_METADATA_OPS */
+ #endif /* USE_PARALLEL4 */
+ 
+     /* Only set cache for non-parallel opens. */

--- a/recipes/recipes_emscripten/libnetcdf/parallel-disable.patch
+++ b/recipes/recipes_emscripten/libnetcdf/parallel-disable.patch
@@ -1,0 +1,24 @@
+From c471b9ce6f726101563f7738844e4dbb7bd6fd7b Mon Sep 17 00:00:00 2001
+From: Sam Gardner <sam@wx4stg.com>
+Date: Sun, 16 Mar 2025 16:32:35 -0500
+Subject: [PATCH] dont use hdf5 parallel if available but not requested
+
+---
+ configure | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index ae48feca8d..7d7f45f85f 100755
+--- a/configure
++++ b/configure
+@@ -27628,7 +27628,9 @@ printf "%s\n" "#define HDF5_HAS_COLL_METADATA_OPS 1" >>confdefs.h
+ 
+    # If parallel is available in hdf5, enable it in the C code. Also add some stuff to netcdf.h.
+    if test "x$ac_cv_func_H5Pget_fapl_mpio" = xyes -o "x$ac_cv_func_H5Pget_fapl_mpiposix" = xyes; then
+-      hdf5_parallel=yes
++      if test "x$enable_parallel" = xyes; then
++          hdf5_parallel=yes
++      fi
+    fi
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether parallel io is enabled in hdf5" >&5
+ printf %s "checking whether parallel io is enabled in hdf5... " >&6; }

--- a/recipes/recipes_emscripten/libnetcdf/recipe.yaml
+++ b/recipes/recipes_emscripten/libnetcdf/recipe.yaml
@@ -1,0 +1,32 @@
+context:
+  version: "4.9.3"
+  name: "libnetcdf"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Unidata/netcdf-c/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff
+  patches:
+    - parallel-disable.patch
+    - hdf5-parallel-disable.patch
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - pip
+    - m4
+    - make
+  host:
+    - python
+    - libxml2
+    - hdf5
+    - zlib
+  run:
+    - python

--- a/recipes/recipes_emscripten/netcdf4/build.sh
+++ b/recipes/recipes_emscripten/netcdf4/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# remove the emcc symlink in the $BUILD_PREFIX/bin
+rm $BUILD_PREFIX/bin/emcc
+
+# make callable
+chmod +x $RECIPE_DIR/emcc_wrapper.sh
+
+# create symlink to $RECIPE_DIR/emcc_wrapper.sh 
+ln -s $RECIPE_DIR/emcc_wrapper.sh $BUILD_PREFIX/bin/emcc
+
+${PYTHON} -m pip install .

--- a/recipes/recipes_emscripten/netcdf4/emcc_wrapper.sh
+++ b/recipes/recipes_emscripten/netcdf4/emcc_wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+$BUILD_PREFIX/bin/python3 $RECIPE_DIR/py_emcc_wrapper.py $BUILD_PREFIX/opt/emsdk/upstream/emscripten/emcc  "$@"
+exit $?

--- a/recipes/recipes_emscripten/netcdf4/py_emcc_wrapper.py
+++ b/recipes/recipes_emscripten/netcdf4/py_emcc_wrapper.py
@@ -1,0 +1,18 @@
+import sys
+import subprocess
+if __name__ == '__main__':
+
+    args = sys.argv[2:]
+
+    filtered_args = []
+    for arg in args:
+        if ("-Wl,-R$PREFIX/lib" in arg )or ("-R" in arg):
+            print("removed arg:", arg)
+        else:
+            filtered_args.append(arg)
+    
+    # run the actual command in argv[1]
+    subprocess.run([sys.argv[1]] + filtered_args, check=True)
+
+
+

--- a/recipes/recipes_emscripten/netcdf4/recipe.yaml
+++ b/recipes/recipes_emscripten/netcdf4/recipe.yaml
@@ -27,6 +27,9 @@ requirements:
     - libnetcdf
   run:
     - python
+    - numpy
+    - hdf5
+    - libnetcdf # not sure yet about this,  only needed if libnetcdf is a shared lib
 
 
 tests:

--- a/recipes/recipes_emscripten/netcdf4/recipe.yaml
+++ b/recipes/recipes_emscripten/netcdf4/recipe.yaml
@@ -1,0 +1,29 @@
+context:
+  version: "1.7.2"
+  name: "netcdf4"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Unidata/netcdf4-python/archive/refs/tags/v${{ version }}rel.tar.gz
+  sha256: cce7d42a83f84b6ce6288bb2fb171d5ffd294f1a1ba2650807d238ae961e9629
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - cross-python_${{ target_platform }}
+    - ${{ compiler("c") }}
+    - pip
+    - pkg-config
+    - numpy
+    - cython
+  host:
+    - python
+    - hdf5
+    - libnetcdf
+  run:
+    - python

--- a/recipes/recipes_emscripten/netcdf4/recipe.yaml
+++ b/recipes/recipes_emscripten/netcdf4/recipe.yaml
@@ -30,6 +30,7 @@ requirements:
     - numpy
     - hdf5
     - cftime
+    - certifi
     - libnetcdf # not sure yet about this,  only needed if libnetcdf is a shared lib
 
 

--- a/recipes/recipes_emscripten/netcdf4/recipe.yaml
+++ b/recipes/recipes_emscripten/netcdf4/recipe.yaml
@@ -29,6 +29,7 @@ requirements:
     - python
     - numpy
     - hdf5
+    - cftime
     - libnetcdf # not sure yet about this,  only needed if libnetcdf is a shared lib
 
 

--- a/recipes/recipes_emscripten/netcdf4/recipe.yaml
+++ b/recipes/recipes_emscripten/netcdf4/recipe.yaml
@@ -31,8 +31,6 @@ requirements:
     - hdf5
     - cftime
     - certifi
-    - libnetcdf # not sure yet about this,  only needed if libnetcdf is a shared lib
-
 
 tests:
 - script: pytester

--- a/recipes/recipes_emscripten/netcdf4/recipe.yaml
+++ b/recipes/recipes_emscripten/netcdf4/recipe.yaml
@@ -27,3 +27,15 @@ requirements:
     - libnetcdf
   run:
     - python
+
+
+tests:
+- script: pytester
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+  files:
+    recipe:
+    - test_netcdf4.py

--- a/recipes/recipes_emscripten/netcdf4/test_netcdf4.py
+++ b/recipes/recipes_emscripten/netcdf4/test_netcdf4.py
@@ -1,0 +1,7 @@
+def test_netcdf4():
+  from netCDF4 import Dataset
+  rootgrp = Dataset("test.nc", "w", format="NETCDF4")
+  rootgrp.data_model == "NETCDF4"
+  rootgrp.close()
+
+

--- a/variant.yaml
+++ b/variant.yaml
@@ -377,7 +377,7 @@ harfbuzz:
 hdf4:
   - 4.2
 hdf5:
-  - 1.12.2
+  - 1.12.3
 icu:
   - '73'
 ipopt:
@@ -443,7 +443,7 @@ libmatio:
 libmicrohttpd:
   - 0.9
 libnetcdf:
-  - 4.8.1
+  - 4.9.3
 libopencv:
   - 4.5.5
 libpcap:


### PR DESCRIPTION
third time's the charm! (see previous #1896 and #1972)

Useful for meteorological and geographical datasets. I'm personally interested in having this built as I want to use xeus python jupyterlite for my library's documentation page. 

`netcdf4` is maintained by NSF Unidata. The [python bindings in `netcdf4`](https://github.com/Unidata/netcdf4-python) depend on the [underlying C library, `libnetcdf`](https://github.com/Unidata/netcdf-c).

I am mildly conflicted about the emcc_wrapper included in netcdf4. for some reason a -R$PREFIX/bin argument was being injected and I couldn't figure out where. This "fix" is done the same way that pyproj does it (see #1170)

Thanks again @DerThorsten for your previous assistance