### PR TITLE
Build coreutils on 4x branch

### DIFF
--- a/recipes/recipes_emscripten/coreutils/build.sh
+++ b/recipes/recipes_emscripten/coreutils/build.sh
@@ -15,8 +15,6 @@ export CONFIG_LDFLAGS="\
     "
 
 emconfigure ./configure \
-    --build=x86_64-linux-gnu \
-    --host=wasm32-unknown-emscripten \
     --disable-acl \
     --disable-nls \
     --disable-threads \
@@ -27,7 +25,12 @@ emconfigure ./configure \
     FORCE_UNSAFE_CONFIGURE=1 \
     TIME_T_32_BIT_OK=yes \
     ac_cv_have_decl_alarm=no \
-    gl_cv_func_sleep_works=yes
+    gl_cv_func_sleep_works=yes \
+    gl_cv_bitsizeof_ptrdiff_t=32 \
+    gl_cv_bitsizeof_sig_atomic_t=32 \
+    gl_cv_bitsizeof_size_t=32 \
+    gl_cv_bitsizeof_wchar_t=16 \
+    gl_cv_bitsizeof_wint_t=32
 
 echo "sed"
 sed -i 's|$(MAKE) src/make-prime-list$(EXEEXT)|gcc src/make-prime-list.c -o src/make-prime-list$(EXEEXT) -Ilib/|' Makefile

--- a/recipes/recipes_emscripten/coreutils/recipe.yaml
+++ b/recipes/recipes_emscripten/coreutils/recipe.yaml
@@ -1,25 +1,22 @@
 context:
-  version: "9.5"
   name: "coreutils"
+  version: "9.5"
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 source:
-  # url: https://github.com/coreutils/coreutils/archive/refs/tags/v${{version}}.tar.gz
-  # sha256: 7155d01f31bccf3387933ae3ba7ff1b313f15ed73ab13ccc5b211018a2d14636
   git: https://github.com/coreutils/coreutils
   tag: v9.5
 build:
-  number: 6
+  number: 0
 
 requirements:
   build:
     - ${{ compiler("c") }}
     - make  # [unix]
     - autoconf
-    # - autopoint
     - gettext
     - gperf
     - pkg-config
@@ -27,13 +24,15 @@ requirements:
     - help2man
     - automake
     - wget
+
 tests:
-  - script:
-    - test -f $PREFIX/bin/coreutils.js
-    - test -f $PREFIX/bin/coreutils.wasm
+- package_contents:
+    files:
+    - bin/coreutils.js
+    - bin/coreutils.wasm
 
 about:
-  license: 	GPL-3.0-only
+  license: GPL-3.0-only
   license_file: COPYING
 
 extra:


### PR DESCRIPTION
Build `coreutils` on `emscripten-4x` branch for `cockle`.