### PR TITLE
Dropping nlohmann_json pin on xeus-cpp

### DIFF
--- a/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 679f4065490f49d7d5aee4639a0f44e1e70412421f5ad0a029ee21f76fb3e33e
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
   - make    # [unix]
   host:
   - nlohmann_json-abi
-  - nlohmann_json=3.12.0
+  - nlohmann_json
   - xeus-lite >=4.0,<5.0
   - xeus >=5.0.0,<6.0
   - cpp-argparse


### PR DESCRIPTION
Addressing https://github.com/emscripten-forge/recipes/pull/3008/files#r2376261328 (Bot merged it without being addressed last night)