### PR TITLE
Attempt to get xeus-cpp-lite on iphone

### DIFF
--- a/recipes/recipes_emscripten/cppinterop/build.sh
+++ b/recipes/recipes_emscripten/cppinterop/build.sh
@@ -4,6 +4,16 @@ cd build
 export CMAKE_PREFIX_PATH=$PREFIX
 export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
 
+unset EM_FORGE_OPTFLAGS
+unset EM_FORGE_DBGFLAGS
+unset EM_FORGE_LDFLAGS_BASE
+unset EM_FORGE_CFLAGS_BASE
+unset EM_FORGE_SIDE_MODULE_LDFLAGS
+unset EM_FORGE_SIDE_MODULE_CFLAGS
+
+unset CFLAGS
+unset LDFLAGS
+
 # Configure step
 emcmake cmake -DCMAKE_BUILD_TYPE=Release               \
     -DCMAKE_PREFIX_PATH=$PREFIX                        \

--- a/recipes/recipes_emscripten/cppinterop/recipe.yaml
+++ b/recipes/recipes_emscripten/cppinterop/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 7208cee5da55043b9d121a7f0236ef09daada4a1c517b3bed611530eee325622
 
 build:
-  number: 5
+  number: 6
 
 requirements:
   build:


### PR DESCRIPTION
We currently have 4 main links for xeus-cpp-lite 

1) Cppinterop's deploy on their main : https://compiler-research.org/CppInterOp/lab/index.html

This builds llvm and cppinterop in the CI -> fetches xeus-cpp's main branch and then builds xeus-cpp-lite

2) Xeus-cpp's deployment on main : https://compiler-research.org/xeus-cpp/lab/index.html

Uses cppinterop from emscripten-forge and xeus-cpp's upstream 

3) Demo link used for blog through template repo : https://compiler-research.org/xeus-cpp-wasm/lab/index.html
4) Jupyter try page link : https://jupyter.org/try-jupyter/lab/index.html

Uses everything from emscripten-forge.