### PR TITLE
Minor fix in cross-python

### DIFF
--- a/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
+++ b/recipes/recipes/cross-python_emscripten-wasm32/activate.sh
@@ -83,7 +83,7 @@ if compgen -G "${BUILD_PREFIX}/conda-meta/cmake-*.json" > /dev/null; then
   CMAKE_VERSION=""
   if command -v cmake &> /dev/null; then
       # cmake is found, try to get the version
-      if CMAKE_VERSION_OUTPUT=$(cmake --version 2>&1); then
+      if CMAKE_VERSION_OUTPUT=$($BUILD_PREFIX/bin/cmake --version 2>&1); then
           # Command succeeded
           CMAKE_VERSION=$(echo "$CMAKE_VERSION_OUTPUT" | head -n 1 | cut -d ' ' -f 3)
           echo "CMake version: $CMAKE_VERSION"

--- a/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-python_emscripten-wasm32/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 10
+  number: 11
 
 requirements:
   run:


### PR DESCRIPTION
`cmake --version` defaults to `emcmake cmake --version`