### PR TITLE
Bump xeus-cpp build number to use latest xeus-lite

### DIFF
--- a/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8f085c0ac8fde263a07c212ba1c2ccd31f6e0b7c0a545c7bf279b7302311c3c8
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
Bump `xeus-cpp` build number to rebuild using latest `xeus-lite 3.1.0` that includes fixes for reading from `stdin`.