### PR TITLE
Update python and node in emsdk package to match upstream emsdk

### DIFF
--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -3,7 +3,7 @@ context:
   version: 3.1.73
 
 build:
-  number: 12
+  number: 13
 
 outputs:
   - package:


### PR DESCRIPTION
@anutosh491 As requested here https://github.com/compiler-research/xeus-cpp/pull/400#issuecomment-3442404206 this will fix your issue where emsdk was using an outdated version of node, which caused issues with your tests running. 

The python change isn't strictly necessary but it will make Emscripten forges emsdk 3.1.73 recipe match the versions of node and python that the upstream emsdk uses for version 3.1.73 . i.e.

```
git clone https://github.com/emscripten-core/emsdk.git
./emsdk/emsdk install  3.1.73
Cloning into 'emsdk'...
remote: Enumerating objects: 4633, done.
remote: Counting objects: 100% (657/657), done.
remote: Compressing objects: 100% (51/51), done.
remote: Total 4633 (delta 632), reused 609 (delta 606), pack-reused 3976 (from 2)
Receiving objects: 100% (4633/4633), 2.65 MiB | 2.13 MiB/s, done.
Resolving deltas: 100% (3064/3064), done.
Resolving SDK version '3.1.73' to 'sdk-releases-b363a836e75a245c548b7a6a021822d8c9e4c6df-64bit'
Installing SDK 'sdk-releases-b363a836e75a245c548b7a6a021822d8c9e4c6df-64bit'..
Installing tool 'node-22.16.0-64bit'..
Downloading: /Users/username/emsdk/downloads/node-v22.16.0-darwin-arm64.tar.gz from https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/node-v22.16.0-darwin-arm64.tar.gz
############################################################################################################################################################################################################# 100.0%
Unpacking '/Users/username/emsdk/downloads/node-v22.16.0-darwin-arm64.tar.gz' to '/Users/username/emsdk/node/22.16.0_64bit'
Done installing tool 'node-22.16.0-64bit'.
Installing tool 'python-3.13.3-64bit'..
Downloading: /Users/username/emsdk/downloads/python-3.13.3-0-macos-arm64.tar.gz from https://storage.googleapis.com/webassembly/emscripten-releases-builds/deps/python-3.13.3-0-macos-arm64.tar.gz
############################################################################################################################################################################################################# 100.0%
Unpacking '/Users/username/emsdk/downloads/python-3.13.3-0-macos-arm64.tar.gz' to '/Users/username/emsdk/python/3.13.3_64bit'
Done installing tool 'python-3.13.3-64bit'.
Installing tool 'releases-b363a836e75a245c548b7a6a021822d8c9e4c6df-64bit'..
Downloading: /Users/username/emsdk/downloads/b363a836e75a245c548b7a6a021822d8c9e4c6df-wasm-binaries-arm64.tar.xz from https://storage.googleapis.com/webassembly/emscripten-releases-builds/mac/b363a836e75a245c548b7a6a021822d8c9e4c6df/wasm-binaries-arm64.tar.xz
############################################################################################################################################################################################################# 100.0%
Unpacking '/Users/username/emsdk/downloads/b363a836e75a245c548b7a6a021822d8c9e4c6df-wasm-binaries-arm64.tar.xz' to '/Users/username/emsdk/upstream'
Done installing tool 'releases-b363a836e75a245c548b7a6a021822d8c9e4c6df-64bit'.
Done installing SDK 'sdk-releases-b363a836e75a245c548b7a6a021822d8c9e4c6df-64bit'.
```

Assuming this PR is approved and goes in I will open up a minimal diff PR in xeus-cpp to take advantage of this change.