### PR TITLE
Built xeus-lite on top of latest xeus

### DIFF
--- a/recipes/recipes_emscripten/xeus-lite/build.sh
+++ b/recipes/recipes_emscripten/xeus-lite/build.sh
@@ -3,13 +3,11 @@ mkdir build
 cd build
 
 # Configure step
-cmake ${CMAKE_ARGS} ..             \
-    -GNinja                        \
-    -DCMAKE_BUILD_TYPE=Release     \
-    -DCMAKE_PREFIX_PATH=$PREFIX    \
+emcmake cmake \
+    -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DXSQL_BUILD_XSQLITE_EXECUTABLE=OFF \
-    -DCMAKE_FIND_DEBUG_MODE=OFF \
+    -DCMAKE_FIND_ROOT_PATH=$PREFIX \
+    ..
 
 # Build step
-ninja install
+emmake make -j8 install

--- a/recipes/recipes_emscripten/xeus-lite/patches/shared.patch
+++ b/recipes/recipes_emscripten/xeus-lite/patches/shared.patch
@@ -1,0 +1,56 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aade34c..76f8613 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -33,6 +33,7 @@ message(STATUS "xeus-lite version: v${XEUS_LITE_VERSION}")
+ 
+ # Build options
+ # =============
++option(XEUS_LITE_USE_SHARED_XEUS "Link with the xeus shared library (instead of the static library)" ON)
+ 
+ # Test options
+ option(XEUS_LITE_BUILD_NODE_TESTS          "xeus-lite test suite (node)" OFF)
+@@ -49,11 +50,16 @@ endif()
+ # Print build configuration
+ # ==========================
+ 
+-message(STATUS "XEUS_LITE_BUILD_NODE_TESTS:                ${XEUS_LITE_BUILD_NODE_TESTS}")  
++message(STATUS "XEUS_LITE_USE_SHARED_XEUS:                ${XEUS_LITE_USE_SHARED_XEUS}")
++message(STATUS "XEUS_LITE_BUILD_NODE_TESTS:                ${XEUS_LITE_BUILD_NODE_TESTS}")
+ 
+ # Dependencies
+ # ============
+ 
++if(EMSCRIPTEN AND XEUS_LITE_USE_SHARED_XEUS)
++    set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
++endif()
++
+ set(xeus_REQUIRED_VERSION 5.0.0)
+ 
+ if (NOT TARGET xeus)
+@@ -86,10 +92,21 @@ target_include_directories(
+     PUBLIC $<BUILD_INTERFACE:${XEUS_LITE_INCLUDE_DIR}>
+     $<INSTALL_INTERFACE:include>
+ )
+-target_link_libraries(
+-    xeus-lite
+-    PUBLIC xeus-static
+-)
++if(XEUS_LITE_USE_SHARED_XEUS)
++    message(STATUS "Linking xeus-lite with shared xeus target")
++    if(TARGET xeus)
++        target_link_libraries(xeus-lite PRIVATE xeus)
++    else()
++        message(FATAL_ERROR "XEUS_LITE_USE_SHARED_XEUS is ON but 'xeus' target not found")
++    endif()
++else()
++    message(STATUS "Linking xeus-lite with static xeus target")
++    if(TARGET xeus-static)
++        target_link_libraries(xeus-lite PRIVATE xeus-static)
++    else()
++        message(FATAL_ERROR "XEUS_LITE_USE_SHARED_XEUS is OFF but 'xeus-static' target not found")
++    endif()
++endif()
+ 
+ set_target_properties(
+     xeus-lite

--- a/recipes/recipes_emscripten/xeus-lite/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-lite/recipe.yaml
@@ -8,15 +8,17 @@ package:
 source:
   url: https://github.com/jupyter-xeus/xeus-lite/archive/refs/tags/${{ version }}.tar.gz
   sha256: e64a509d2a2fae780bbcfb10d9c1713cd8c6e947ae012e3a244470b6e776380b
+  patches:
+  - patches/shared.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
   - ${{ compiler("cxx") }}
   - cmake
-  - ninja
+  - make
   host:
   - nlohmann_json
   - xeus >=5.0.0


### PR DESCRIPTION
I am having a tad bit of doubt here.

Cause whether we use xeus-static or xeus as the target. This is what happens internally (as can be seen in `xeus-lite/build/CMakeFiles/xeus-lite.dir/link.txt` locally)
```
/Users/anutosh491/micromamba/envs/xeus-cpp-wasm-build/opt/emsdk/upstream/emscripten/emar qc libxeus-lite.a "CMakeFiles/xeus-lite.dir/src/xembind.cpp.o" "CMakeFiles/xeus-lite.dir/src/xserver_emscripten.cpp.o"
/Users/anutosh491/micromamba/envs/xeus-cpp-wasm-build/opt/emsdk/upstream/emscripten/emranlib libxeus-lite.a
```

So a libxeus.a or libxeus.so doesn't a too big of a role here I think but we should be able to build xeus-lite on top of our shared xeus build and hence this patch.