### PR TITLE
xeus-python: Remove jedi dependency

### DIFF
--- a/recipes/recipes_emscripten/xeus-python/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-python/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5b465638561019469c32974998b6f4bcde0b38c243c0b6f50bc5b001a4d78b4f
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -31,7 +31,6 @@ requirements:
   run:
   - python
   - ipython
-  - jedi
   - xeus-python-shell >=0.6.0,<0.7
   - pyjs >=2,<3
 


### PR DESCRIPTION
Interestingly, we don't use jedi for the WASM build of xeus-python https://github.com/jupyter-xeus/xeus-python/blob/57b5416650fbfccdce9adb6747fe569961c77eb1/src/xinterpreter_wasm.cpp#L44

But it is listed as a dependency in the emscripten-forge recipe https://github.com/emscripten-forge/recipes/blob/main/recipes/recipes_emscripten/xeus-python/recipe.yaml#L34

So we should remove it from the recipe