### PR TITLE
vim: disable automatic backups by default

### DIFF
--- a/recipes/recipes_emscripten/vim/build.sh
+++ b/recipes/recipes_emscripten/vim/build.sh
@@ -37,10 +37,13 @@ emconfigure ./configure \
     ac_cv_sizeof_off_t=4 \
     ac_cv_sizeof_time_t=4
 
-# Use /etc/vimrc for system vimrc file and turn some features on.
+# Use /etc/vimrc for system vimrc file and turn some features on and off.
 sed -ri "s/.*(#define SYS_VIMRC_FILE\s.*)/\1/" src/feature.h
 echo "syntax on" > $VIMRC
 echo "set termguicolors" >> $VIMRC
+echo "set nobackup" >> $VIMRC
+echo "set noswapfile" >> $VIMRC
+echo "set nowritebackup" >> $VIMRC
 
 # Installs runtime config files under $PWD/usr/local/share/vim
 DESTDIR=$PWD make -C src installruntime

--- a/recipes/recipes_emscripten/vim/recipe.yaml
+++ b/recipes/recipes_emscripten/vim/recipe.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-const-char-args.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
In `vim`, disable automatic writing of backup files via settings in `vimrc` file. Can be re-enabled at runtime by users if desired.