### PR TITLE
Add wasm-opt wrapper

### DIFF
--- a/recipes/recipes/emscripten_emscripten-wasm32/build_compiler_package.sh
+++ b/recipes/recipes/emscripten_emscripten-wasm32/build_compiler_package.sh
@@ -48,3 +48,9 @@ for file in $PREFIX/opt/emsdk/upstream/emscripten/*; do
     ln -sf $file $PREFIX/bin/
   fi
 done
+
+# Add wasm-opt wrapper. See NOTE in patches/wasm-opt-wrapper.
+EMSDK_DIR=$PREFIX/opt/emsdk/upstream
+mv $EMSDK_DIR/bin/wasm-opt $EMSDK_DIR/bin/wasm-opt-original
+cp $RECIPE_DIR/patches/wasm-opt-wrapper $EMSDK_DIR/bin/wasm-opt
+chmod +x $EMSDK_DIR/bin/wasm-opt

--- a/recipes/recipes/emscripten_emscripten-wasm32/patches/wasm-opt-wrapper
+++ b/recipes/recipes/emscripten_emscripten-wasm32/patches/wasm-opt-wrapper
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# NOTE:
+# This is only required when using an external LLVM which is newer than the LLVM
+# version used by Emscripten; that is the case for packages using LLVM + Flang
+# such as Octave.
+# This wrapper should likely be removed once this package is upgraded to >3.1.73
+# The removal of these two flags should have no effect in any other packages
+# since these options are simply not supported (yet).
+
+filtered_args=()
+for arg in "$@"; do
+    if [[ "$arg" != "--enable-bulk-memory-opt" && "$arg" != "--enable-call-indirect-overlong" ]]; then
+        filtered_args+=("$arg")
+    fi
+done
+
+$BUILD_PREFIX/opt/emsdk/upstream/bin/wasm-opt-original "${filtered_args[@]}"

--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -3,7 +3,7 @@ context:
   version: 3.1.73
 
 build:
-  number: 10
+  number: 11
 
 outputs:
   - package:


### PR DESCRIPTION
This wrapper filters out the options `--enable-bulk-memory-opt` and `--enable-call-indirect-overlong` which are not recognized by the `wasm-opt` version packaged in emscripten. These options are added when using the custom LLVM + Flang setup because it is a newer LLVM version; and this causes recipes like Octave and Xeus-Octave to fail.

Patching `wasm-opt` in the emscripten compiler package directly simplifies the recipes for Octave, Xeus-Octave, and any future Octave packages. Filtering out these arguments should have no effect in any of the other packages.