### PR TITLE
Fix llvm recipe (adding back patch for generating llvm-tblgen)

### DIFF
--- a/recipes/recipes_emscripten/llvm/patches/cross_compile.patch
+++ b/recipes/recipes_emscripten/llvm/patches/cross_compile.patch
@@ -1,0 +1,15 @@
+diff --git a/llvm/cmake/modules/CrossCompile.cmake b/llvm/cmake/modules/CrossCompile.cmake
+index 6af47b51d4c6..c635e7f5be9e 100644
+--- a/llvm/cmake/modules/CrossCompile.cmake
++++ b/llvm/cmake/modules/CrossCompile.cmake
+@@ -70,8 +70,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
+   add_custom_command(OUTPUT ${${project_name}_${target_name}_BUILD}/CMakeCache.txt
+     COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
+         -DCMAKE_MAKE_PROGRAM="${CMAKE_MAKE_PROGRAM}"
+-        -DCMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER}"
+-        -DCMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}"
++        -DCMAKE_C_COMPILER="clang"
++        -DCMAKE_CXX_COMPILER="clang++"
+         ${CROSS_TOOLCHAIN_FLAGS_${target_name}} ${CMAKE_CURRENT_SOURCE_DIR}
+         ${CROSS_TOOLCHAIN_FLAGS_${project_name}_${target_name}}
+         -DLLVM_TARGET_IS_CROSSCOMPILE_HOST=TRUE

--- a/recipes/recipes_emscripten/llvm/recipe.yaml
+++ b/recipes/recipes_emscripten/llvm/recipe.yaml
@@ -10,6 +10,7 @@ source:
     }}.tar.gz
   sha256: afa487c401613f5e4a35935b2abfb5d07e6ebfa20df32787e34a5c7e97c6ea4b
   patches:
+  - patches/cross_compile.patch
   - patches/shift_temporary_files_to_tmp_dir.patch
   - patches/enable_exception_handling.patch
   - patches/fix_initialization_logs.patch
@@ -17,7 +18,7 @@ source:
   - patches/fix_clang_keywords.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -25,7 +26,6 @@ requirements:
   - ${{ compiler("cxx") }}
   - cmake
   - make    # [unix]
-  - llvm-tblgen
 
 tests:
 - package_contents:


### PR DESCRIPTION
After we started making use of a separate llvm-tblgen recipe (and not generating it at build time)

https://github.com/emscripten-forge/recipes/tree/main/recipes/recipes/llvm-tblgen

we have been seeing these errors 

![image](https://github.com/user-attachments/assets/252a79f2-7264-487e-94cd-afa919d79c32)


