### PR TITLE
Replicate CppInterOp's llvm build

### DIFF
--- a/recipes/recipes_emscripten/llvm/build.sh
+++ b/recipes/recipes_emscripten/llvm/build.sh
@@ -6,6 +6,16 @@ cd build
 export CMAKE_PREFIX_PATH=$PREFIX
 export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
 
+unset EM_FORGE_OPTFLAGS
+unset EM_FORGE_DBGFLAGS
+unset EM_FORGE_LDFLAGS_BASE
+unset EM_FORGE_CFLAGS_BASE
+unset EM_FORGE_SIDE_MODULE_LDFLAGS
+unset EM_FORGE_SIDE_MODULE_CFLAGS
+
+unset CFLAGS
+unset LDFLAGS
+
 # Configure step
 emcmake cmake -S ../llvm -B .         \
     -DCMAKE_BUILD_TYPE=Release                      \
@@ -14,8 +24,6 @@ emcmake cmake -S ../llvm -B .         \
     -DLLVM_HOST_TRIPLE=wasm32-unknown-emscripten    \
     -DLLVM_TARGETS_TO_BUILD="WebAssembly"           \
     -DLLVM_ENABLE_ASSERTIONS=ON                     \
-    -DLLVM_ENABLE_EH=ON                             \
-    -DLLVM_ENABLE_RTTI=ON                           \
     -DLLVM_INCLUDE_BENCHMARKS=OFF                   \
     -DLLVM_INCLUDE_EXAMPLES=OFF                     \
     -DLLVM_INCLUDE_TESTS=OFF                        \
@@ -29,9 +37,8 @@ emcmake cmake -S ../llvm -B .         \
     -DCLANG_ENABLE_ARCMT=OFF                        \
     -DCLANG_ENABLE_BOOTSTRAP=OFF                    \
     -DCLANG_BUILD_TOOLS=OFF                         \
-    -DCMAKE_CXX_FLAGS="-Dwait4=__syscall_wait4 -fexceptions" \
-    -DLLVM_TABLEGEN=$BUILD_PREFIX/bin/llvm-tblgen \
-    -DCLANG_TABLEGEN=$BUILD_PREFIX/bin/clang-tblgen 
+    -DCMAKE_CXX_FLAGS="-Dwait4=__syscall_wait4" \
+    -DLLVM_NATIVE_TOOL_DIR=$BUILD_PREFIX/bin/
 
 # Build and Install step
 emmake make clangInterpreter lldWasm -j16 install

--- a/recipes/recipes_emscripten/llvm/recipe.yaml
+++ b/recipes/recipes_emscripten/llvm/recipe.yaml
@@ -18,7 +18,7 @@ source:
   - patches/fix_clang_keywords.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
Problem:

At this point, we've tired quite some things to get the llvm build working. It is just the `nlohmann/json.hpp` header that is troubling is (by itself or while being included by xwidgets/xcanvas etc). This has lot of template influence and llvm ends up in a recursive infinite loop calling `printTemplateSpecializationBefore`

Approach:

Building llvm locally without any configs inspired by emscripten-forge or the patched emsdk works perfectly.
This is what CppInterOp is doing 
https://github.com/compiler-research/CppInterOp/blob/main/.github/workflows/emscripten.yml#L207-L228

And the link on their main is working perfectly 

![image](https://github.com/user-attachments/assets/8a739623-ac4d-4912-8532-2c976f60f3a4)

https://compiler-research.org/CppInterOp/lab/index.html

Hence this PR tries to replicate the build there.