### PR TITLE
Building lldb-tblgen for lldb

### DIFF
--- a/recipes/recipes/llvm-tblgen/build.sh
+++ b/recipes/recipes/llvm-tblgen/build.sh
@@ -2,11 +2,17 @@
 
 mkdir build
 cd build
-cmake -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" ../llvm/
-make llvm-tblgen clang-tblgen -j$(nproc --all)
+cmake -DLLVM_ENABLE_PROJECTS="clang;lldb" \
+      -DLLVM_TARGETS_TO_BUILD=host \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_COMPILER=clang \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      ../llvm/
+make llvm-tblgen clang-tblgen lldb-tblgen -j$(nproc --all)
 
 mkdir -p $PREFIX/bin
 cp bin/llvm-tblgen $PREFIX/bin/
 cp bin/clang-tblgen $PREFIX/bin/
+cp bin/lldb-tblgen $PREFIX/bin/
 cp bin/llvm-lit $PREFIX/bin/
 cp bin/llvm-min-tblgen $PREFIX/bin/

--- a/recipes/recipes/llvm-tblgen/recipe.yaml
+++ b/recipes/recipes/llvm-tblgen/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: a6cbad9b2243b17e87795817cfff2107d113543a12486586f8a055a2bb044963
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -23,6 +23,7 @@ tests:
     files:
     - bin/llvm-tblgen
     - bin/clang-tblgen
+    - bin/lldb-tblgen
 
 about:
   license: Apache-2.0 WITH LLVM-exception


### PR DESCRIPTION
I don't have concrete proof if this idea can be put to use. This is experimental but something similar has been put to use in the past ([GitHub - jawilk/lldb2wasm: LLDB compiled to wasm with gdb-remote process plugin support.](https://github.com/jawilk/lldb2wasm/?tab=readme-ov-file))

Once I finish my experimentation (and if it doesn't go as per how I would like it). I will revert back to only having clang and lld through llvm as we have as of now.