### PR TITLE
Rebuild xeus-lite on latest xeus

### DIFF
--- a/recipes/recipes_emscripten/xeus-lite/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-lite/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f2a57eaab24661aed5cf72dcda84089c788378aaf3bdfa27b207167fa4ae0a08
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
   - ninja
   host:
   - nlohmann_json
-  - xeus >=5.2.3
+  - xeus
 
 tests:
 - script:


### PR DESCRIPTION
xeus was updated to 5.2.4 on the 4-x branch. Hence rebuilding xeus-lite on top of the same.