### PR TITLE
Add `rustworkx` alpha

### DIFF
--- a/recipes/recipes_emscripten/rustworkx/build.sh
+++ b/recipes/recipes_emscripten/rustworkx/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+
+export MATURIN_PYTHON_SYSCONFIGDATA_DIR=${PREFIX}/etc/conda/_sysconfigdata__emscripten_wasm32-emscripten.py
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 
+${PYTHON} -m pip  install . -vvv
+

--- a/recipes/recipes_emscripten/rustworkx/recipe.yaml
+++ b/recipes/recipes_emscripten/rustworkx/recipe.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
   - cross-python_${{target_platform}}
+  - ${{ compiler("c") }}
   - cffi
   - setuptools-rust
   - rust

--- a/recipes/recipes_emscripten/rustworkx/recipe.yaml
+++ b/recipes/recipes_emscripten/rustworkx/recipe.yaml
@@ -1,0 +1,41 @@
+context:
+  name: rustworkx
+  version: 0.17.0a3
+
+package:
+  name: ${{name}}
+  version: ${{ version }}
+
+source:
+- url: https://github.com/IvanIsCoding/rustworkx/releases/download/v0.17.0a3/rustworkx-0.17.0a3.tar.gz
+  sha256: 8bd0c295134e2b0c03808d4e69428b41153849db6488839084a78793c337f191
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - cross-python_${{target_platform}}
+  - cffi
+  - setuptools-rust
+  - rust
+  - rust-src
+  - maturin
+
+  host:
+  - python
+  - openssl
+  - cffi
+  run:
+  - cffi
+
+tests:
+- script: pytester
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+  files:
+    recipe:
+    - test_rustworkx.py

--- a/recipes/recipes_emscripten/rustworkx/test_rustworkx.py
+++ b/recipes/recipes_emscripten/rustworkx/test_rustworkx.py
@@ -1,0 +1,22 @@
+import rustworkx
+
+def test_isomorphism():
+    # Adapted from tests/graph/test_isomorphic.py to work with pytest
+    n = 15
+    upper_bound_k = (n - 1) // 2
+    for k in range(1, upper_bound_k + 1):
+        for t in range(k, upper_bound_k + 1):
+            result = rustworkx.is_isomorphic(
+                rustworkx.generators.generalized_petersen_graph(n, k),
+                rustworkx.generators.generalized_petersen_graph(n, t),
+            )
+            expected = (k == t) or (k == n - t) or (k * t % n == 1) or (k * t % n == n - 1)
+            assert result == expected
+
+def test_rayon_works():
+    # This essentially tests that multi-threading is set to one core and does not panic
+    graph = rustworkx.generators.cycle_graph(10)
+    path_lenghts_floyd = rustworkx.floyd_warshall(graph)
+    path_lenghts_no_self = rustworkx.all_pairs_dijkstra_path_lengths(graph, lambda _: 1.0)
+    path_lenghts_dijkstra = {k: {**v, k: 0.0} for k, v in path_lenghts_no_self.items()}
+    assert path_lenghts_floyd == path_lenghts_dijkstra


### PR DESCRIPTION
Related: https://github.com/pyodide/pyodide-recipes/pull/90 and https://github.com/Qiskit/rustworkx/pull/1447

In short, this adds a very experimental rustworkx to emscripten-forge. It works with Pyodide, so I confirmed it worked with emscripten-forge as well: the tests passed after running `pixi run build-emscripten-wasm32-pkg recipes/recipes_emscripten/rustworkx`

At the current status, the other rustworkx author has not yet merged the Pyodide/emscripten-forge support. It also might take a while for us to publish 0.17.0. So I called it a pre-release with 0.17.0a3 and hosted it in my GitHub fork's release. If that is not ok, let me know.