### PR TITLE
git2cpp: Update to use patched libgit2 and CORS proxy

### DIFF
--- a/recipes/recipes_emscripten/git2cpp/build.sh
+++ b/recipes/recipes_emscripten/git2cpp/build.sh
@@ -1,17 +1,21 @@
 export CONFIG_CXXFLAGS="\
     -Os \
     -I$BUILD_PREFIX/include \
+    -Wno-deprecated-declarations \
     -fexceptions \
     "
+
+# stringToNewUTF8 and writeArrayToMemory are used by libgit2.
 export CONFIG_LDFLAGS="\
     -Os \
     --minify=0 \
     -sALLOW_MEMORY_GROWTH=1 \
     -sEXIT_RUNTIME=1 \
-    -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY \
+    -sEXPORTED_RUNTIME_METHODS=FS,ENV,getEnvStrings,TTY,stringToNewUTF8,writeArrayToMemory \
     -sFORCE_FILESYSTEM=1 \
     -sMODULARIZE=1 \
     -fexceptions \
+    --post-js $RECIPE_DIR/post.js \
     "
 
 export CXXFLAGS="$CXXFLAGS $CONFIG_CXXFLAGS"

--- a/recipes/recipes_emscripten/git2cpp/post.js
+++ b/recipes/recipes_emscripten/git2cpp/post.js
@@ -1,0 +1,20 @@
+Module["libgit2_convert_url"] = (input_url) => {
+  // Convert URL to use CORS proxy based on env vars GIT_CORS_PROXY and GIT_CORS_PROXY_TYPE.
+  const url = new URL(input_url);
+  const env = Module["ENV"] ?? {};
+  const GIT_CORS_PROXY = env["GIT_CORS_PROXY"];
+  if (GIT_CORS_PROXY) {
+    const GIT_CORS_PROXY_TYPE = env["GIT_CORS_PROXY_TYPE"] ?? "prefix";
+    if (GIT_CORS_PROXY_TYPE == "prefix") {
+      return `${GIT_CORS_PROXY}${input_url}`;
+    } else if (GIT_CORS_PROXY_TYPE == "insert") {
+      let ret = `${url.protocol}//${GIT_CORS_PROXY}`;
+      if (ret.at(-1) != '/') {
+        ret += '/';
+      }
+      return `${ret}${url.host}${url.pathname}${url.search}`;
+    }
+    console.warn(`Invalid GIT_CORS_PROXY_TYPE of '${GIT_CORS_PROXY_TYPE}'`);
+  }
+  return input_url;
+};

--- a/recipes/recipes_emscripten/git2cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/git2cpp/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 3f1d7db6107a1425a1ff0dcb2c53a33eeedf882d24cfe25045f28dcb35474c14
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Rebuild `git2cpp` using the latest `libgit2` that supports `git clone` in the browser.

This includes a `post.js` file containing a `Module["libgit2_convert_url"]` function that is called by `libgit2` when attempting http(s) access of a remote repository. This function is used to modify the requested URL to allow a CORS proxy to be used. The implementation here reads the environment variables `GIT_CORS_PROXY` and `GIT_CORS_PROXY_TYPE` to convert the URL, and hence the CORS proxy to be used can be set at runtime without having to rebuild `libgit2` or `git2cpp`.

As example of how to use this, for the public proxy https://corsproxy.io you would set
```
GIT_CORS_PROXY='https://corsproxy.io/?url='
```
which uses the default `GIT_CORS_PROXY_TYPE` of `prefix` to put the `GIT_CORS_PROXY` in front of the originally requested URL.

Alternatively, to use a local https://github.com/isomorphic-git/cors-proxy on port 3000 you would set
```
GIT_CORS_PROXY="localhost:3000"
GIT_CORS_PROXY_TYPE="insert"
```