### PR TITLE
Enable rich display for xtensor through xeus-cpp-lite

### DIFF
--- a/recipes/recipes_emscripten/xtensor/patches/rich_display.patch
+++ b/recipes/recipes_emscripten/xtensor/patches/rich_display.patch
@@ -1,0 +1,12 @@
+diff --git a/include/xtensor/io/xio.hpp b/include/xtensor/io/xio.hpp
+index ca9d694a..345edc4d 100644
+--- a/include/xtensor/io/xio.hpp
++++ b/include/xtensor/io/xio.hpp
+@@ -827,6 +827,6 @@ namespace xt
+ 
+ // Backward compatibility: include xmime.hpp in xio.hpp by default.
+ 
+-#ifdef __CLING__
++#if defined(__CLING__) || defined(__CLANG_REPL__)
+ #include "xmime.hpp"
+ #endif

--- a/recipes/recipes_emscripten/xtensor/recipe.yaml
+++ b/recipes/recipes_emscripten/xtensor/recipe.yaml
@@ -9,9 +9,11 @@ package:
 source:
   url: https://github.com/xtensor-stack/xtensor/archive/${{ version }}.tar.gz
   sha256: f5f42267d850f781d71097b50567a480a82cd6875a5ec3e6238555e0ef987dc6
+  patches:
+  - patches/rich_display.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
This should fix this 

![image](https://github.com/user-attachments/assets/6e127e3a-c08f-4e1d-afc8-905264e86504)
