### PR TITLE
Update xvega-bindings version to 0.1.2

### DIFF
--- a/recipes/recipes_emscripten/xvega-bindings/recipe.yaml
+++ b/recipes/recipes_emscripten/xvega-bindings/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: xvega-bindings
-  version: 0.1.0
+  version: 0.1.2
 
 package:
   name: ${{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/jupyter-xeus/${{ name }}/archive/refs/tags/${{ version }}.tar.gz
-  sha256: 0929eadf383971c32dbda67379c1cadddf232af70dca5584526b2c211c8876b7
+  sha256: 3c60b64587e8c0bdd57579724c875115d7b08efdb7948b3fc4907b3e39aeed31
 
 build:
   number: 0


### PR DESCRIPTION
Outdated because of https://github.com/emscripten-forge/recipes/blob/6f5fbd8aa783ed11585ac68a0cf8fc72add5ef28/emci/bot/bump_recipes_versions.py#L324-L328

Shouldn't this skip rule be removed for xvega-bindings ?