### PR TITLE
libgit2: handle http errors better

### DIFF
--- a/recipes/recipes_emscripten/libgit2/recipe.yaml
+++ b/recipes/recipes_emscripten/libgit2/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 14cab3014b2b7ad75970ff4548e83615f74d719afe00aa479b4a889c1e13fc00
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -29,7 +29,7 @@ tests:
 
 about:
   homepage: https://github.com/libgit2/libgit2
-  license: GPL-2.0
+  license: GPL-2.0-only
   license_file: COPYING
 
 extra:


### PR DESCRIPTION
Modifications to the `libgit2` recipe on `main` to better handle http errors.