### PR TITLE
Enable color in CI logs

### DIFF
--- a/.github/workflows/build_recipes.yaml
+++ b/.github/workflows/build_recipes.yaml
@@ -15,6 +15,7 @@ jobs:
   build_recipes:
     runs-on: ubuntu-latest
     env:
+      FORCE_COLOR: 1
       TARGET_PLATFORM: emscripten-wasm32
       GITHUB_OWNER: "emscripten-forge"
     strategy:


### PR DESCRIPTION
The logs contain many ANSI escape codes which makes them difficult to read. Enabling color in the logs provides more readable text.

```
\x1b[1m============================= test session starts ==============================\x1b[0m
platform emscripten -- Python 3.13.1, pytest-8.4.2, pluggy-1.6.0
\x1b[1mcollecting ... \x1b[0m\x1b[1m
collected 1 item                                                               \x1b[0m
test_lz4.py \x1b[32m.\x1b[0m
```