### PR TITLE
[bot] Handle recipes with source paths

### DIFF
--- a/emci/bot/bump_recipes_versions.py
+++ b/emci/bot/bump_recipes_versions.py
@@ -91,7 +91,7 @@ def get_new_version(recipe_file):
     return None, None,None
 
 
-def update_recipe_version(recipe_file, new_version, new_sha256, is_ratler):
+def update_recipe_version(recipe_file, new_version, new_sha256, is_rattler):
 
     # read the file
     with open(recipe_file) as file:
@@ -166,12 +166,12 @@ def bump_recipe_version(recipe_dir, target_pr_branch_name):
         for recipe_fname, is_rattler in recipe_locations:
             if (recipe_dir / recipe_fname).exists():
                 recipe_file = recipe_dir / recipe_fname
-                update_recipe_version(recipe_file, new_version=new_version, new_sha256=new_sha256, is_ratler=is_rattler)
+                update_recipe_version(recipe_file, new_version=new_version, new_sha256=new_sha256, is_rattler=is_rattler)
 
         # commit the changes and make a PR
         pr_title = make_pr_title(name, current_version, new_version, target_pr_branch_name)
         print(f"Making PR for {name} with title: {pr_title} with target branch {target_pr_branch_name}")
-        make_pr_for_recipe(recipe_dir=recipe_dir, pr_title=pr_title, branch_name=branch_name, 
+        make_pr_for_recipe(recipe_dir=recipe_dir, pr_title=pr_title, branch_name=branch_name,
             target_branch_name=target_pr_branch_name,
             automerge=automerge)
 


### PR DESCRIPTION
Many recipes fail to be updated if they have a path listed under sources.
```yaml
source:
- url: https://github.com/python-pillow/Pillow/archive/refs/tags/${{ version }}.tar.gz
  sha256: 5a2f1a812237bf9bd57f283422f46ca97a1c3d43d5f67b9bf8a0d499c4b97c85
  patches:
  - patches/setitup.patch
- path: src/setup.cfg
- path: setup.py
```

This excludes those paths.