### PR TITLE
Add default python flags to env var PIP_ARGS

### DIFF
--- a/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
+++ b/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
@@ -63,7 +63,7 @@ if [[ "${PYTHONPATH}" != "" ]]; then
 fi
 export PYTHONPATH=$BUILD_PREFIX/venv/lib/python$PY_VER/site-packages
 export PYTHON=$PYTHON_HOST # This should be a script to set up the cross env
-export PY_ARGS="--prefix=$PREFIX --no-deps -vv"
+export PIP_ARGS="--prefix=$PREFIX --no-deps -vv"
 
 # Set up flags
 export LDFLAGS="$EM_FORGE_SIDE_MODULE_LDFLAGS"

--- a/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
+++ b/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
@@ -63,6 +63,7 @@ if [[ "${PYTHONPATH}" != "" ]]; then
 fi
 export PYTHONPATH=$BUILD_PREFIX/venv/lib/python$PY_VER/site-packages
 export PYTHON=$PYTHON_HOST # This should be a script to set up the cross env
+export PY_ARGS="--prefix=$PREFIX --no-deps -vv"
 
 # Set up flags
 export LDFLAGS="$EM_FORGE_SIDE_MODULE_LDFLAGS"

--- a/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 8
+  number: 9
 
 requirements:
   run:

--- a/recipes/recipes_emscripten/pyrsistent/build.sh
+++ b/recipes/recipes_emscripten/pyrsistent/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-${PYTHON} -m pip  install .

--- a/recipes/recipes_emscripten/pyrsistent/recipe.yaml
+++ b/recipes/recipes_emscripten/pyrsistent/recipe.yaml
@@ -11,7 +11,8 @@ source:
   sha256: d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96
 
 build:
-  number: 0
+  number: 1
+  script: ${{ PYTHON }} -m pip install . ${{ PY_ARGS }}
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/pyrsistent/recipe.yaml
+++ b/recipes/recipes_emscripten/pyrsistent/recipe.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 1
-  script: ${{ PYTHON }} -m pip install . ${{ PY_ARGS }}
+  script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/pysocks/recipe.yaml
+++ b/recipes/recipes_emscripten/pysocks/recipe.yaml
@@ -10,8 +10,8 @@ source:
   sha256: 3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0
 
 build:
-  number: 0
-  script: ${{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1
+  script: ${{ PYTHON }} -m pip install . ${{ PY_ARGS }}
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/pysocks/recipe.yaml
+++ b/recipes/recipes_emscripten/pysocks/recipe.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 1
-  script: ${{ PYTHON }} -m pip install . ${{ PY_ARGS }}
+  script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/pywavelets/recipe.yaml
+++ b/recipes/recipes_emscripten/pywavelets/recipe.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 2
-  script: ${{ PYTHON }} -m pip install . ${{ PY_ARGS }}
+  script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/pywavelets/recipe.yaml
+++ b/recipes/recipes_emscripten/pywavelets/recipe.yaml
@@ -14,8 +14,8 @@ source:
   - 0001-prevent-double-definition-linking.patch
 
 build:
-  number: 1
-  script: ${{ PYTHON }} -m pip install . --no-deps -vv
+  number: 2
+  script: ${{ PYTHON }} -m pip install . ${{ PY_ARGS }}
 
 requirements:
   build:


### PR DESCRIPTION
This simplifies how python packages are built.

```bash
${PYTHON} -m pip install . ${PIP_ARGS}
```