### PR TITLE
`vim`: disable use of `ftruncate` system call

### DIFF
--- a/recipes/recipes_emscripten/vim/build.sh
+++ b/recipes/recipes_emscripten/vim/build.sh
@@ -35,7 +35,8 @@ emconfigure ./configure \
     ac_cv_sizeof_int=4 \
     ac_cv_sizeof_long=8 \
     ac_cv_sizeof_off_t=4 \
-    ac_cv_sizeof_time_t=4
+    ac_cv_sizeof_time_t=4 \
+    ac_cv_func_ftruncate=no
 
 # Use /etc/vimrc for system vimrc file and turn some features on and off.
 sed -ri "s/.*(#define SYS_VIMRC_FILE\s.*)/\1/" src/feature.h

--- a/recipes/recipes_emscripten/vim/recipe.yaml
+++ b/recipes/recipes_emscripten/vim/recipe.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-const-char-args.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
Disable use of `ftruncate` system call in `vim`. Fixes JupyterLite terminal issue jupyterlite/terminal#59.