### PR TITLE
Update git2cpp to 0.0.4

### DIFF
--- a/recipes/recipes_emscripten/git2cpp/build.sh
+++ b/recipes/recipes_emscripten/git2cpp/build.sh
@@ -24,7 +24,8 @@ export LDFLAGS="$LDFLAGS $CONFIG_LDFLAGS"
 emcmake cmake \
     -Bbuild \
     -DCMAKE_PREFIX_PATH=$PREFIX \
-    -Dlibgit2_DIR=$PREFIX/lib/cmake/libgit2
+    -Dlibgit2_DIR=$PREFIX/lib/cmake/libgit2 \
+    -Dtermcolor_DIR=$BUILD_PREFIX/lib/cmake/termcolor
 
 cd build
 emmake make -j$CPU_COUNT

--- a/recipes/recipes_emscripten/git2cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/git2cpp/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: git2cpp
-  version: 0.0.3
+  version: 0.0.4
 
 package:
   name: ${{ name }}
@@ -8,16 +8,17 @@ package:
 
 source:
   url: https://github.com/QuantStack/${{ name }}/archive/refs/tags/${{ version }}.tar.gz
-  sha256: 3f1d7db6107a1425a1ff0dcb2c53a33eeedf882d24cfe25045f28dcb35474c14
+  sha256: 3750102d4a36ff4a584c4ff1f667387bb695c86d1bf5861f14c3b67b65fda718
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:
     - ${{ compiler("cxx") }}
     - cli11
     - cmake
+    - termcolor-cpp
   host:
     - libgit2>=1.9.0
 


### PR DESCRIPTION
Update `git2cpp` from 0.0.3 to 0.0.4. This involves adding a new header-only build dependency `termcolor-cpp`.