### PR TITLE
Add recipe for libgit2

### DIFF
--- a/recipes/recipes_emscripten/libgit2/build.sh
+++ b/recipes/recipes_emscripten/libgit2/build.sh
@@ -1,0 +1,16 @@
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} .. \
+    -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH=$PREFIX \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DBUILD_EXAMPLES=OFF \
+    -DUSE_HTTPS=OFF \
+    -DUSE_THREADS=OFF
+
+ninja install
+
+# Install .wasm files as well
+cp git2.wasm ${PREFIX}/bin

--- a/recipes/recipes_emscripten/libgit2/recipe.yaml
+++ b/recipes/recipes_emscripten/libgit2/recipe.yaml
@@ -1,0 +1,38 @@
+context:
+  name: libgit2
+  version: 1.9.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/${{ name }}/${{ name }}/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 75b27d4d6df44bd34e2f70663cfd998f5ec41e680e1e593238bbe517a84c7ed2
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - cmake
+    - ninja
+    - pkg-config
+
+tests:
+  - script:
+    - test -f ${PREFIX}/bin/git2.js
+    - test -f ${PREFIX}/bin/git2.wasm
+    - test -f ${PREFIX}/include/git2.h
+    - test -f ${PREFIX}/lib/libgit2.a
+    - test -f ${PREFIX}/lib/pkgconfig/libgit2.pc
+
+about:
+  homepage: https://github.com/libgit2/libgit2
+  license: GPL-2.0
+  license_file: COPYING
+
+extra:
+  recipe-maintainers:
+    - ianthomas23


### PR DESCRIPTION
Add new recipe for `libgit2`, which is a required dependency of [git2cpp](https://github.com/QuantStack/git2cpp). 

Eventually we will need to patch fetch requests like `wasm-git` does.