### PR TITLE
Switch `run_modularized` to be `noarch`

### DIFF
--- a/recipes/recipes/run_modularized/recipe.yaml
+++ b/recipes/recipes/run_modularized/recipe.yaml
@@ -7,7 +7,8 @@ package:
   version: ${{ version }}
 
 build:
-  number: 2
+  number: 3
+  noarch: generic
 
 requirements:
   run:


### PR DESCRIPTION
Switch `run_modularized` to be `noarch` instead of platform-specific (currently it is `linux-64`). The packaged code is pure JavaScript so it makes sense for it to be `noarch`.

Thanks to @DerThorsten for the specific changes.