### PR TITLE
Fix SymEngine Recipe

### DIFF
--- a/recipes/recipes_emscripten/symengine/patches/shared.patch
+++ b/recipes/recipes_emscripten/symengine/patches/shared.patch
@@ -72,7 +72,7 @@ index f90b9974..6394dce6 100644
  #endif
  
 diff --git a/symengine/symengine_config_cling.h.in b/symengine/symengine_config_cling.h.in
-index bf99d723..91ea1042 100644
+index bf99d723..f9c2353e 100644
 --- a/symengine/symengine_config_cling.h.in
 +++ b/symengine/symengine_config_cling.h.in
 @@ -1,7 +1,10 @@
@@ -83,7 +83,7 @@ index bf99d723..91ea1042 100644
 -#pragma cling load("@CMAKE_SHARED_LIBRARY_PREFIX@symengine")
 +#include "clang/Interpreter/CppInterOp.h"
 +static bool _symengine_loaded = []() {
-+    Cpp::LoadLibrary(@SYMENGINE_CPPINTEROP_LIBRARY_PATH@);
++    Cpp::LoadLibrary(@SYMENGINE_CPPINTEROP_LIBRARY_PATH@, false);
 +    return true;
 +}();
  

--- a/recipes/recipes_emscripten/symengine/recipe.yaml
+++ b/recipes/recipes_emscripten/symengine/recipe.yaml
@@ -14,7 +14,7 @@ source:
    - patches/shared.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -22,6 +22,8 @@ requirements:
   - cmake
   - make
   host:
+  - boost-cpp
+  run:
   - boost-cpp
 about:
   homepage: https://symengine.org/


### PR DESCRIPTION
SymEngine would need boost-cpp under the run field to work, otherwise we see this error 

![image](https://github.com/user-attachments/assets/5130c8d9-af56-4ee0-9d06-86f70d81d1b1)


This should address it and give us 

![image](https://github.com/user-attachments/assets/b2d8209c-f219-4f20-8e90-8f0e4a643ac8)
