### PR TITLE
Remove backup files in cross-python

### DIFF
--- a/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
+++ b/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
@@ -47,7 +47,7 @@ if [[ ! -d "$BUILD_PREFIX/venv" ]]; then
   rm -r $BUILD_PREFIX/venv/lib/python$PY_VER/site-packages
   ln -s $BUILD_PREFIX/lib/python$PY_VER/site-packages \
         $BUILD_PREFIX/venv/lib/python$PY_VER/site-packages
-  sed -i.bak "s@$BUILD_PREFIX/venv/lib@$BUILD_PREFIX/venv/lib', '$BUILD_PREFIX/venv/lib/python$PY_VER/site-packages@g" $PYTHON_HOST
+  sed -i "s@$BUILD_PREFIX/venv/lib@$BUILD_PREFIX/venv/lib', '$BUILD_PREFIX/venv/lib/python$PY_VER/site-packages@g" $PYTHON_HOST
 
   # Copy the sysconfigdata file
   rm $BUILD_PREFIX/venv/lib/_sysconfigdata__emscripten_wasm32-emscripten.py

--- a/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 9
+  number: 10
 
 requirements:
   run:


### PR DESCRIPTION
The backup files such as `bin/python.bak` are accidentally packaged in other Python packages, so instead, this prevents the creation of backup files which are not needed.