### PR TITLE
Undo replacement of fortran runtime lib in flang

### DIFF
--- a/recipes/recipes/flang_emscripten-wasm32/activate-flang_emscripten-wasm32.sh
+++ b/recipes/recipes/flang_emscripten-wasm32/activate-flang_emscripten-wasm32.sh
@@ -14,10 +14,8 @@ export F95=flang-new
 export F18=flang-new
 export FLANG=flang-new
 
+export FFLAGS="--target=wasm32-unknown-emscripten"
 export FPICFLAGS="-fPIC"
-
-rm $PREFIX/lib/libFortranRuntime.a || true
-cp $BUILD_PREFIX/lib/libFortranRuntime_emscripten-wasm32.a $PREFIX/lib/libFortranRuntime.a
 
 rm $BUILD_PREFIX/bin/clang || true
 ln -s $BUILD_PREFIX/bin/clang-20 $BUILD_PREFIX/bin/clang # links to emsdk clang

--- a/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This will only affect `r-base`, but the problem with the fortran library and R should be handled in `r-base` directly.