### PR TITLE
obspy: dependency adjustment and maintainer

### DIFF
--- a/recipes/recipes_emscripten/obspy/recipe.yaml
+++ b/recipes/recipes_emscripten/obspy/recipe.yaml
@@ -71,3 +71,4 @@ about:
 extra:
   recipe-maintainers:
   - DerThorsten
+  - MMesch


### PR DESCRIPTION
- numpy <2.3 seems to be a transitive constraint from scipy. This causes a bug when using obspy's dynamic loading of plugins/modules which checks version constraints.
- added myself as maintainer