### PR TITLE
Add nlohmann_json to xeus-cpp as runtime dependecy

### DIFF
--- a/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
@@ -26,7 +26,7 @@ requirements:
     - CppInterOp
   run:
     - CppInterOp
-    - {{ pin_compatible('nlohmann_json', max_pin='x.x.x') }}
+    - "${{ pin_compatible('nlohmann_json', max_pin='x.x.x') }}"
 
 tests:
   - script:

--- a/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
@@ -26,7 +26,7 @@ requirements:
     - CppInterOp
   run:
     - CppInterOp
-    - "${{ pin_compatible('nlohmann_json', max_pin='x.x.x') }}"
+    - "${{ pin_compatible('nlohmann_json', upper_bound='x.x.x') }}"
 
 tests:
   - script:

--- a/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8f085c0ac8fde263a07c212ba1c2ccd31f6e0b7c0a545c7bf279b7302311c3c8
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -18,7 +18,7 @@ requirements:
     - cmake
     - make  # [unix]
   host:
-    - nlohmann_json
+    - nlohmann_json=3.12.0
     - xeus-lite >=3.0.0,<4.0
     - xeus >=5.0.0,<6.0
     - cpp-argparse
@@ -26,6 +26,7 @@ requirements:
     - CppInterOp
   run:
     - CppInterOp
+    - {{ pin_compatible('nlohmann_json', max_pin='x.x.x') }}
 
 tests:
   - script:


### PR DESCRIPTION
Needed for running rich rendering and other examples with xeus-cpp-lite in notebook link.