### PR TITLE
Bump xeus-python build number to use latest xeus-lite

### DIFF
--- a/recipes/recipes_emscripten/xeus-python/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-python/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5b465638561019469c32974998b6f4bcde0b38c243c0b6f50bc5b001a4d78b4f
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Bump `xeus-python` build number to rebuild using latest `xeus-lite 3.1.0` that includes fixes for reading from `stdin`.