### PR TITLE
Improve documentation, add post about awesome latest changes

### DIFF
--- a/docs/blog/posts/updates.md
+++ b/docs/blog/posts/updates.md
@@ -1,0 +1,28 @@
+---
+date: 2023-04-30
+category:
+    - server
+    - python
+    - compiler
+    
+authors:
+    - derthorsten
+---
+
+# Major updates
+
+## We moved to prefix.dev
+
+When emscripten-forge started, packages where build
+hosted on a [quetz packge server](https://beta.mamba.pm/channels/conda-forge/packages/setuptools). Now we moved to [prefix.dev](https://prefix.dev/)
+
+## We changed the default compiler
+
+We changed the default emscripten-compiler we use to 3.1.73. Before that we used
+3.1.45. Its a bit unfortunate that emscripten 4 landed in the middle of this
+release. 
+
+## We changed the default python version to 3.13
+
+We changed the default python version to 3.13. Before that we used 3.11
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 
 Emscripten-forge is a GitHub [organization](https://github.com/emscripten-forge)/[repository](https://github.com/emscripten-forge/recipes) containing  [conda recipes](https://github.com/emscripten-forge/recipes) for the `emscripten-wasm32` platform.
 Conda-forge does not (yet) support the `emscripten-wasm32` platform. `emscripten-forge` fills this gap by providing a channel with conda packages for the `emscripten-wasm32` platform.
-The recipes repository not only stores the recipe files for multiple packages, but it also builds and uploads these packages to the `emscripten-forge` channel on [Quetz](https://beta.mamba.pm/channels/emscripten-forge)
+The recipes repository not only stores the recipe files for multiple packages, but it also builds and uploads these packages to the `emscripten-forge` channel on [prefix.dev](https://prefix.dev/channels/emscripten-forge-dev)
 
 ##
 

--- a/docs/project/credits.md
+++ b/docs/project/credits.md
@@ -14,5 +14,5 @@ Many recipes, build scripts, and patches are heavily inspired by the conda-forge
 ## Contributors
 
 This project has been started by [Thorsten Beier](https://github.com/derthorsten/) and [Wolf Vollprecht](https://github.com/wolfv).
-Since then many contributors have joined the project.
+Many other have contributed to the project.
 Many thanks to [all the contributors](https://github.com/emscripten-forge/recipes/graphs/contributors) of the emscripten-forge project.


### PR DESCRIPTION
* Point top prefix.dev instead of the deprecated quetz instance
* Announce the changes in the posts section of the documentation