### PR TITLE
Iterate over a larger version range

### DIFF
--- a/emci/bot/next_version.py
+++ b/emci/bot/next_version.py
@@ -97,13 +97,23 @@ def next_version(ver: str, increment_alpha: bool = False) -> Iterator[str]:
         try:
             t = int(ver_split[k])
             is_num = True
+            is_patch_ver = (k == len(ver_split) - 1) # the last element
+            is_major_ver = (k == 0) # the first element
         except Exception:
             is_num = False
 
         if is_num:
-            ver_split[k] = str(t + 1)
-            yield "".join(ver_split)
-            ver_split[k] = "0"
+            n_bumps = 1 if is_major_ver else 3
+            for ver_bump in range(1, n_bumps + 1):
+                ver_split[k] = str(t + ver_bump)
+                if not is_patch_ver and k + 2 < len(ver_split):
+                    for i_bump in range(0, 3):
+                        ver_split[k + 2] = str(i_bump)
+                        yield "".join(ver_split)
+                        ver_split[k + 2] = "0"
+                else:
+                    yield "".join(ver_split)
+                    ver_split[k] = "0"
         elif increment_alpha and ver_split[k].isalpha() and len(ver_split[k]) == 1:
             ver_split[k] = chr(ord(ver_split[k]) + 1)
             yield "".join(ver_split)


### PR DESCRIPTION
### Before

Many packages do not strictly follow version updates and oftentimes skip consecutive numbering. Currently, the bot is not able to update such packages because it only checks for the next consecutive number.

```
Next versions for 4.9.4: ['4.9.5', '4.10.0', '5.0.0']

Next versions for 7.3-65: ['7.3-66', '7.4-0', '8.0-0']

Next versions for 1.5: ['1.6', '2.0']

Next versions for 4.6.0-1: ['4.6.0-2', '4.6.1-0', '4.7.0-0', '5.0.0-0']

Next versions for 1.0.0a1: ['1.0.1a1', '1.1.0a1', '2.0.0a1']
```

### After

This PR changes the logic so that it can check for 3 consecutive version numbers in the minor and patch version numbers, to hopefully catch more package updates. This range can also be easily increased.


```
Next versions for 4.9.4: ['4.9.5', '4.9.6', '4.9.7', '4.10.0', '4.10.1', '4.10.2', '4.11.0', '4.11.1', '4.11.2', '4.12.0', '4.12.1', '4.12.2', '5.0.0', '5.1.0', '5.2.0']

Next versions for 7.3-65: ['7.3-66', '7.3-67', '7.3-68', '7.4-0', '7.4-1', '7.4-2', '7.5-0', '7.5-1', '7.5-2', '7.6-0', '7.6-1', '7.6-2', '8.0-0', '8.1-0', '8.2-0']

Next versions for 1.5: ['1.6', '1.7', '1.8', '2.0', '2.1', '2.2']

Next versions for 4.6.0-1: ['4.6.0-2', '4.6.0-3', '4.6.0-4', '4.6.1-0', '4.6.1-1', '4.6.1-2', '4.6.2-0', '4.6.2-1', '4.6.2-2', '4.6.3-0', '4.6.3-1', '4.6.3-2', '4.7.0-0', '4.7.1-0', '4.7.2-0', '4.8.0-0', '4.8.1-0', '4.8.2-0', '4.9.0-0', '4.9.1-0', '4.9.2-0', '5.0.0-0', '5.1.0-0', '5.2.0-0']

Next versions for 1.0.0a1: ['1.0.1a1', '1.0.2a1', '1.0.3a1', '1.1.0a1', '1.1.1a1', '1.1.2a1', '1.2.0a1', '1.2.1a1', '1.2.2a1', '1.3.0a1', '1.3.1a1', '1.3.2a1', '2.0.0a1', '2.1.0a1', '2.2.0a1']
```