### PR TITLE
Add recipe for `less` to run in `cockle`

### DIFF
--- a/recipes/recipes_emscripten/less/build.sh
+++ b/recipes/recipes_emscripten/less/build.sh
@@ -1,0 +1,50 @@
+export NCURSES_CFLAGS=$($PREFIX/bin/ncurses6-config --cflags)
+export NCURSES_LDFLAGS=$($PREFIX/bin/ncurses6-config --libs)
+export TERMINFO=$($PREFIX/bin/ncurses6-config --terminfo)
+export XTERM_256COLOR=$TERMINFO/x/xterm-256color
+
+echo $NCURSES_CFLAGS
+echo $NCURSES_LDFLAGS
+ls -l $XTERM_256COLOR
+
+export CONFIG_CFLAGS="\
+    $NCURSES_CFLAGS \
+    -Os \
+    -Wno-incompatible-function-pointer-types \
+    "
+
+export CONFIG_LDFLAGS="\
+    $NCURSES_LDFLAGS \
+    -Os \
+    --minify=0 \
+    -sALLOW_MEMORY_GROWTH=1 \
+    -sEXIT_RUNTIME=1 \
+    -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY \
+    -sFORCE_FILESYSTEM=1 \
+    -sMODULARIZE=1 \
+    -sLZ4 \
+    "
+
+# Use same return type for signals that is used in ncurses.
+sed -i -e 's/#define RETSIGTYPE void/#define RETSIGTYPE int/g' defines.h.in
+
+# Use ncurses' winch not local copy.
+sed -i -e 's/RETSIGTYPE winch/RETSIGTYPE notwinch/g' signal.c
+
+emconfigure ./configure \
+    --host=wasm32-unknown-emscripten \
+    CFLAGS="$CFLAGS $CONFIG_CFLAGS" \
+    LDFLAGS="$LDFLAGS $CONFIG_LDFLAGS" \
+    ac_cv_func__setjmp=no \
+    ac_cv_func_popen=no \
+    ac_cv_func_sigprocmask=no
+
+# Build less but not lessecho and lesskey.
+emmake make less.js EXEEXT=.js -j${CPU_COUNT} LDFLAGS=" \
+    $LDFLAGS \
+    $CONFIG_LDFLAGS \
+    --preload-file $XTERM_256COLOR@/usr/local/share/terminfo/x/xterm-256color \
+    "
+
+mkdir -p $PREFIX/bin
+cp less.{data,js,wasm} $PREFIX/bin/

--- a/recipes/recipes_emscripten/less/recipe.yaml
+++ b/recipes/recipes_emscripten/less/recipe.yaml
@@ -1,0 +1,45 @@
+context:
+  name: less
+  version: 668
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://ftp.gnu.org/gnu/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 2819f55564d86d542abbecafd82ff61e819a3eec967faa36cd3e68f1596a44b8
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - make
+    - autoconf
+  host:
+    - ncurses <6.5
+
+tests:
+  - script:
+    - test -f $PREFIX/bin/less.data
+    - test -f $PREFIX/bin/less.js
+    - test -f $PREFIX/bin/less.wasm
+  - script: |
+      OUTPUT=$(run_modularized $PREFIX/bin/less.js --version | head -1 | cut -c -9)
+      if [[ "$OUTPUT" != "less 668 " ]]; then
+        echo "Unexpected output: $OUTPUT"
+        exit 1
+      fi
+    requirements:
+      build:
+        - run_modularized >= 0.1.2
+
+about:
+  license: GPL-3.0-only
+  license_file: COPYING
+
+extra:
+  recipe-maintainers:
+    - ianthomas23


### PR DESCRIPTION
Add recipe for `less` command to run in `cockle`. It is similar to the other `cockle` command recipes that use `ncurses`.