### PR TITLE
cross-python-cmake-find-python

### DIFF
--- a/recipes/recipes/cross-python_emscripten-wasm32/FindPython.cmake
+++ b/recipes/recipes/cross-python_emscripten-wasm32/FindPython.cmake
@@ -1,0 +1,128 @@
+# This is your custom FindPython.cmake
+
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
+set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-s SIDE_MODULE=1")
+set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-s SIDE_MODULE=1")
+set(CMAKE_STRIP FALSE)  # used by default in pybind11 on .so modules
+
+
+# Indicate that Python and its components are found
+set(Python_FOUND TRUE)
+set(Python_Interpreter_FOUND TRUE)
+set(Python_Development_FOUND TRUE)
+
+
+set(PY_VER "$ENV{PY_VER}") # This should be set to the Python version you are using, e.g., "3.13"
+
+set(MY_PYTHON_PREFIX "$ENV{PREFIX}") 
+
+# Hardcode the Python interpreter path
+set(Python_EXECUTABLE "$ENV{PYTHON}") 
+
+
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c "import sys; print(sys.version_info[0])"
+  OUTPUT_VARIABLE PYTHON_MAJOR_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE PYTHON_VERSION_MAJOR
+)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c "import sys; print(sys.version_info[1])"
+  OUTPUT_VARIABLE PYTHON_MAJOR_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE PYTHON_VERSION_MINOR
+)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c "import sys; print(sys.version_info[2])"
+  OUTPUT_VARIABLE PYTHON_MAJOR_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE PYTHON_VERSION_PATCH
+)
+
+
+# Hardcode the Python development library path
+# This often points to the shared library. Adjust for your OS (e.g., .so, .dylib, .lib)
+# You might need to specify the exact version, e.g., libpython3.10.so
+set(Python_LIBRARIES "${MY_PYTHON_PREFIX}/lib/libpython${PY_VER}.a")
+set(Python_Development_LIBRARIES "${MY_PYTHON_PREFIX}/lib/libpython${PY_VER}.a") # Often the same as Python_LIBRARIES for development
+
+# Hardcode the Python include directories
+# This typically includes two paths: one for the base include and one for the specific version
+set(Python_INCLUDE_DIRS
+    "${MY_PYTHON_PREFIX}/include/python${PY_VER}" # Adjust for your Python version, e.g., python3.10
+    # "${MY_PYTHON_PREFIX}/include/python3/pyconfig.h" # This often contains architecture-specific definitions
+)
+set(Python_Development_INCLUDE_DIRS ${Python_INCLUDE_DIRS}) # Often the same as Python_INCLUDE_DIRS for development
+
+# # --- Optional: Set Python Version Variables (Highly Recommended) ---
+# # Many projects check these variables. Adjust based on your Python version.
+# set(Python_VERSION_MAJOR 3)
+# set(Python_VERSION_MINOR 13) # Example: Adjust to your actual minor version
+# set(Python_VERSION_PATCH 1) # Example: Adjust to your actual patch version
+set(Python_VERSION_STRING "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}.${Python_VERSION_PATCH}")
+
+# --- Optional: Set other commonly used variables if needed ---
+# For instance, if you need the site-packages directory
+set(Python_SITELIB "${MY_PYTHON_PREFIX}/lib/python${PY_VER}/site-packages")
+
+# Inform the user that Python was found via this custom module (useful for debugging)
+message(STATUS "Found Python (custom FindPython.cmake):")
+message(STATUS "  Interpreter: ${Python_EXECUTABLE}")
+message(STATUS "  Libraries: ${Python_LIBRARIES}")
+message(STATUS "  Includes: ${Python_INCLUDE_DIRS}")
+message(STATUS "  Version: ${Python_VERSION_STRING}")
+
+# Mark variables as advanced so they don't clutter the CMake GUI by default
+mark_as_advanced(
+    Python_EXECUTABLE
+    Python_LIBRARIES
+    Python_INCLUDE_DIRS
+    Python_Development_LIBRARIES
+    Python_Development_INCLUDE_DIRS
+    Python_VERSION_MAJOR
+    Python_VERSION_MINOR
+    Python_VERSION_PATCH
+    Python_VERSION_STRING
+)
+
+
+
+
+# To satisfy the if (NOT TARGET Python::Module) check, you need to create an ALIAS target named Python::Module in your custom FindPython.cmake. This is a common pattern in CMake for exporting discovered libraries and executables as well-defined targets.
+
+
+
+
+# --- NEW ADDITIONS FOR TARGETS ---
+
+# Create an imported INTERFACE library target for Python development
+# This makes Python::Python and Python::Module available for linking and includes
+if (NOT TARGET Python::Python)
+    add_library(Python::Python INTERFACE IMPORTED)
+    set_target_properties(Python::Python PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${Python_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES "${Python_LIBRARIES}"
+    )
+    message(STATUS "Created Python::Python INTERFACE target.")
+endif()
+
+# Create an alias target for Python::Module, pointing to Python::Python
+# This is what packages like nanobind specifically check for.
+# It ensures that even if they expect a specific 'Module' target,
+# it points to the general Python development target.
+if (NOT TARGET Python::Module)
+    add_library(Python::Module ALIAS Python::Python)
+    message(STATUS "Created Python::Module ALIAS target pointing to Python::Python.")
+endif()
+
+# Optional: Create an executable target for the interpreter
+if (NOT TARGET Python::Interpreter)
+    add_executable(Python::Interpreter IMPORTED)
+    set_target_properties(Python::Interpreter PROPERTIES
+        IMPORTED_LOCATION "${Python_EXECUTABLE}"
+    )
+    message(STATUS "Created Python::Interpreter IMPORTED executable target.")
+endif()

--- a/recipes/recipes/cross-python_emscripten-wasm32/FindPython.cmake
+++ b/recipes/recipes/cross-python_emscripten-wasm32/FindPython.cmake
@@ -1,10 +1,7 @@
-# This is your custom FindPython.cmake
-
 set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
 set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-s SIDE_MODULE=1")
 set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-s SIDE_MODULE=1")
 set(CMAKE_STRIP FALSE)  # used by default in pybind11 on .so modules
-
 
 # Indicate that Python and its components are found
 set(Python_FOUND TRUE)
@@ -13,13 +10,10 @@ set(Python_Development_FOUND TRUE)
 
 
 set(PY_VER "$ENV{PY_VER}") # This should be set to the Python version you are using, e.g., "3.13"
-
 set(MY_PYTHON_PREFIX "$ENV{PREFIX}") 
 
 # Hardcode the Python interpreter path
 set(Python_EXECUTABLE "$ENV{PYTHON}") 
-
-
 
 execute_process(
   COMMAND "${Python_EXECUTABLE}" -c "import sys; print(sys.version_info[0])"
@@ -42,27 +36,18 @@ execute_process(
   RESULT_VARIABLE PYTHON_VERSION_PATCH
 )
 
+set(Python_VERSION_STRING "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}.${Python_VERSION_PATCH}")
 
-# Hardcode the Python development library path
-# This often points to the shared library. Adjust for your OS (e.g., .so, .dylib, .lib)
-# You might need to specify the exact version, e.g., libpython3.10.so
+
 set(Python_LIBRARIES "${MY_PYTHON_PREFIX}/lib/libpython${PY_VER}.a")
 set(Python_Development_LIBRARIES "${MY_PYTHON_PREFIX}/lib/libpython${PY_VER}.a") # Often the same as Python_LIBRARIES for development
 
-# Hardcode the Python include directories
-# This typically includes two paths: one for the base include and one for the specific version
 set(Python_INCLUDE_DIRS
-    "${MY_PYTHON_PREFIX}/include/python${PY_VER}" # Adjust for your Python version, e.g., python3.10
-    # "${MY_PYTHON_PREFIX}/include/python3/pyconfig.h" # This often contains architecture-specific definitions
+    "${MY_PYTHON_PREFIX}/include/python${PY_VER}"
 )
 set(Python_Development_INCLUDE_DIRS ${Python_INCLUDE_DIRS}) # Often the same as Python_INCLUDE_DIRS for development
 
-# # --- Optional: Set Python Version Variables (Highly Recommended) ---
-# # Many projects check these variables. Adjust based on your Python version.
-# set(Python_VERSION_MAJOR 3)
-# set(Python_VERSION_MINOR 13) # Example: Adjust to your actual minor version
-# set(Python_VERSION_PATCH 1) # Example: Adjust to your actual patch version
-set(Python_VERSION_STRING "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}.${Python_VERSION_PATCH}")
+
 
 # --- Optional: Set other commonly used variables if needed ---
 # For instance, if you need the site-packages directory
@@ -88,15 +73,6 @@ mark_as_advanced(
     Python_VERSION_STRING
 )
 
-
-
-
-# To satisfy the if (NOT TARGET Python::Module) check, you need to create an ALIAS target named Python::Module in your custom FindPython.cmake. This is a common pattern in CMake for exporting discovered libraries and executables as well-defined targets.
-
-
-
-
-# --- NEW ADDITIONS FOR TARGETS ---
 
 # Create an imported INTERFACE library target for Python development
 # This makes Python::Python and Python::Module available for linking and includes

--- a/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
+++ b/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
@@ -67,3 +67,23 @@ export PYTHON=$PYTHON_HOST # This should be a script to set up the cross env
 # Set up flags
 export LDFLAGS="$EM_FORGE_SIDE_MODULE_LDFLAGS"
 export CFLAGS="$EM_FORGE_SIDE_MODULE_CFLAGS"
+
+
+# is cmake installed?
+if  command -v cmake &> /dev/null; then
+  echo "CMake is installed, setting up custom FindPython.cmake"
+
+  # we overwrite the FindPython.cmake **IN THE BUILD PREFIX**
+  CUSTOM_FIND_PYTHON=$BUILD_PREFIX/share/cross-python/FindPython.cmake
+
+  # guess the cmake version (ie 4.0.1)
+  CMAKE_VERSION=$(cmake --version | head -n 1 | cut -d ' ' -f 3)
+
+  # remove the patch version
+  CMAKE_VERSION=$(echo $CMAKE_VERSION | cut -d '.' -f 1-2)
+
+  CMAKE_MODULE_DIR="$BUILD_PREFIX/share/cmake-$CMAKE_VERSION/Modules"
+
+  cp $CUSTOM_FIND_PYTHON $CMAKE_MODULE_DIR/FindPython.cmake
+
+fi

--- a/recipes/recipes/cross-python_emscripten-wasm32/build.sh
+++ b/recipes/recipes/cross-python_emscripten-wasm32/build.sh
@@ -7,3 +7,7 @@ do
     mkdir -p "${PREFIX}/etc/conda/${TASK}.d"
     cp "${RECIPE_DIR}/${TASK}.sh" "${PREFIX}/etc/conda/${TASK}.d/${TASK}_z-${PKG_NAME}.sh"
 done
+
+
+mkdir -p "${PREFIX}/share/cross-python"
+cp $RECIPE_DIR/FindPython.cmake "${PREFIX}/share/cross-python/FindPython.cmake"

--- a/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 9
+  number: 7
 
 requirements:
   run:

--- a/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 6
+  number: 9
 
 requirements:
   run:

--- a/recipes/recipes_emscripten/pyb2d3/build.sh
+++ b/recipes/recipes_emscripten/pyb2d3/build.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -e
 
-# CUSTOM_FIND_PYTHON=$RECIPE_DIR/FindPython.cmake
-# mkdir -p $BUILD_PREFIX/share/cmake-4.0/Modules
-# cp $CUSTOM_FIND_PYTHON $BUILD_PREFIX/share/cmake-4.0/Modules/FindPython.cmake
-
-
-
 # add nanobind dir to cmake args
 NANOBIND_CMAKE_DIR=$(python -m nanobind --cmake_dir)
 CMAKE_ARGS="${CMAKE_ARGS} -Dnanobind_DIR=${NANOBIND_CMAKE_DIR}"

--- a/recipes/recipes_emscripten/pyb2d3/build.sh
+++ b/recipes/recipes_emscripten/pyb2d3/build.sh
@@ -1,40 +1,17 @@
-mkdir build
-cd build
+#!/bin/bash
+set -e
 
-export CMAKE_PREFIX_PATH=$PREFIX
-export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
-
-export PYTHON_LIBRARIES=$PREFIX/lib/libpython3.13.a
-export PYTHON_INCLUDE_DIR=$PREFIX/include/python3.13
-
-
-nanobind_DIR=$($PYTHON -m nanobind --cmake_dir)
-echo "nanobind_DIR: $nanobind_DIR"
-
-ls $nanobind_DIR
-
-# Configure step
-cmake ${CMAKE_ARGS} ..                                \
-    -GNinja                                           \
-    -DCMAKE_BUILD_TYPE=Release                        \
-    -DCMAKE_PREFIX_PATH=$PREFIX                       \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX                    \
-    -DPython_EXECUTABLE=$PYTHON                     \
-    -DPython_Interpreter=$PYTHON                     \
-    -DPYB2D_NO_THREADING=ON                          \
-    -DPython_INCLUDE_DIRS=$PREFIX/include/python3.13 \
-    -DPython_LIBRARY=$PREFIX/lib/libpython3.13.a \
-    -DPython_LIBRARIES=$PREFIX/lib/libpython3.13.a \
-    -DNB_SUFFIX="" \
-    -DNB_SUFFIX_S="" \
-    -DEXT_SUFFIX="so" \
-    -Dnanobind_DIR=$nanobind_DIR
-
-
-# Build step
-ninja
+# CUSTOM_FIND_PYTHON=$RECIPE_DIR/FindPython.cmake
+# mkdir -p $BUILD_PREFIX/share/cmake-4.0/Modules
+# cp $CUSTOM_FIND_PYTHON $BUILD_PREFIX/share/cmake-4.0/Modules/FindPython.cmake
 
 
 
-mkdir -p $PREFIX/lib/python3.13/site-packages/pyb2d3
-cp -r $SRC_DIR/src/module/pyb2d3 $PREFIX/lib/python3.13/site-packages/
+# add nanobind dir to cmake args
+NANOBIND_CMAKE_DIR=$(python -m nanobind --cmake_dir)
+CMAKE_ARGS="${CMAKE_ARGS} -Dnanobind_DIR=${NANOBIND_CMAKE_DIR}"
+CMAKE_ARGS="${CMAKE_ARGS} -DPYB2D3_NO_THREADING=ON" 
+export CMAKE_ARGS
+
+#!/bin/bash
+${PYTHON} -m pip  install . --prefix="$PREFIX"

--- a/recipes/recipes_emscripten/pyb2d3/recipe.yaml
+++ b/recipes/recipes_emscripten/pyb2d3/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.1.0
+  version: 0.2.1
   name: pyb2d3
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://github.com/DerThorsten/pyb2d3/archive/refs/tags/v${{version}}.tar.gz
-    sha256: 90f8d9288431ce60294c3837c2278a1939540cdfa6d8a9da417a7b6401186cac
+    sha256: 05ddddc8719a96b569553b44259510b69249b400a29db2b6d06c5ef780051c08
 
 build:
   number: 0
@@ -17,7 +17,7 @@ requirements:
   build:
   - ${{ compiler("cxx") }}
   - cross-python_emscripten-wasm32
-  - cmake
+  - cmake>=4.0
   - ninja
   - numpy
   - nanobind
@@ -28,7 +28,6 @@ requirements:
   - python
   - numpy
   - box2d-static
-
 
   run:
   - numpy

--- a/recipes/recipes_emscripten/pyb2d3/recipe.yaml
+++ b/recipes/recipes_emscripten/pyb2d3/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.2.1
+  version: 0.3.0
   name: pyb2d3
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://github.com/DerThorsten/pyb2d3/archive/refs/tags/v${{version}}.tar.gz
-    sha256: 05ddddc8719a96b569553b44259510b69249b400a29db2b6d06c5ef780051c08
+    sha256: b7dbcf515882255514b665c328d6cb4d73ce37ed1a57cdf3a24add6d36ddc7c5
 
 build:
   number: 0
@@ -28,6 +28,7 @@ requirements:
   - python
   - numpy
   - box2d-static
+
 
   run:
   - numpy


### PR DESCRIPTION
python extensions build with cmake, in particular extensions using nanobind rely on `FindPython.cmake` in the **build-prefix** to do the right thing. But of course it does not :/.

This ment that packages had to do horrible stuff to avoid running into issues from `FindPython.cmake`.
The following are the horrors we had to do (ie create a MyFakePythonModule and and alias from `MyFakePythonModule`to `Python::Module`):
```cmake
if(EMSCRIPTEN)
    set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
    set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-s SIDE_MODULE=1")
    set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-s SIDE_MODULE=1")
    set(CMAKE_STRIP FALSE)  # used by default in pybind11 on .so modules

    # Create a target that holds Python module information
    add_library(MyFakePythonModule INTERFACE)

    # Define the include directories
    set_target_properties(MyFakePythonModule PROPERTIES
        INTERFACE_INCLUDE_DIRECTORIES "${Python_INCLUDE_DIRS}"
    )

    # Define the link libraries (the actual Python library)
    set_target_properties(MyFakePythonModule PROPERTIES
        INTERFACE_LINK_LIBRARIES "${Python_LIBRARIES}"
    )

    # Optionally, if nanobind uses the Python executable path:
    set_target_properties(MyFakePythonModule PROPERTIES
        INTERFACE_COMPILE_DEFINITIONS "PYTHON_EXECUTABLE=\"${Python_EXECUTABLE}\""
    )

    # Attempt to create an alias (might not fully satisfy the check)
    add_library(Python::Module ALIAS MyFakePythonModule)
else()
    # Find Python
    find_package(Python COMPONENTS Interpreter Development REQUIRED)
endif()
```


To avoid this, we overwrite the build-prefix FindPython with a custom one in the cross-python activation script.
We build `pyb2d3` with the described changed to see if this works!


Not only the `CMakeLists.txt` are drastically simplified, but also the build script.
(see the diff)