### PR TITLE
Bump xeus-r build number to use latest xeus-lite

### DIFF
--- a/recipes/recipes_emscripten/xeus-r/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-r/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: f7165ce9e3d46cde395baa29a5b5306333a3436ef0047a1b5c64e3b9f87b4171
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Bump `xeus-r` build number to rebuild using latest `xeus-lite 3.1.0` that includes fixes for reading from `stdin`.