### PR TITLE
Rebuild git2cpp to use latest libgit2

### DIFF
--- a/recipes/recipes_emscripten/git2cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/git2cpp/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 3750102d4a36ff4a584c4ff1f667387bb695c86d1bf5861f14c3b67b65fda718
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Rebuild `git2cpp` to use latest `libgit2` on `main` branch.