### PR TITLE
Add narwhals

### DIFF
--- a/recipes/recipes_emscripten/narwhals/recipe.yaml
+++ b/recipes/recipes_emscripten/narwhals/recipe.yaml
@@ -1,0 +1,49 @@
+context:
+  name: narwhals
+  version: 1.44.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/narwhals-${{ version }}.tar.gz
+  sha256: 8cf0616d4f6f21225b3b56fcde96ccab6d05023561a0f162402aa9b8c33ad31d
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - python
+    - cross-python_emscripten-wasm32
+    - pip
+    - hatchling
+  host:
+    - python
+  run:
+    - python
+
+tests:
+  - script: pytester
+    files:
+      recipe:
+        - test_import_narwhals.py
+    requirements:
+      build:
+        - pytester
+      run:
+        - pytester-run
+
+about:
+  summary: Extremely lightweight compatibility layer between pandas, Polars, cuDF, and Modin
+  license: MIT
+  license_file: LICENSE.md
+  homepage: https://marcogorelli.github.io/narwhals/
+  repository: https://github.com/MarcoGorelli/narwhals
+
+extra:
+  recipe-maintainers:
+    - jjerphan 

--- a/recipes/recipes_emscripten/narwhals/test_import_narwhals.py
+++ b/recipes/recipes_emscripten/narwhals/test_import_narwhals.py
@@ -1,0 +1,6 @@
+def test_import_narwhals():
+    import narwhals
+
+    # Test basic import functionality
+    print("Successfully imported narwhals")
+    print(f"narwhals version: {narwhals.__version__}") 


### PR DESCRIPTION
One of the dependencies of `skore`, also useful for different workflows using dataframes for non-exclusively scikit-learn et al (see https://github.com/scikit-learn/scikit-learn/issues/31049).

Also a first contribution to `emscripten-forge`.