### PR TITLE
Rebuild openblas-flang on main to support scipy

### DIFF
--- a/recipes/recipes_emscripten/openblas-flang/patches/0001-Remove-march-flags.patch
+++ b/recipes/recipes_emscripten/openblas-flang/patches/0001-Remove-march-flags.patch
@@ -1,86 +1,16 @@
-From 59dae6e8509b7b974eff7cc5dff5f5217b0cc666 Mon Sep 17 00:00:00 2001
+From 3ccdc39cfc3be211cf926cf78a748a8879416a93 Mon Sep 17 00:00:00 2001
 From: Isabel Paredes <isabel.paredes@quantstack.net>
-Date: Fri, 25 Apr 2025 14:29:53 +0200
-Subject: [PATCH 1/3] Remove -march flags
+Date: Mon, 8 Dec 2025 07:47:46 +0000
+Subject: [PATCH 1/8] Remove -march flags
 
 ---
- 0001-Add-Wno-return-type-flag.patch | 13 ++++++++++
- 0002-march.patch                    | 39 +++++++++++++++++++++++++++++
- Makefile.prebuild                   |  4 ---
- Makefile.riscv64                    |  4 ---
- Makefile.system                     |  2 +-
- 5 files changed, 53 insertions(+), 9 deletions(-)
- create mode 100644 0001-Add-Wno-return-type-flag.patch
- create mode 100644 0002-march.patch
+ Makefile.prebuild | 4 ----
+ Makefile.riscv64  | 4 ----
+ Makefile.system   | 2 +-
+ 3 files changed, 1 insertion(+), 9 deletions(-)
 
-diff --git a/0001-Add-Wno-return-type-flag.patch b/0001-Add-Wno-return-type-flag.patch
-new file mode 100644
-index 0000000..b1c64a3
---- /dev/null
-+++ b/0001-Add-Wno-return-type-flag.patch
-@@ -0,0 +1,13 @@
-+diff --git a/Makefile.rule b/Makefile.rule
-+index e57388844..3e2f23611 100644
-+--- a/Makefile.rule
-++++ b/Makefile.rule
-+@@ -256,7 +256,7 @@ NO_AFFINITY = 1
-+ # Common Optimization Flag;
-+ # The default -O2 is enough.
-+ # Flags for POWER8 are defined in Makefile.power. Don't modify COMMON_OPT
-+-# COMMON_OPT = -O2
-++COMMON_OPT = -O2 -Wno-implicit-function-declaration
-+ 
-+ # gfortran option for LAPACK to improve thread-safety
-+ # It is enabled by default in Makefile.system for gfortran
-\ No newline at end of file
-diff --git a/0002-march.patch b/0002-march.patch
-new file mode 100644
-index 0000000..23ea356
---- /dev/null
-+++ b/0002-march.patch
-@@ -0,0 +1,39 @@
-+diff --git a/Makefile.prebuild b/Makefile.prebuild
-+index b7d695a75..47cbcbf83 100644
-+--- a/Makefile.prebuild
-++++ b/Makefile.prebuild
-+@@ -71,10 +71,6 @@ ifeq ($(TARGET), RISCV64_ZVL128B)
-+ TARGET_FLAGS = -march=rv64imafdcv -mabi=lp64d
-+ endif
-+
-+-ifeq ($(TARGET), RISCV64_GENERIC)
-+-TARGET_FLAGS = -march=rv64imafdc -mabi=lp64d
-+-endif
-+-
-+ all: getarch_2nd
-+	./getarch_2nd  0 >> $(TARGET_MAKE)
-+	./getarch_2nd  1 >> $(TARGET_CONF)
-+diff --git a/Makefile.riscv64 b/Makefile.riscv64
-+index 9f6e48b7a..da9848a98 100644
-+--- a/Makefile.riscv64
-++++ b/Makefile.riscv64
-+@@ -14,7 +14,3 @@ ifeq ($(CORE), RISCV64_ZVL128B)
-+ CCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d 
-+ FCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d
-+ endif
-+-ifeq ($(CORE), RISCV64_GENERIC)
-+-CCOMMON_OPT += -march=rv64imafdc -mabi=lp64d
-+-FCOMMON_OPT += -march=rv64imafdc -mabi=lp64d
-+-endif
-+diff --git a/Makefile.system b/Makefile.system
-+index 7bae72855..f9b2c0e78 100644
-+--- a/Makefile.system
-++++ b/Makefile.system
-+@@ -202,7 +202,7 @@ endif
-+ # On x86_64 build getarch with march=native unless the compiler is PGI. This is required to detect AVX512 support in getarch.
-+ ifeq ($(HOSTARCH), x86_64)
-+ ifeq ($(findstring pgcc,$(HOSTCC))$(findstring nvc,$(HOSTCC)),)
-+-GETARCH_FLAGS += -march=native
-++# GETARCH_FLAGS += -march=native
-+ endif
-+ endif
-\ No newline at end of file
 diff --git a/Makefile.prebuild b/Makefile.prebuild
-index b7d695a..47cbcbf 100644
+index b7d695a75..47cbcbf83 100644
 --- a/Makefile.prebuild
 +++ b/Makefile.prebuild
 @@ -71,10 +71,6 @@ ifeq ($(TARGET), RISCV64_ZVL128B)
@@ -95,7 +25,7 @@ index b7d695a..47cbcbf 100644
  	./getarch_2nd  0 >> $(TARGET_MAKE)
  	./getarch_2nd  1 >> $(TARGET_CONF)
 diff --git a/Makefile.riscv64 b/Makefile.riscv64
-index 0ee26c1..bf21fd6 100644
+index 0ee26c1b5..bf21fd68d 100644
 --- a/Makefile.riscv64
 +++ b/Makefile.riscv64
 @@ -14,7 +14,3 @@ ifeq ($(CORE), RISCV64_ZVL128B)
@@ -107,7 +37,7 @@ index 0ee26c1..bf21fd6 100644
 -FCOMMON_OPT += -march=rv64imafdc -mabi=lp64d
 -endif
 diff --git a/Makefile.system b/Makefile.system
-index 38646c3..540d869 100644
+index 38646c3c6..540d8694c 100644
 --- a/Makefile.system
 +++ b/Makefile.system
 @@ -202,7 +202,7 @@ endif
@@ -119,3 +49,6 @@ index 38646c3..540d869 100644
  endif
  endif
  
+-- 
+2.51.0
+

--- a/recipes/recipes_emscripten/openblas-flang/patches/0002-Skip-linktest.patch
+++ b/recipes/recipes_emscripten/openblas-flang/patches/0002-Skip-linktest.patch
@@ -1,14 +1,14 @@
-From be03ff58d409ef42dc0b1df174130cd4a81c5a05 Mon Sep 17 00:00:00 2001
+From ff8c4ad19a31231053786857ae893302a2ca5b7e Mon Sep 17 00:00:00 2001
 From: Isabel Paredes <isabel.paredes@quantstack.net>
-Date: Fri, 20 Jun 2025 13:52:17 +0200
-Subject: [PATCH 2/3] Skip linktest
+Date: Mon, 8 Dec 2025 07:50:30 +0000
+Subject: [PATCH 2/8] Skip linktest
 
 ---
  exports/Makefile | 15 +++++++--------
  1 file changed, 7 insertions(+), 8 deletions(-)
 
 diff --git a/exports/Makefile b/exports/Makefile
-index 04fc64c..3354b0b 100644
+index 04fc64cfe..3354b0bad 100644
 --- a/exports/Makefile
 +++ b/exports/Makefile
 @@ -196,18 +196,18 @@ ifeq ($(F_COMPILER), INTEL)
@@ -63,3 +63,6 @@ index 04fc64c..3354b0b 100644
  
  linktest.c : $(GENSYM) ../Makefile.system ../getarch.c
  	./$(GENSYM) linktest  $(ARCH) "$(BU)" $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" $(BUILD_LAPACK_DEPRECATED) $(BUILD_BFLOAT16) $(BUILD_SINGLE) $(BUILD_DOUBLE) $(BUILD_COMPLEX) $(BUILD_COMPLEX16) > linktest.c
+-- 
+2.51.0
+

--- a/recipes/recipes_emscripten/openblas-flang/patches/0003-Add-emscripten-as-supported-arch.patch
+++ b/recipes/recipes_emscripten/openblas-flang/patches/0003-Add-emscripten-as-supported-arch.patch
@@ -1,14 +1,14 @@
-From 745af787860ce1faae6545c4684418a5232ce1f0 Mon Sep 17 00:00:00 2001
+From ed18218029bf9450205a2fee26a601b700b79588 Mon Sep 17 00:00:00 2001
 From: Isabel Paredes <isabel.paredes@quantstack.net>
-Date: Thu, 10 Jul 2025 15:10:26 +0200
-Subject: [PATCH 3/3] Add emscripten as supported arch
+Date: Mon, 8 Dec 2025 07:51:01 +0000
+Subject: [PATCH 3/8] Add emscripten as supported arch
 
 ---
  getarch.c | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/getarch.c b/getarch.c
-index b51c3ed..b1493ee 100644
+index b51c3ed64..b1493ee9f 100644
 --- a/getarch.c
 +++ b/getarch.c
 @@ -1895,6 +1895,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -23,3 +23,6 @@ index b51c3ed..b1493ee 100644
  #ifndef OPENBLAS_SUPPORTED
  #error "This arch/CPU is not supported by OpenBLAS."
  #endif
+-- 
+2.51.0
+

--- a/recipes/recipes_emscripten/openblas-flang/patches/0004-Add-dummy-length-arguments-for-char-arguments.patch
+++ b/recipes/recipes_emscripten/openblas-flang/patches/0004-Add-dummy-length-arguments-for-char-arguments.patch
@@ -1,0 +1,1860 @@
+From 07a0413ce52951076d9a53479af0b17d886dc734 Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Mon, 8 Dec 2025 07:59:50 +0000
+Subject: [PATCH 4/8] Add dummy length arguments for char arguments
+
+---
+ common_interface.h        | 548 +++++++++++++++++++-------------------
+ interface/gbmv.c          |   2 +-
+ interface/gemm.c          |   4 +-
+ interface/gemmt.c         |   6 +-
+ interface/gemv.c          |   4 +-
+ interface/lapack/getrf.c  |   2 +-
+ interface/lapack/getrs.c  |   2 +-
+ interface/lapack/lauu2.c  |   2 +-
+ interface/lapack/lauum.c  |   2 +-
+ interface/lapack/potf2.c  |   2 +-
+ interface/lapack/potrf.c  |   4 +-
+ interface/lapack/potri.c  |   2 +-
+ interface/lapack/trti2.c  |   2 +-
+ interface/lapack/trtri.c  |   2 +-
+ interface/lapack/trtrs.c  |   2 +-
+ interface/lapack/zgetrs.c |   2 +-
+ interface/lapack/zlauu2.c |   2 +-
+ interface/lapack/zlauum.c |   2 +-
+ interface/lapack/zpotf2.c |   2 +-
+ interface/lapack/zpotrf.c |   2 +-
+ interface/lapack/zpotri.c |   2 +-
+ interface/lapack/ztrti2.c |   2 +-
+ interface/lapack/ztrtri.c |   2 +-
+ interface/lapack/ztrtrs.c |   2 +-
+ interface/sbmv.c          |   2 +-
+ interface/spmv.c          |   2 +-
+ interface/spr.c           |   4 +-
+ interface/spr2.c          |   2 +-
+ interface/symm.c          |   4 +-
+ interface/symv.c          |   2 +-
+ interface/syr.c           |   6 +-
+ interface/syr2.c          |   4 +-
+ interface/syr2k.c         |   2 +-
+ interface/syrk.c          |   2 +-
+ interface/tbmv.c          |   2 +-
+ interface/tbsv.c          |   2 +-
+ interface/tpmv.c          |   2 +-
+ interface/tpsv.c          |   2 +-
+ interface/trmv.c          |   2 +-
+ interface/trsm.c          |   4 +-
+ interface/trsv.c          |   2 +-
+ interface/zgbmv.c         |   4 +-
+ interface/zgemv.c         |   8 +-
+ interface/zhbmv.c         |   2 +-
+ interface/zhemv.c         |   2 +-
+ interface/zher.c          |   2 +-
+ interface/zher2.c         |   2 +-
+ interface/zhpmv.c         |   2 +-
+ interface/zhpr.c          |   2 +-
+ interface/zhpr2.c         |   2 +-
+ interface/zsbmv.c         |   2 +-
+ interface/zspmv.c         |   2 +-
+ interface/zspr.c          |   2 +-
+ interface/zspr2.c         |   2 +-
+ interface/zsymv.c         |   2 +-
+ interface/zsyr.c          |   2 +-
+ interface/zsyr2.c         |   2 +-
+ interface/ztbmv.c         |   2 +-
+ interface/ztbsv.c         |   4 +-
+ interface/ztpmv.c         |   4 +-
+ interface/ztpsv.c         |   4 +-
+ interface/ztrmv.c         |   4 +-
+ interface/ztrsv.c         |   4 +-
+ kernel/generic/lsame.c    |   2 +-
+ 64 files changed, 357 insertions(+), 357 deletions(-)
+
+diff --git a/common_interface.h b/common_interface.h
+index efd3c6649..e35a21ac6 100644
+--- a/common_interface.h
++++ b/common_interface.h
+@@ -256,421 +256,421 @@ void BLASFUNC(xgerc)(blasint *,    blasint *, xdouble *, xdouble *, blasint *,
+ 		    xdouble *, blasint *, xdouble *, blasint *);
+ 
+ void BLASFUNC(sbgemv)(char *, blasint *, blasint *, float  *, bfloat16 *, blasint *,
+-            bfloat16  *, blasint *, float  *, float  *, blasint *);
++            bfloat16  *, blasint *, float  *, float  *, blasint *, int);
+ void BLASFUNC(sgemv)(char *, blasint *, blasint *, float  *, float  *, blasint *,
+-		    float  *, blasint *, float  *, float  *, blasint *);
++		    float  *, blasint *, float  *, float  *, blasint *, int);
+ void BLASFUNC(dgemv)(char *, blasint *, blasint *, double *, double *, blasint *,
+-		    double *, blasint *, double *, double *, blasint *);
++		    double *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(qgemv)(char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-		    xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++		    xdouble *, blasint *, xdouble *, xdouble *, blasint *, int);
+ void BLASFUNC(cgemv)(char *, blasint *, blasint *, float  *, float  *, blasint *,
+-		    float  *, blasint *, float  *, float  *, blasint *);
++		    float  *, blasint *, float  *, float  *, blasint *, int);
+ void BLASFUNC(zgemv)(char *, blasint *, blasint *, double *, double *, blasint *,
+-		    double *, blasint *, double *, double *, blasint *);
++		    double *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(xgemv)(char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-		    xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++		    xdouble *, blasint *, xdouble *, xdouble *, blasint *, int);
+ 
+ void BLASFUNC(strsv) (char *, char *, char *, blasint *, float  *, blasint *,
+-		     float  *, blasint *);
++		     float  *, blasint *, int, int, int);
+ void BLASFUNC(dtrsv) (char *, char *, char *, blasint *, double *, blasint *,
+-		     double *, blasint *);
++		     double *, blasint *, int, int, int);
+ void BLASFUNC(qtrsv) (char *, char *, char *, blasint *, xdouble *, blasint *,
+-		     xdouble *, blasint *);
++		     xdouble *, blasint *, int, int, int);
+ void BLASFUNC(ctrsv) (char *, char *, char *, blasint *, float  *, blasint *,
+-		     float  *, blasint *);
++		     float  *, blasint *, int, int, int);
+ void BLASFUNC(ztrsv) (char *, char *, char *, blasint *, double *, blasint *,
+-		     double *, blasint *);
++		     double *, blasint *, int, int, int);
+ void BLASFUNC(xtrsv) (char *, char *, char *, blasint *, xdouble *, blasint *,
+-		     xdouble *, blasint *);
++		     xdouble *, blasint *, int, int, int);
+ 
+ void BLASFUNC(strmv) (char *, char *, char *, blasint *, float  *, blasint *,
+-		     float  *, blasint *);
++		     float  *, blasint *, int, int, int);
+ void BLASFUNC(dtrmv) (char *, char *, char *, blasint *, double *, blasint *,
+-		     double *, blasint *);
++		     double *, blasint *, int, int, int);
+ void BLASFUNC(qtrmv) (char *, char *, char *, blasint *, xdouble *, blasint *,
+-		     xdouble *, blasint *);
++		     xdouble *, blasint *, int, int, int);
+ void BLASFUNC(ctrmv) (char *, char *, char *, blasint *, float  *, blasint *,
+-		     float  *, blasint *);
++		     float  *, blasint *, int, int, int);
+ void BLASFUNC(ztrmv) (char *, char *, char *, blasint *, double *, blasint *,
+-		     double *, blasint *);
++		     double *, blasint *, int, int, int);
+ void BLASFUNC(xtrmv) (char *, char *, char *, blasint *, xdouble *, blasint *,
+-		     xdouble *, blasint *);
+-
+-void BLASFUNC(stpsv) (char *, char *, char *, blasint *, float  *, float  *, blasint *);
+-void BLASFUNC(dtpsv) (char *, char *, char *, blasint *, double *, double *, blasint *);
+-void BLASFUNC(qtpsv) (char *, char *, char *, blasint *, xdouble *, xdouble *, blasint *);
+-void BLASFUNC(ctpsv) (char *, char *, char *, blasint *, float  *, float  *, blasint *);
+-void BLASFUNC(ztpsv) (char *, char *, char *, blasint *, double *, double *, blasint *);
+-void BLASFUNC(xtpsv) (char *, char *, char *, blasint *, xdouble *, xdouble *, blasint *);
+-
+-void BLASFUNC(stpmv) (char *, char *, char *, blasint *, float  *, float  *, blasint *);
+-void BLASFUNC(dtpmv) (char *, char *, char *, blasint *, double *, double *, blasint *);
+-void BLASFUNC(qtpmv) (char *, char *, char *, blasint *, xdouble *, xdouble *, blasint *);
+-void BLASFUNC(ctpmv) (char *, char *, char *, blasint *, float  *, float  *, blasint *);
+-void BLASFUNC(ztpmv) (char *, char *, char *, blasint *, double *, double *, blasint *);
+-void BLASFUNC(xtpmv) (char *, char *, char *, blasint *, xdouble *, xdouble *, blasint *);
+-
+-void BLASFUNC(stbmv) (char *, char *, char *, blasint *, blasint *, float  *, blasint *, float  *, blasint *);
+-void BLASFUNC(dtbmv) (char *, char *, char *, blasint *, blasint *, double *, blasint *, double *, blasint *);
+-void BLASFUNC(qtbmv) (char *, char *, char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *);
+-void BLASFUNC(ctbmv) (char *, char *, char *, blasint *, blasint *, float  *, blasint *, float  *, blasint *);
+-void BLASFUNC(ztbmv) (char *, char *, char *, blasint *, blasint *, double *, blasint *, double *, blasint *);
+-void BLASFUNC(xtbmv) (char *, char *, char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *);
+-
+-void BLASFUNC(stbsv) (char *, char *, char *, blasint *, blasint *, float  *, blasint *, float  *, blasint *);
+-void BLASFUNC(dtbsv) (char *, char *, char *, blasint *, blasint *, double *, blasint *, double *, blasint *);
+-void BLASFUNC(qtbsv) (char *, char *, char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *);
+-void BLASFUNC(ctbsv) (char *, char *, char *, blasint *, blasint *, float  *, blasint *, float  *, blasint *);
+-void BLASFUNC(ztbsv) (char *, char *, char *, blasint *, blasint *, double *, blasint *, double *, blasint *);
+-void BLASFUNC(xtbsv) (char *, char *, char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *);
++		     xdouble *, blasint *, int, int, int);
++
++void BLASFUNC(stpsv) (char *, char *, char *, blasint *, float  *, float  *, blasint *, int, int, int);
++void BLASFUNC(dtpsv) (char *, char *, char *, blasint *, double *, double *, blasint *, int, int, int);
++void BLASFUNC(qtpsv) (char *, char *, char *, blasint *, xdouble *, xdouble *, blasint *, int, int, int);
++void BLASFUNC(ctpsv) (char *, char *, char *, blasint *, float  *, float  *, blasint *, int, int, int);
++void BLASFUNC(ztpsv) (char *, char *, char *, blasint *, double *, double *, blasint *, int, int, int);
++void BLASFUNC(xtpsv) (char *, char *, char *, blasint *, xdouble *, xdouble *, blasint *, int, int, int);
++
++void BLASFUNC(stpmv) (char *, char *, char *, blasint *, float  *, float  *, blasint *, int, int, int);
++void BLASFUNC(dtpmv) (char *, char *, char *, blasint *, double *, double *, blasint *, int, int, int);
++void BLASFUNC(qtpmv) (char *, char *, char *, blasint *, xdouble *, xdouble *, blasint *, int, int, int);
++void BLASFUNC(ctpmv) (char *, char *, char *, blasint *, float  *, float  *, blasint *, int, int, int);
++void BLASFUNC(ztpmv) (char *, char *, char *, blasint *, double *, double *, blasint *, int, int, int);
++void BLASFUNC(xtpmv) (char *, char *, char *, blasint *, xdouble *, xdouble *, blasint *, int, int, int);
++
++void BLASFUNC(stbmv) (char *, char *, char *, blasint *, blasint *, float  *, blasint *, float  *, blasint *, int, int, int);
++void BLASFUNC(dtbmv) (char *, char *, char *, blasint *, blasint *, double *, blasint *, double *, blasint *, int, int, int);
++void BLASFUNC(qtbmv) (char *, char *, char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, int, int, int);
++void BLASFUNC(ctbmv) (char *, char *, char *, blasint *, blasint *, float  *, blasint *, float  *, blasint *, int, int, int);
++void BLASFUNC(ztbmv) (char *, char *, char *, blasint *, blasint *, double *, blasint *, double *, blasint *, int, int, int);
++void BLASFUNC(xtbmv) (char *, char *, char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, int, int, int);
++
++void BLASFUNC(stbsv) (char *, char *, char *, blasint *, blasint *, float  *, blasint *, float  *, blasint *, int, int, int);
++void BLASFUNC(dtbsv) (char *, char *, char *, blasint *, blasint *, double *, blasint *, double *, blasint *, int, int, int);
++void BLASFUNC(qtbsv) (char *, char *, char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, int, int, int);
++void BLASFUNC(ctbsv) (char *, char *, char *, blasint *, blasint *, float  *, blasint *, float  *, blasint *, int, int, int);
++void BLASFUNC(ztbsv) (char *, char *, char *, blasint *, blasint *, double *, blasint *, double *, blasint *, int, int, int);
++void BLASFUNC(xtbsv) (char *, char *, char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, int, int, int);
+ 
+ void BLASFUNC(ssymv) (char *, blasint *, float  *, float *, blasint *,
+-		     float  *, blasint *, float *, float *, blasint *);
++		     float  *, blasint *, float *, float *, blasint *, int);
+ void BLASFUNC(dsymv) (char *, blasint *, double  *, double *, blasint *,
+-		     double  *, blasint *, double *, double *, blasint *);
++		     double  *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(qsymv) (char *, blasint *, xdouble  *, xdouble *, blasint *,
+-		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *);
++		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *, int);
+ void BLASFUNC(csymv) (char *, blasint *, float  *, float *, blasint *,
+-		     float  *, blasint *, float *, float *, blasint *);
++		     float  *, blasint *, float *, float *, blasint *, int);
+ void BLASFUNC(zsymv) (char *, blasint *, double  *, double *, blasint *,
+-		     double  *, blasint *, double *, double *, blasint *);
++		     double  *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(xsymv) (char *, blasint *, xdouble  *, xdouble *, blasint *,
+-		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *);
++		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *, int);
+ 
+ void BLASFUNC(sspmv) (char *, blasint *, float  *, float *,
+-		     float  *, blasint *, float *, float *, blasint *);
++		     float  *, blasint *, float *, float *, blasint *, int);
+ void BLASFUNC(dspmv) (char *, blasint *, double  *, double *,
+-		     double  *, blasint *, double *, double *, blasint *);
++		     double  *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(qspmv) (char *, blasint *, xdouble  *, xdouble *,
+-		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *);
++		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *, int);
+ void BLASFUNC(cspmv) (char *, blasint *, float  *, float *,
+-		     float  *, blasint *, float *, float *, blasint *);
++		     float  *, blasint *, float *, float *, blasint *, int);
+ void BLASFUNC(zspmv) (char *, blasint *, double  *, double *,
+-		     double  *, blasint *, double *, double *, blasint *);
++		     double  *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(xspmv) (char *, blasint *, xdouble  *, xdouble *,
+-		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *);
++		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *, int);
+ 
+ void BLASFUNC(ssyr) (char *, blasint *, float   *, float  *, blasint *,
+-		    float  *, blasint *);
++		    float  *, blasint *, int);
+ void BLASFUNC(dsyr) (char *, blasint *, double  *, double *, blasint *,
+-		    double *, blasint *);
++		    double *, blasint *, int);
+ void BLASFUNC(qsyr) (char *, blasint *, xdouble  *, xdouble *, blasint *,
+-		    xdouble *, blasint *);
++		    xdouble *, blasint *, int);
+ void BLASFUNC(csyr) (char *, blasint *, float   *, float  *, blasint *,
+-		    float  *, blasint *);
++		    float  *, blasint *, int);
+ void BLASFUNC(zsyr) (char *, blasint *, double  *, double *, blasint *,
+-		    double *, blasint *);
++		    double *, blasint *, int);
+ void BLASFUNC(xsyr) (char *, blasint *, xdouble  *, xdouble *, blasint *,
+-		    xdouble *, blasint *);
++		    xdouble *, blasint *, int);
+ 
+ void BLASFUNC(ssyr2) (char *, blasint *, float   *,
+-		     float  *, blasint *, float  *, blasint *, float  *, blasint *);
++		     float  *, blasint *, float  *, blasint *, float  *, blasint *, int);
+ void BLASFUNC(dsyr2) (char *, blasint *, double  *,
+-		     double *, blasint *, double *, blasint *, double *, blasint *);
++		     double *, blasint *, double *, blasint *, double *, blasint *, int);
+ void BLASFUNC(qsyr2) (char *, blasint *, xdouble  *,
+-		     xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *);
++		     xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *, int);
+ void BLASFUNC(csyr2) (char *, blasint *, float   *,
+-		     float  *, blasint *, float  *, blasint *, float  *, blasint *);
++		     float  *, blasint *, float  *, blasint *, float  *, blasint *, int);
+ void BLASFUNC(zsyr2) (char *, blasint *, double  *,
+-		     double *, blasint *, double *, blasint *, double *, blasint *);
++		     double *, blasint *, double *, blasint *, double *, blasint *, int);
+ void BLASFUNC(xsyr2) (char *, blasint *, xdouble  *,
+-		     xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *);
++		     xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *, int);
+ 
+ void BLASFUNC(sspr) (char *, blasint *, float   *, float  *, blasint *,
+-		    float  *);
++		    float  *, int);
+ void BLASFUNC(dspr) (char *, blasint *, double  *, double *, blasint *,
+-		    double *);
++		    double *, int);
+ void BLASFUNC(qspr) (char *, blasint *, xdouble  *, xdouble *, blasint *,
+-		    xdouble *);
++		    xdouble *, int);
+ void BLASFUNC(cspr) (char *, blasint *, float   *, float  *, blasint *,
+-		    float  *);
++		    float  *, int);
+ void BLASFUNC(zspr) (char *, blasint *, double  *, double *, blasint *,
+-		    double *);
++		    double *, int);
+ void BLASFUNC(xspr) (char *, blasint *, xdouble  *, xdouble *, blasint *,
+-		    xdouble *);
++		    xdouble *, int);
+ 
+ void BLASFUNC(sspr2) (char *, blasint *, float   *,
+-		     float  *, blasint *, float  *, blasint *, float  *);
++		     float  *, blasint *, float  *, blasint *, float  *, int);
+ void BLASFUNC(dspr2) (char *, blasint *, double  *,
+-		     double *, blasint *, double *, blasint *, double *);
++		     double *, blasint *, double *, blasint *, double *, int);
+ void BLASFUNC(qspr2) (char *, blasint *, xdouble  *,
+-		     xdouble *, blasint *, xdouble *, blasint *, xdouble *);
++		     xdouble *, blasint *, xdouble *, blasint *, xdouble *, int);
+ void BLASFUNC(cspr2) (char *, blasint *, float   *,
+-		     float  *, blasint *, float  *, blasint *, float  *);
++		     float  *, blasint *, float  *, blasint *, float  *, int);
+ void BLASFUNC(zspr2) (char *, blasint *, double  *,
+-		     double *, blasint *, double *, blasint *, double *);
++		     double *, blasint *, double *, blasint *, double *, int);
+ void BLASFUNC(xspr2) (char *, blasint *, xdouble  *,
+-		     xdouble *, blasint *, xdouble *, blasint *, xdouble *);
++		     xdouble *, blasint *, xdouble *, blasint *, xdouble *, int);
+ 
+ void BLASFUNC(cher) (char *, blasint *, float   *, float  *, blasint *,
+-		    float  *, blasint *);
++		    float  *, blasint *, int);
+ void BLASFUNC(zher) (char *, blasint *, double  *, double *, blasint *,
+-		    double *, blasint *);
++		    double *, blasint *, int);
+ void BLASFUNC(xher) (char *, blasint *, xdouble  *, xdouble *, blasint *,
+-		    xdouble *, blasint *);
++		    xdouble *, blasint *, int);
+ 
+-void BLASFUNC(chpr) (char *, blasint *, float   *, float  *, blasint *, float  *);
+-void BLASFUNC(zhpr) (char *, blasint *, double  *, double *, blasint *, double *);
+-void BLASFUNC(xhpr) (char *, blasint *, xdouble  *, xdouble *, blasint *, xdouble *);
++void BLASFUNC(chpr) (char *, blasint *, float   *, float  *, blasint *, float  *, int);
++void BLASFUNC(zhpr) (char *, blasint *, double  *, double *, blasint *, double *, int);
++void BLASFUNC(xhpr) (char *, blasint *, double  *, xdouble *, blasint *, xdouble *, int);
+ 
+ void BLASFUNC(cher2) (char *, blasint *, float   *,
+-		     float  *, blasint *, float  *, blasint *, float  *, blasint *);
++		     float  *, blasint *, float  *, blasint *, float  *, blasint *, int);
+ void BLASFUNC(zher2) (char *, blasint *, double  *,
+-		     double *, blasint *, double *, blasint *, double *, blasint *);
++		     double *, blasint *, double *, blasint *, double *, blasint *, int);
+ void BLASFUNC(xher2) (char *, blasint *, xdouble  *,
+-		     xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *);
++		     xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *, int);
+ 
+ void BLASFUNC(chpr2) (char *, blasint *, float   *,
+-		     float  *, blasint *, float  *, blasint *, float  *);
++		     float  *, blasint *, float  *, blasint *, float  *, int);
+ void BLASFUNC(zhpr2) (char *, blasint *, double  *,
+-		     double *, blasint *, double *, blasint *, double *);
++		     double *, blasint *, double *, blasint *, double *, int);
+ void BLASFUNC(xhpr2) (char *, blasint *, xdouble  *,
+-		     xdouble *, blasint *, xdouble *, blasint *, xdouble *);
++		     xdouble *, blasint *, xdouble *, blasint *, xdouble *, int);
+ 
+ void BLASFUNC(chemv) (char *, blasint *, float  *, float *, blasint *,
+-		     float  *, blasint *, float *, float *, blasint *);
++		     float  *, blasint *, float *, float *, blasint *, int);
+ void BLASFUNC(zhemv) (char *, blasint *, double  *, double *, blasint *,
+-		     double  *, blasint *, double *, double *, blasint *);
++		     double  *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(xhemv) (char *, blasint *, xdouble  *, xdouble *, blasint *,
+-		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *);
++		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *, int);
+ 
+ void BLASFUNC(chpmv) (char *, blasint *, float  *, float *,
+-		     float  *, blasint *, float *, float *, blasint *);
++		     float  *, blasint *, float *, float *, blasint *, int);
+ void BLASFUNC(zhpmv) (char *, blasint *, double  *, double *,
+-		     double  *, blasint *, double *, double *, blasint *);
++		     double  *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(xhpmv) (char *, blasint *, xdouble  *, xdouble *,
+-		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *);
++		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *, int);
+ 
+-int BLASFUNC(snorm)(char *, blasint *, blasint *, float  *, blasint *);
+-int BLASFUNC(dnorm)(char *, blasint *, blasint *, double *, blasint *);
+-int BLASFUNC(cnorm)(char *, blasint *, blasint *, float  *, blasint *);
+-int BLASFUNC(znorm)(char *, blasint *, blasint *, double *, blasint *);
++int BLASFUNC(snorm)(char *, blasint *, blasint *, float  *, blasint *, int);
++int BLASFUNC(dnorm)(char *, blasint *, blasint *, double *, blasint *, int);
++int BLASFUNC(cnorm)(char *, blasint *, blasint *, float  *, blasint *, int);
++int BLASFUNC(znorm)(char *, blasint *, blasint *, double *, blasint *, int);
+ 
+ void BLASFUNC(sgbmv)(char *, blasint *, blasint *, blasint *, blasint *, float  *, float  *, blasint *,
+-		    float  *, blasint *, float  *, float  *, blasint *);
++		    float  *, blasint *, float  *, float  *, blasint *, int);
+ void BLASFUNC(dgbmv)(char *, blasint *, blasint *, blasint *, blasint *, double *, double *, blasint *,
+-		    double *, blasint *, double *, double *, blasint *);
++		    double *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(qgbmv)(char *, blasint *, blasint *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-		    xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++		    xdouble *, blasint *, xdouble *, xdouble *, blasint *, int);
+ void BLASFUNC(cgbmv)(char *, blasint *, blasint *, blasint *, blasint *, float  *, float  *, blasint *,
+-		    float  *, blasint *, float  *, float  *, blasint *);
++		    float  *, blasint *, float  *, float  *, blasint *, int);
+ void BLASFUNC(zgbmv)(char *, blasint *, blasint *, blasint *, blasint *, double *, double *, blasint *,
+-		    double *, blasint *, double *, double *, blasint *);
++		    double *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(xgbmv)(char *, blasint *, blasint *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-		    xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++		    xdouble *, blasint *, xdouble *, xdouble *, blasint *, int);
+ 
+ void BLASFUNC(ssbmv)(char *, blasint *, blasint *, float  *, float  *, blasint *,
+-		    float  *, blasint *, float  *, float  *, blasint *);
++		    float  *, blasint *, float  *, float  *, blasint *, int);
+ void BLASFUNC(dsbmv)(char *, blasint *, blasint *, double *, double *, blasint *,
+-		    double *, blasint *, double *, double *, blasint *);
++		    double *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(qsbmv)(char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-		    xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++		    xdouble *, blasint *, xdouble *, xdouble *, blasint *, int);
+ void BLASFUNC(csbmv)(char *, blasint *, blasint *, float  *, float  *, blasint *,
+-		    float  *, blasint *, float  *, float  *, blasint *);
++		    float  *, blasint *, float  *, float  *, blasint *, int);
+ void BLASFUNC(zsbmv)(char *, blasint *, blasint *, double *, double *, blasint *,
+-		    double *, blasint *, double *, double *, blasint *);
++		    double *, blasint *, double *, double *, blasint *, int);
+ void BLASFUNC(xsbmv)(char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-		    xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++		    xdouble *, blasint *, xdouble *, xdouble *, blasint *, int);
+ 
+ void BLASFUNC(chbmv)(char *, blasint *, blasint *, float  *, float  *, blasint *,
+-		    float  *, blasint *, float  *, float  *, blasint *);
++		    float  *, blasint *, float  *, float  *, blasint *, int);
+ void BLASFUNC(zhbmv)(char *, blasint *, blasint *, double *, double *, blasint *,
+-		    double *, blasint *, double *, double *, blasint *);
++		    double *, blasint *, double *, double *, blasint *,  int);
+ void BLASFUNC(xhbmv)(char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-		    xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++		    xdouble *, blasint *, xdouble *, xdouble *, blasint *, int);
+ 
+ /* Level 3 routines */
+ 
+ void BLASFUNC(sbgemm)(char *, char *, blasint *, blasint *, blasint *, float *,
+-	   bfloat16 *, blasint *, bfloat16 *, blasint *, float *, float *, blasint *);
++	   bfloat16 *, blasint *, bfloat16 *, blasint *, float *, float *, blasint *, int, int);
+ void BLASFUNC(sgemm)(char *, char *, blasint *, blasint *, blasint *, float *,
+-	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(dgemm)(char *, char *, blasint *, blasint *, blasint *, double *,
+-	   double *, blasint *, double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(qgemm)(char *, char *, blasint *, blasint *, blasint *, xdouble *,
+-	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ void BLASFUNC(cgemm)(char *, char *, blasint *, blasint *, blasint *, float *,
+-	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zgemm)(char *, char *, blasint *, blasint *, blasint *, double *,
+-	   double *, blasint *, double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(xgemm)(char *, char *, blasint *, blasint *, blasint *, xdouble *,
+-	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ void BLASFUNC(cgemm3m)(char *, char *, blasint *, blasint *, blasint *, float *,
+-	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zgemm3m)(char *, char *, blasint *, blasint *, blasint *, double *,
+-	   double *, blasint *, double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(xgemm3m)(char *, char *, blasint *, blasint *, blasint *, xdouble *,
+-	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ void BLASFUNC(sgemmt)(char*, char *, char *, blasint *, blasint *, float *,
+-	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *, int, int, int);
+ void BLASFUNC(dgemmt)(char*, char *, char *, blasint *, blasint *, double *,
+-	   double *, blasint *, double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int, int);
+ void BLASFUNC(cgemmt)(char*, char *, char *, blasint *, blasint *, float *,
+-	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *, int, int, int);
+ void BLASFUNC(zgemmt)(char*, char *, char *, blasint *, blasint *, double *,
+-	   double *, blasint *, double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int, int);
+ 
+ int BLASFUNC(sge2mm)(char *, char *, char *, blasint *, blasint *,
+ 		     float *, float  *, blasint *, float  *, blasint *,
+-		     float *, float  *, blasint *);
++		     float *, float  *, blasint *, int, int, int);
+ int BLASFUNC(dge2mm)(char *, char *, char *, blasint *, blasint *,
+ 		     double *, double  *, blasint *, double  *, blasint *,
+-		     double *, double  *, blasint *);
++		     double *, double  *, blasint *, int, int, int);
+ int BLASFUNC(cge2mm)(char *, char *, char *, blasint *, blasint *,
+ 		     float *, float  *, blasint *, float  *, blasint *,
+-		     float *, float  *, blasint *);
++		     float *, float  *, blasint *, int, int, int);
+ int BLASFUNC(zge2mm)(char *, char *, char *, blasint *, blasint *,
+ 		     double *, double  *, blasint *, double  *, blasint *,
+-		     double *, double  *, blasint *);
++		     double *, double  *, blasint *, int, int, int);
+ 
+ void BLASFUNC(strsm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   float *,  float *, blasint *, float *, blasint *);
++	   float *,  float *, blasint *, float *, blasint *, int, int, int, int);
+ void BLASFUNC(dtrsm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   double *,  double *, blasint *, double *, blasint *);
++	   double *,  double *, blasint *, double *, blasint *, int, int, int, int);
+ void BLASFUNC(qtrsm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   xdouble *,  xdouble *, blasint *, xdouble *, blasint *);
++	   xdouble *,  xdouble *, blasint *, xdouble *, blasint *, int, int, int, int);
+ void BLASFUNC(ctrsm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   float *,  float *, blasint *, float *, blasint *);
++	   float *,  float *, blasint *, float *, blasint *, int, int, int, int);
+ void BLASFUNC(ztrsm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   double *,  double *, blasint *, double *, blasint *);
++	   double *,  double *, blasint *, double *, blasint *, int, int, int, int);
+ void BLASFUNC(xtrsm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   xdouble *,  xdouble *, blasint *, xdouble *, blasint *);
++	   xdouble *,  xdouble *, blasint *, xdouble *, blasint *, int, int, int, int);
+ 
+ void BLASFUNC(strmm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   float *,  float *, blasint *, float *, blasint *);
++	   float *,  float *, blasint *, float *, blasint *, int, int, int, int);
+ void BLASFUNC(dtrmm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   double *,  double *, blasint *, double *, blasint *);
++	   double *,  double *, blasint *, double *, blasint *, int, int, int, int);
+ void BLASFUNC(qtrmm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   xdouble *,  xdouble *, blasint *, xdouble *, blasint *);
++	   xdouble *,  xdouble *, blasint *, xdouble *, blasint *, int, int, int, int);
+ void BLASFUNC(ctrmm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   float *,  float *, blasint *, float *, blasint *);
++	   float *,  float *, blasint *, float *, blasint *, int, int, int, int);
+ void BLASFUNC(ztrmm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   double *,  double *, blasint *, double *, blasint *);
++	   double *,  double *, blasint *, double *, blasint *, int, int, int, int);
+ void BLASFUNC(xtrmm)(char *, char *, char *, char *, blasint *, blasint *,
+-	   xdouble *,  xdouble *, blasint *, xdouble *, blasint *);
++	   xdouble *,  xdouble *, blasint *, xdouble *, blasint *, int, int, int, int);
+ 
+ void BLASFUNC(ssymm)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(dsymm)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(qsymm)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ void BLASFUNC(csymm)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zsymm)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(xsymm)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ void BLASFUNC(csymm3m)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zsymm3m)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(xsymm3m)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ void BLASFUNC(ssyrk)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float  *, float  *, blasint *);
++	   float  *, float  *, blasint *, int, int);
+ void BLASFUNC(dsyrk)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double *, double *, blasint *);
++	   double *, double *, blasint *, int, int);
+ void BLASFUNC(qsyrk)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble *, xdouble *, blasint *);
++	   xdouble *, xdouble *, blasint *, int, int);
+ void BLASFUNC(csyrk)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float  *, float  *, blasint *);
++	   float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zsyrk)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double *, double *, blasint *);
++	   double *, double *, blasint *, int, int);
+ void BLASFUNC(xsyrk)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble *, xdouble *, blasint *);
++	   xdouble *, xdouble *, blasint *, int, int);
+ 
+ void BLASFUNC(ssyr2k)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float *, blasint *, float  *, float  *, blasint *);
++	   float *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(dsyr2k)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double*, blasint *, double *, double *, blasint *);
++	   double*, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(qsyr2k)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble*, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble*, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ void BLASFUNC(csyr2k)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float *, blasint *, float  *, float  *, blasint *);
++	   float *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zsyr2k)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double*, blasint *, double *, double *, blasint *);
++	   double*, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(xsyr2k)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble*, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble*, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ void BLASFUNC(chemm)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zhemm)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(xhemm)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ void BLASFUNC(chemm3m)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zhemm3m)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(xhemm3m)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ void BLASFUNC(cherk)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float  *, float  *, blasint *);
++	   float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zherk)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double *, double *, blasint *);
++	   double *, double *, blasint *, int, int);
+ void BLASFUNC(xherk)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble *, xdouble *, blasint *);
++	   xdouble *, xdouble *, blasint *, int, int);
+ 
+ void BLASFUNC(cher2k)(char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float *, blasint *, float  *, float  *, blasint *);
++	   float *, blasint *, float  *, float  *, blasint *, int, int);
+ void BLASFUNC(zher2k)(char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double*, blasint *, double *, double *, blasint *);
++	   double*, blasint *, double *, double *, blasint *, int, int);
+ void BLASFUNC(xher2k)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble*, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble*, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ int BLASFUNC(cher2m)(char *, char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+-	   float *, blasint *, float  *, float  *, blasint *);
++	   float *, blasint *, float  *, float  *, blasint *, int, int, int);
+ int BLASFUNC(zher2m)(char *, char *, char *, blasint *, blasint *, double *, double *, blasint *,
+-	   double*, blasint *, double *, double *, blasint *);
++	   double*, blasint *, double *, double *, blasint *, int, int, int);
+ int BLASFUNC(xher2m)(char *, char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+-	   xdouble*, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble*, blasint *, xdouble *, xdouble *, blasint *, int, int, int);
+ 
+ int BLASFUNC(sgemt)(char *, blasint *, blasint *, float  *, float  *, blasint *,
+-		    float  *, blasint *);
++		    float  *, blasint *, int);
+ int BLASFUNC(dgemt)(char *, blasint *, blasint *, double *, double *, blasint *,
+-		    double *, blasint *);
++		    double *, blasint *, int);
+ int BLASFUNC(cgemt)(char *, blasint *, blasint *, float  *, float  *, blasint *,
+-		    float  *, blasint *);
++		    float  *, blasint *, int);
+ int BLASFUNC(zgemt)(char *, blasint *, blasint *, double *, double *, blasint *,
+-		    double *, blasint *);
++		    double *, blasint *, int);
+ 
+ int BLASFUNC(sgema)(char *, char *, blasint *, blasint *, float  *,
+-		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *);
++		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *, int, int);
+ int BLASFUNC(dgema)(char *, char *, blasint *, blasint *, double *,
+-		    double *, blasint *, double*, double *, blasint *, double*, blasint *);
++		    double *, blasint *, double*, double *, blasint *, double*, blasint *, int, int);
+ int BLASFUNC(cgema)(char *, char *, blasint *, blasint *, float  *,
+-		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *);
++		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *, int, int);
+ int BLASFUNC(zgema)(char *, char *, blasint *, blasint *, double *,
+-		    double *, blasint *, double*, double *, blasint *, double*, blasint *);
++		    double *, blasint *, double*, double *, blasint *, double*, blasint *, int, int);
+ 
+ int BLASFUNC(sgems)(char *, char *, blasint *, blasint *, float  *,
+-		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *);
++		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *, int, int);
+ int BLASFUNC(dgems)(char *, char *, blasint *, blasint *, double *,
+-		    double *, blasint *, double*, double *, blasint *, double*, blasint *);
++		    double *, blasint *, double*, double *, blasint *, double*, blasint *, int, int);
+ int BLASFUNC(cgems)(char *, char *, blasint *, blasint *, float  *,
+-		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *);
++		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *, int, int);
+ int BLASFUNC(zgems)(char *, char *, blasint *, blasint *, double *,
+-		    double *, blasint *, double*, double *, blasint *, double*, blasint *);
++		    double *, blasint *, double*, double *, blasint *, double*, blasint *, int, int);
+ 
+ int BLASFUNC(sgemc)(char *, char *, blasint *, blasint *, blasint *, float *,
+-	   float  *, blasint *, float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *, int, int);
+ int BLASFUNC(dgemc)(char *, char *, blasint *, blasint *, blasint *, double *,
+-	   double *, blasint *, double *, blasint *, double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int);
+ int BLASFUNC(qgemc)(char *, char *, blasint *, blasint *, blasint *, xdouble *,
+-	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *,  xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *,  xdouble *, xdouble *, blasint *, int, int);
+ int BLASFUNC(cgemc)(char *, char *, blasint *, blasint *, blasint *, float *,
+-	   float  *, blasint *, float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *);
++	   float  *, blasint *, float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *, int, int);
+ int BLASFUNC(zgemc)(char *, char *, blasint *, blasint *, blasint *, double *,
+-	   double *, blasint *, double *, blasint *, double *, blasint *, double *, double *, blasint *);
++	   double *, blasint *, double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int);
+ int BLASFUNC(xgemc)(char *, char *, blasint *, blasint *, blasint *, xdouble *,
+-	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *, xdouble *, xdouble *, blasint *);
++	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ /* Lapack routines */
+ 
+@@ -695,12 +695,12 @@ int BLASFUNC(claswp)(blasint *, float  *, blasint *, blasint *, blasint *, blasi
+ int BLASFUNC(zlaswp)(blasint *, double *, blasint *, blasint *, blasint *, blasint *, blasint *);
+ int BLASFUNC(xlaswp)(blasint *, xdouble *, blasint *, blasint *, blasint *, blasint *, blasint *);
+ 
+-int BLASFUNC(sgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(dgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(qgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *);
+-int BLASFUNC(cgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(zgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(xgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *);
++int BLASFUNC(sgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(dgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(qgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *, int);
++int BLASFUNC(cgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(zgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(xgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *, int);
+ 
+ int BLASFUNC(sgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float *, blasint *, blasint *);
+ int BLASFUNC(dgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
+@@ -709,66 +709,66 @@ int BLASFUNC(cgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float
+ int BLASFUNC(zgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
+ int BLASFUNC(xgesv)(blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble*, blasint *, blasint *);
+ 
+-int BLASFUNC(spotf2)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(dpotf2)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(qpotf2)(char *, blasint *, xdouble *, blasint *, blasint *);
+-int BLASFUNC(cpotf2)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(zpotf2)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(xpotf2)(char *, blasint *, xdouble *, blasint *, blasint *);
+-
+-int BLASFUNC(spotrf)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(dpotrf)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(qpotrf)(char *, blasint *, xdouble *, blasint *, blasint *);
+-int BLASFUNC(cpotrf)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(zpotrf)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(xpotrf)(char *, blasint *, xdouble *, blasint *, blasint *);
+-
+-int BLASFUNC(spotri)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(dpotri)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(qpotri)(char *, blasint *, xdouble *, blasint *, blasint *);
+-int BLASFUNC(cpotri)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(zpotri)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(xpotri)(char *, blasint *, xdouble *, blasint *, blasint *);
+-
+-int BLASFUNC(spotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *);
+-int BLASFUNC(dpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *);
+-int BLASFUNC(qpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *);
+-int BLASFUNC(cpotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *);
+-int BLASFUNC(zpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *);
+-int BLASFUNC(xpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *);
+-
+-int BLASFUNC(slauu2)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(dlauu2)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(qlauu2)(char *, blasint *, xdouble *, blasint *, blasint *);
+-int BLASFUNC(clauu2)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(zlauu2)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(xlauu2)(char *, blasint *, xdouble *, blasint *, blasint *);
+-
+-int BLASFUNC(slauum)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(dlauum)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(qlauum)(char *, blasint *, xdouble *, blasint *, blasint *);
+-int BLASFUNC(clauum)(char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(zlauum)(char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(xlauum)(char *, blasint *, xdouble *, blasint *, blasint *);
+-
+-int BLASFUNC(strti2)(char *, char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(dtrti2)(char *, char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(qtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
+-int BLASFUNC(ctrti2)(char *, char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(ztrti2)(char *, char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(xtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
+-
+-int BLASFUNC(strtri)(char *, char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(dtrtri)(char *, char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(qtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
+-int BLASFUNC(ctrtri)(char *, char *, blasint *, float  *, blasint *, blasint *);
+-int BLASFUNC(ztrtri)(char *, char *, blasint *, double *, blasint *, blasint *);
+-int BLASFUNC(xtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
+-
+-
+-FLOATRET  BLASFUNC(slamch)(char *);
+-double    BLASFUNC(dlamch)(char *);
+-xdouble   BLASFUNC(qlamch)(char *);
++int BLASFUNC(spotf2)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(dpotf2)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(qpotf2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++int BLASFUNC(cpotf2)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(zpotf2)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(xpotf2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++int BLASFUNC(spotrf)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(dpotrf)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(qpotrf)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++int BLASFUNC(cpotrf)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(zpotrf)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(xpotrf)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++int BLASFUNC(spotri)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(dpotri)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(qpotri)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++int BLASFUNC(cpotri)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(zpotri)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(xpotri)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++int BLASFUNC(spotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *, int);
++int BLASFUNC(dpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *, int);
++int BLASFUNC(qpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *, int);
++int BLASFUNC(cpotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *, int);
++int BLASFUNC(zpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *, int);
++int BLASFUNC(xpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *, int);
++
++int BLASFUNC(slauu2)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(dlauu2)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(qlauu2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++int BLASFUNC(clauu2)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(zlauu2)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(xlauu2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++int BLASFUNC(slauum)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(dlauum)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(qlauum)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++int BLASFUNC(clauum)(char *, blasint *, float  *, blasint *, blasint *, int);
++int BLASFUNC(zlauum)(char *, blasint *, double *, blasint *, blasint *, int);
++int BLASFUNC(xlauum)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++int BLASFUNC(strti2)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
++int BLASFUNC(dtrti2)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
++int BLASFUNC(qtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
++int BLASFUNC(ctrti2)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
++int BLASFUNC(ztrti2)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
++int BLASFUNC(xtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
++
++int BLASFUNC(strtri)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
++int BLASFUNC(dtrtri)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
++int BLASFUNC(qtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
++int BLASFUNC(ctrtri)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
++int BLASFUNC(ztrtri)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
++int BLASFUNC(xtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
++
++
++FLOATRET  BLASFUNC(slamch)(char *, int);
++double    BLASFUNC(dlamch)(char *, int);
++xdouble   BLASFUNC(qlamch)(char *, int);
+ 
+ FLOATRET  BLASFUNC(slamc3)(float *, float *);
+ double    BLASFUNC(dlamc3)(double *, double *);
+@@ -791,10 +791,10 @@ void    BLASFUNC(dimatcopy) (char *, char *, blasint *, blasint *, double  *, do
+ void    BLASFUNC(cimatcopy) (char *, char *, blasint *, blasint *, float  *, float  *, blasint *, blasint *);
+ void    BLASFUNC(zimatcopy) (char *, char *, blasint *, blasint *, double  *, double  *, blasint *, blasint *);
+ 
+-void    BLASFUNC(sgeadd) (blasint *, blasint *, float *, float *, blasint *, float *, float *, blasint*); 
+-void    BLASFUNC(dgeadd) (blasint *, blasint *, double *, double *, blasint *, double *, double *, blasint*); 
+-void    BLASFUNC(cgeadd) (blasint *, blasint *, float *, float *, blasint *, float *, float *, blasint*); 
+-void    BLASFUNC(zgeadd) (blasint *, blasint *, double *, double *, blasint *, double *, double *, blasint*); 
++void    BLASFUNC(sgeadd) (blasint *, blasint *, float *, float *, blasint *, float *, float *, blasint*);
++void    BLASFUNC(dgeadd) (blasint *, blasint *, double *, double *, blasint *, double *, double *, blasint*);
++void    BLASFUNC(cgeadd) (blasint *, blasint *, float *, float *, blasint *, float *, float *, blasint*);
++void    BLASFUNC(zgeadd) (blasint *, blasint *, double *, double *, blasint *, double *, double *, blasint*);
+ 
+ 
+ #ifdef __cplusplus
+diff --git a/interface/gbmv.c b/interface/gbmv.c
+index 7a6581368..04172cb8d 100644
+--- a/interface/gbmv.c
++++ b/interface/gbmv.c
+@@ -80,7 +80,7 @@ void NAME(char *TRANS, blasint *M, blasint *N,
+ 	 blasint *KU, blasint *KL,
+ 	 FLOAT *ALPHA, FLOAT *a, blasint *LDA,
+ 	 FLOAT *x, blasint *INCX,
+-	 FLOAT *BETA, FLOAT *y, blasint *INCY){
++	 FLOAT *BETA, FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char trans = *TRANS;
+   blasint m = *M;
+diff --git a/interface/gemm.c b/interface/gemm.c
+index 54e5604fd..bb86895b4 100644
+--- a/interface/gemm.c
++++ b/interface/gemm.c
+@@ -253,7 +253,7 @@ void NAME(char *TRANSA, char *TRANSB,
+ 	  IFLOAT *a, blasint *ldA,
+ 	  IFLOAT *b, blasint *ldB,
+ 	  FLOAT *beta,
+-	  FLOAT *c, blasint *ldC){
++	  FLOAT *c, blasint *ldC, int dummy_len0, int dummy_len1){
+ 
+   blas_arg_t args;
+ 
+@@ -417,7 +417,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANS
+ 
+   PRINT_DEBUG_CNAME;
+ 
+-#if !defined(COMPLEX) && !defined(DOUBLE) && !defined(BFLOAT16) 
++#if !defined(COMPLEX) && !defined(DOUBLE) && !defined(BFLOAT16)
+ #if defined(ARCH_x86) && (defined(USE_SGEMM_KERNEL_DIRECT)||defined(DYNAMIC_ARCH))
+ #if defined(DYNAMIC_ARCH)
+   if (support_avx512() )
+diff --git a/interface/gemmt.c b/interface/gemmt.c
+index aa65f81ed..887be7ec6 100644
+--- a/interface/gemmt.c
++++ b/interface/gemmt.c
+@@ -90,7 +90,7 @@ void NAME(char *UPLO, char *TRANSA, char *TRANSB,
+ 	  blasint * M, blasint * K,
+ 	  FLOAT * Alpha,
+ 	  IFLOAT * a, blasint * ldA,
+-	  IFLOAT * b, blasint * ldB, FLOAT * Beta, FLOAT * c, blasint * ldC)
++	  IFLOAT * b, blasint * ldB, FLOAT * Beta, FLOAT * c, blasint * ldC, int dummy_len0, int dummy_len1, int dummy_len2)
+ {
+ 
+ 	blasint m, k;
+@@ -180,7 +180,7 @@ void NAME(char *UPLO, char *TRANSA, char *TRANSB,
+ 		uplo = 0;
+ 	if (Uplo == 'L')
+ 		uplo = 1;
+-	
++
+ 	nrowa = m;
+ 	if (transa & 1) nrowa = k;
+ 	nrowb = k;
+@@ -377,7 +377,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
+ 
+ 		info = -1;
+ 
+-		blasint ncola; 
++		blasint ncola;
+ #if !defined(COMPLEX)
+ 		blasint ncolb;
+ #endif
+diff --git a/interface/gemv.c b/interface/gemv.c
+index 34b6addd3..47c6c9e6c 100644
+--- a/interface/gemv.c
++++ b/interface/gemv.c
+@@ -132,7 +132,7 @@ static inline int get_gemv_optimal_nthreads(BLASLONG MN) {
+ void NAME(char *TRANS, blasint *M, blasint *N,
+ 	   FLOAT *ALPHA, FLOAT *a, blasint *LDA,
+ 	   FLOAT *x, blasint *INCX,
+-	   FLOAT *BETA, FLOAT *y, blasint *INCY){
++	   FLOAT *BETA, FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char trans = *TRANS;
+   blasint m = *M;
+@@ -265,7 +265,7 @@ void CNAME(enum CBLAS_ORDER order,
+   if (beta != ONE) SCAL_K(leny, 0, 0, beta, y, blasabs(incy), NULL, 0, NULL, 0);
+ 
+   if (alpha == ZERO) return;
+-	
++
+   IDEBUG_START;
+ 
+   FUNCTION_PROFILE_START();
+diff --git a/interface/lapack/getrf.c b/interface/lapack/getrf.c
+index 270604120..4a58774d1 100644
+--- a/interface/lapack/getrf.c
++++ b/interface/lapack/getrf.c
+@@ -98,7 +98,7 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint
+ 
+ #ifndef DOUBLE
+   int nmax = 40000;
+-#else 
++#else
+   int nmax = 10000;
+ #endif
+   if (args.m*args.n <nmax) {
+diff --git a/interface/lapack/getrs.c b/interface/lapack/getrs.c
+index c2a9eb882..ef3f341f4 100644
+--- a/interface/lapack/getrs.c
++++ b/interface/lapack/getrs.c
+@@ -61,7 +61,7 @@ static blasint (*getrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ #endif
+ 
+ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+-  blasint *ipiv, FLOAT *b, blasint *ldB, blasint *Info){
++  blasint *ipiv, FLOAT *b, blasint *ldB, blasint *Info, int dummy_len){
+ 
+   char trans_arg = *TRANS;
+ 
+diff --git a/interface/lapack/lauu2.c b/interface/lapack/lauu2.c
+index e581e3c15..74ddb0831 100644
+--- a/interface/lapack/lauu2.c
++++ b/interface/lapack/lauu2.c
+@@ -60,7 +60,7 @@ static blasint (*lauu2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/lauum.c b/interface/lapack/lauum.c
+index 70f6a0ec5..760cf21c1 100644
+--- a/interface/lapack/lauum.c
++++ b/interface/lapack/lauum.c
+@@ -60,7 +60,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/potf2.c b/interface/lapack/potf2.c
+index 1537b6ee4..cfd116ba1 100644
+--- a/interface/lapack/potf2.c
++++ b/interface/lapack/potf2.c
+@@ -60,7 +60,7 @@ static blasint (*potf2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/potrf.c b/interface/lapack/potrf.c
+index a24e48d95..3f994e7f6 100644
+--- a/interface/lapack/potrf.c
++++ b/interface/lapack/potrf.c
+@@ -60,7 +60,7 @@ static blasint (*potrf_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -114,7 +114,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+   args.common = NULL;
+ #ifndef DOUBLE
+   int nmax = 128;
+-#else 
++#else
+   int nmax = 64;
+ #endif
+   if (args.n <nmax) {
+diff --git a/interface/lapack/potri.c b/interface/lapack/potri.c
+index eb0fcbe70..51eb4fb2e 100644
+--- a/interface/lapack/potri.c
++++ b/interface/lapack/potri.c
+@@ -68,7 +68,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/trti2.c b/interface/lapack/trti2.c
+index 47f04f06f..bd32dc433 100644
+--- a/interface/lapack/trti2.c
++++ b/interface/lapack/trti2.c
+@@ -60,7 +60,7 @@ static blasint (*trti2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/trtri.c b/interface/lapack/trtri.c
+index df79f2665..8a4716090 100644
+--- a/interface/lapack/trtri.c
++++ b/interface/lapack/trtri.c
+@@ -61,7 +61,7 @@ static blasint (*trtri_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ #endif
+ 
+ 
+-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/trtrs.c b/interface/lapack/trtrs.c
+index 3cc449318..069bdbd2d 100644
+--- a/interface/lapack/trtrs.c
++++ b/interface/lapack/trtrs.c
+@@ -61,7 +61,7 @@ static blasint (*trtrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ #endif
+ 
+ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+-  FLOAT *b, blasint *ldB, blasint *Info){
++  FLOAT *b, blasint *ldB, blasint *Info, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+     char uplo_arg = *UPLO;
+     char trans_arg = *TRANS;
+diff --git a/interface/lapack/zgetrs.c b/interface/lapack/zgetrs.c
+index 0add909ca..18914ecff 100644
+--- a/interface/lapack/zgetrs.c
++++ b/interface/lapack/zgetrs.c
+@@ -61,7 +61,7 @@ static blasint (*getrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ #endif
+ 
+ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+-	    blasint *ipiv, FLOAT *b, blasint *ldB, blasint *Info){
++	    blasint *ipiv, FLOAT *b, blasint *ldB, blasint *Info, int dummy_len){
+ 
+   char trans_arg = *TRANS;
+ 
+diff --git a/interface/lapack/zlauu2.c b/interface/lapack/zlauu2.c
+index ae972543c..2385b5ff6 100644
+--- a/interface/lapack/zlauu2.c
++++ b/interface/lapack/zlauu2.c
+@@ -61,7 +61,7 @@ static blasint (*lauu2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/zlauum.c b/interface/lapack/zlauum.c
+index 4a36cc173..03ed0241d 100644
+--- a/interface/lapack/zlauum.c
++++ b/interface/lapack/zlauum.c
+@@ -60,7 +60,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/zpotf2.c b/interface/lapack/zpotf2.c
+index c74b66728..490f0ceae 100644
+--- a/interface/lapack/zpotf2.c
++++ b/interface/lapack/zpotf2.c
+@@ -61,7 +61,7 @@ static blasint (*potf2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/zpotrf.c b/interface/lapack/zpotrf.c
+index 298efbbc1..dd80b9678 100644
+--- a/interface/lapack/zpotrf.c
++++ b/interface/lapack/zpotrf.c
+@@ -60,7 +60,7 @@ static blasint (*potrf_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/zpotri.c b/interface/lapack/zpotri.c
+index 8748c6352..6d789d7a4 100644
+--- a/interface/lapack/zpotri.c
++++ b/interface/lapack/zpotri.c
+@@ -68,7 +68,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/ztrti2.c b/interface/lapack/ztrti2.c
+index cb9c0d557..b8085d387 100644
+--- a/interface/lapack/ztrti2.c
++++ b/interface/lapack/ztrti2.c
+@@ -60,7 +60,7 @@ static blasint (*trti2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/ztrtri.c b/interface/lapack/ztrtri.c
+index dda4a9e4b..a5cb8448c 100644
+--- a/interface/lapack/ztrtri.c
++++ b/interface/lapack/ztrtri.c
+@@ -60,7 +60,7 @@ static blasint (*trtri_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
++int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
+ 
+   blas_arg_t args;
+ 
+diff --git a/interface/lapack/ztrtrs.c b/interface/lapack/ztrtrs.c
+index ec3343393..2b195e615 100644
+--- a/interface/lapack/ztrtrs.c
++++ b/interface/lapack/ztrtrs.c
+@@ -61,7 +61,7 @@ static blasint (*trtrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ #endif
+ 
+ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+-  FLOAT *b, blasint *ldB, blasint *Info){
++  FLOAT *b, blasint *ldB, blasint *Info, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+     char uplo_arg = *UPLO;
+     char trans_arg = *TRANS;
+diff --git a/interface/sbmv.c b/interface/sbmv.c
+index 25e99ca34..6a08e67ab 100644
+--- a/interface/sbmv.c
++++ b/interface/sbmv.c
+@@ -84,7 +84,7 @@ static  int (*sbmv_thread[])(BLASLONG, BLASLONG, FLOAT, FLOAT *, BLASLONG, FLOAT
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, blasint *K, FLOAT  *ALPHA, FLOAT *a, blasint *LDA,
+-            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY){
++            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n	= *N;
+diff --git a/interface/spmv.c b/interface/spmv.c
+index e08ae3f6e..7c5a17339 100644
+--- a/interface/spmv.c
++++ b/interface/spmv.c
+@@ -76,7 +76,7 @@ static  int (*spmv_thread[])(BLASLONG, FLOAT, FLOAT *, FLOAT *, BLASLONG, FLOAT
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA, FLOAT *a,
+-            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY){
++            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/spr.c b/interface/spr.c
+index 8aafc9f85..254b7d551 100644
+--- a/interface/spr.c
++++ b/interface/spr.c
+@@ -76,7 +76,7 @@ static int (*spr_thread[])(BLASLONG, FLOAT, FLOAT *, BLASLONG, FLOAT *, FLOAT *,
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *a){
++	 FLOAT  *x, blasint *INCX, FLOAT *a, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+@@ -176,7 +176,7 @@ void CNAME(enum CBLAS_ORDER order,
+         }
+         a += i + 1;
+       }
+-    } else { 
++    } else {
+       for (i = 0; i < n; i++){
+         if (x[i] != ZERO) {
+           AXPYU_K(n - i, 0, 0, alpha * x[i], x + i, 1, a, 1, NULL, 0);
+diff --git a/interface/spr2.c b/interface/spr2.c
+index b5aab1767..157faf4f8 100644
+--- a/interface/spr2.c
++++ b/interface/spr2.c
+@@ -76,7 +76,7 @@ static int (*spr2_thread[])(BLASLONG, FLOAT, FLOAT *, BLASLONG, FLOAT *, BLASLON
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a){
++	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/symm.c b/interface/symm.c
+index 3e6e0fd48..345e2d2fe 100644
+--- a/interface/symm.c
++++ b/interface/symm.c
+@@ -152,7 +152,7 @@ void NAME(char *SIDE, char *UPLO,
+          blasint *M, blasint *N,
+          FLOAT *alpha, FLOAT *a, blasint *ldA,
+          FLOAT *b, blasint *ldB,
+-         FLOAT *beta,  FLOAT *c, blasint *ldC){
++         FLOAT *beta,  FLOAT *c, blasint *ldC, int dummy_len0, int dummy_len1){
+ 
+   char side_arg  = *SIDE;
+   char uplo_arg  = *UPLO;
+@@ -250,7 +250,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_SIDE Side, enum CBLAS_UPLO Uplo,
+   FLOAT *beta  = (FLOAT*) vbeta;
+   FLOAT *a = (FLOAT*) va;
+   FLOAT *b = (FLOAT*) vb;
+-  FLOAT *c = (FLOAT*) vc;	   
++  FLOAT *c = (FLOAT*) vc;
+ #endif
+ 
+   blas_arg_t args;
+diff --git a/interface/symv.c b/interface/symv.c
+index 1f23ce4ee..b7e6558fb 100644
+--- a/interface/symv.c
++++ b/interface/symv.c
+@@ -54,7 +54,7 @@
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA, FLOAT *a, blasint *LDA,
+-            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY){
++            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n	= *N;
+diff --git a/interface/syr.c b/interface/syr.c
+index ad75264b1..bea321d64 100644
+--- a/interface/syr.c
++++ b/interface/syr.c
+@@ -76,7 +76,7 @@ static int (*syr_thread[])(BLASLONG, FLOAT, FLOAT *, BLASLONG, FLOAT *, BLASLONG
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *a, blasint *LDA){
++	 FLOAT  *x, blasint *INCX, FLOAT *a, blasint *LDA, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+@@ -178,7 +178,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
+           AXPYU_K(i + 1, 0, 0, alpha * x[i], x,     1, a, 1, NULL, 0);
+         }
+         a += lda;
+-      }  
++      }
+     } else {
+       for (i = 0; i < n; i++){
+         if (x[i] != ZERO) {
+@@ -188,7 +188,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
+       }
+     }
+     return;
+-  } 
++  }
+ #endif
+   if (incx < 0 ) x -= (n - 1) * incx;
+ 
+diff --git a/interface/syr2.c b/interface/syr2.c
+index 632906d28..de6493f62 100644
+--- a/interface/syr2.c
++++ b/interface/syr2.c
+@@ -76,7 +76,7 @@ static int (*syr2_thread[])(BLASLONG, FLOAT, FLOAT *, BLASLONG, FLOAT *, BLASLON
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a, blasint *LDA){
++	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a, blasint *LDA, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+@@ -188,7 +188,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
+     return;
+   }
+ 
+-	  
++
+   FUNCTION_PROFILE_START();
+ 
+   if (incx < 0 ) x -= (n - 1) * incx;
+diff --git a/interface/syr2k.c b/interface/syr2k.c
+index 47df7f89f..308b8a211 100644
+--- a/interface/syr2k.c
++++ b/interface/syr2k.c
+@@ -85,7 +85,7 @@ void NAME(char *UPLO, char *TRANS,
+          blasint *N, blasint *K,
+          FLOAT *alpha, FLOAT *a, blasint *ldA,
+ 	               FLOAT *b, blasint *ldB,
+-         FLOAT *beta,  FLOAT *c, blasint *ldC){
++         FLOAT *beta,  FLOAT *c, blasint *ldC, int dummy_len0, int dummy_len1){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+diff --git a/interface/syrk.c b/interface/syrk.c
+index 69f2328a4..93cb36728 100644
+--- a/interface/syrk.c
++++ b/interface/syrk.c
+@@ -96,7 +96,7 @@ static int (*syrk[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *, BLA
+ void NAME(char *UPLO, char *TRANS,
+          blasint *N, blasint *K,
+          FLOAT *alpha, FLOAT *a, blasint *ldA,
+-         FLOAT *beta,  FLOAT *c, blasint *ldC){
++         FLOAT *beta,  FLOAT *c, blasint *ldC, int dummy_len0, int dummy_len1){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+diff --git a/interface/tbmv.c b/interface/tbmv.c
+index b5f3ab740..0e534ce14 100644
+--- a/interface/tbmv.c
++++ b/interface/tbmv.c
+@@ -83,7 +83,7 @@ static int (*tbmv_thread[])(BLASLONG, BLASLONG, FLOAT *, BLASLONG, FLOAT *, BLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+ 	 blasint *N, blasint *K,
+-	 FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX){
++	 FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+diff --git a/interface/tbsv.c b/interface/tbsv.c
+index 12a1eb003..66b806797 100644
+--- a/interface/tbsv.c
++++ b/interface/tbsv.c
+@@ -68,7 +68,7 @@ static int (*tbsv[])(BLASLONG, BLASLONG, FLOAT *, BLASLONG, FLOAT *, BLASLONG, v
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+ 	 blasint *N, blasint *K,
+-	 FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX){
++	 FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+diff --git a/interface/tpmv.c b/interface/tpmv.c
+index 262af2285..2b4511ed3 100644
+--- a/interface/tpmv.c
++++ b/interface/tpmv.c
+@@ -82,7 +82,7 @@ static int (*tpmv_thread[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLOAT *, int)
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+-	   blasint *N, FLOAT *a, FLOAT *x, blasint *INCX){
++	   blasint *N, FLOAT *a, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+diff --git a/interface/tpsv.c b/interface/tpsv.c
+index 58be77cd3..74fe727be 100644
+--- a/interface/tpsv.c
++++ b/interface/tpsv.c
+@@ -67,7 +67,7 @@ static int (*tpsv[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, void *) = {
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+-	   blasint *N, FLOAT *a, FLOAT *x, blasint *INCX){
++	   blasint *N, FLOAT *a, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+diff --git a/interface/trmv.c b/interface/trmv.c
+index 2e52527a3..c249ae0f1 100644
+--- a/interface/trmv.c
++++ b/interface/trmv.c
+@@ -82,7 +82,7 @@ static int (*trmv_thread[])(BLASLONG, FLOAT *, BLASLONG, FLOAT *, BLASLONG, FLOA
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+-	   blasint *N, FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX){
++	   blasint *N, FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+diff --git a/interface/trsm.c b/interface/trsm.c
+index 715c83a1f..07fb57691 100644
+--- a/interface/trsm.c
++++ b/interface/trsm.c
+@@ -113,7 +113,7 @@ static int (*trsm[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *, BLA
+ 
+ void NAME(char *SIDE, char *UPLO, char *TRANS, char *DIAG,
+ 	   blasint *M, blasint *N, FLOAT *alpha,
+-	   FLOAT *a, blasint *ldA, FLOAT *b, blasint *ldB){
++	   FLOAT *a, blasint *ldA, FLOAT *b, blasint *ldB, int dummy_len0, int dummy_len1, int dummy_len2, int dummy_len3){
+ 
+   char side_arg  = *SIDE;
+   char uplo_arg  = *UPLO;
+@@ -383,7 +383,7 @@ void CNAME(enum CBLAS_ORDER order,
+ 	args.nthreads = 1;
+   else
+ 	args.nthreads = num_cpu_avail(3);
+-		
++
+ 
+   if (args.nthreads == 1) {
+ #endif
+diff --git a/interface/trsv.c b/interface/trsv.c
+index a054d8eeb..6372a74e8 100644
+--- a/interface/trsv.c
++++ b/interface/trsv.c
+@@ -67,7 +67,7 @@ static int (*trsv[])(BLASLONG, FLOAT *, BLASLONG, FLOAT *, BLASLONG, void *) = {
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+-	   blasint *N, FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX){
++	   blasint *N, FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+diff --git a/interface/zgbmv.c b/interface/zgbmv.c
+index 5128b22e1..6b0b1b35b 100644
+--- a/interface/zgbmv.c
++++ b/interface/zgbmv.c
+@@ -86,7 +86,7 @@ void NAME(char *TRANS, blasint *M, blasint *N,
+ 	 blasint *KU, blasint *KL,
+ 	 FLOAT *ALPHA, FLOAT *a, blasint *LDA,
+ 	 FLOAT *x, blasint *INCX,
+-	 FLOAT *BETA, FLOAT *y, blasint *INCY){
++	 FLOAT *BETA, FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char trans = *TRANS;
+   blasint m = *M;
+@@ -251,7 +251,7 @@ void CNAME(enum CBLAS_ORDER order,
+   buffer = (FLOAT *)blas_memory_alloc(1);
+ 
+ #ifdef SMP
+-  if (m * n  < 125000 || ku + kl < 15) 
++  if (m * n  < 125000 || ku + kl < 15)
+     nthreads = 1;
+   else
+     nthreads = num_cpu_avail(2);
+diff --git a/interface/zgemv.c b/interface/zgemv.c
+index 3438575b9..2e3b75f3b 100644
+--- a/interface/zgemv.c
++++ b/interface/zgemv.c
+@@ -67,7 +67,7 @@ static int (*gemv_thread[])(BLASLONG, BLASLONG, FLOAT *, FLOAT *, BLASLONG,  FLO
+ void NAME(char *TRANS, blasint *M, blasint *N,
+ 	 FLOAT *ALPHA, FLOAT *a, blasint *LDA,
+ 	 FLOAT *x, blasint *INCX,
+-	 FLOAT *BETA,  FLOAT *y, blasint *INCY){
++	 FLOAT *BETA,  FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char trans = *TRANS;
+   blasint m = *M;
+@@ -253,7 +253,7 @@ void CNAME(enum CBLAS_ORDER order,
+ #ifdef SMP
+ 
+ #if defined(_WIN64) && defined(_M_ARM64)
+-  if (m*n > 25000000L) 
++  if (m*n > 25000000L)
+     nthreads = num_cpu_avail(4);
+   else
+     nthreads = 1;
+@@ -262,10 +262,10 @@ void CNAME(enum CBLAS_ORDER order,
+     nthreads = 1;
+   else
+     nthreads = num_cpu_avail(2);
+-#endif  
++#endif
+ 
+   if (nthreads == 1) {
+-#endif  
++#endif
+ 
+     (gemv[(int)trans])(m, n, 0, alpha_r, alpha_i, a, lda, x, incx, y, incy, buffer);
+ 
+diff --git a/interface/zhbmv.c b/interface/zhbmv.c
+index 656f137c6..32727097e 100644
+--- a/interface/zhbmv.c
++++ b/interface/zhbmv.c
+@@ -76,7 +76,7 @@ static  int (*hbmv_thread[])(BLASLONG, BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLO
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, blasint *K, FLOAT  *ALPHA, FLOAT *a, blasint *LDA,
+-            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY){
++            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n	= *N;
+diff --git a/interface/zhemv.c b/interface/zhemv.c
+index 9c31f31d9..173c46aca 100644
+--- a/interface/zhemv.c
++++ b/interface/zhemv.c
+@@ -58,7 +58,7 @@
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA, FLOAT *a, blasint *LDA,
+-            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY){
++            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zher.c b/interface/zher.c
+index 0d24984e6..b50296d84 100644
+--- a/interface/zher.c
++++ b/interface/zher.c
+@@ -76,7 +76,7 @@ static int (*her_thread[])(BLASLONG, FLOAT, FLOAT *, BLASLONG, FLOAT *, BLASLONG
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	  FLOAT  *x, blasint *INCX, FLOAT *a, blasint *LDA){
++	  FLOAT  *x, blasint *INCX, FLOAT *a, blasint *LDA, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zher2.c b/interface/zher2.c
+index 1cae633ce..4dca65cad 100644
+--- a/interface/zher2.c
++++ b/interface/zher2.c
+@@ -76,7 +76,7 @@ static int (*her2_thread[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLOAT *, BLASL
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a, blasint *LDA){
++	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a, blasint *LDA, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zhpmv.c b/interface/zhpmv.c
+index ff49716b5..5d92325f7 100644
+--- a/interface/zhpmv.c
++++ b/interface/zhpmv.c
+@@ -76,7 +76,7 @@ static  int (*hpmv_thread[])(BLASLONG, FLOAT *, FLOAT *, FLOAT *, BLASLONG, FLOA
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA, FLOAT *a,
+-            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY){
++            FLOAT  *x, blasint *INCX, FLOAT *BETA, FLOAT *y, blasint *INCY, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zhpr.c b/interface/zhpr.c
+index 10507a71f..64f1edeea 100644
+--- a/interface/zhpr.c
++++ b/interface/zhpr.c
+@@ -76,7 +76,7 @@ static int (*hpr_thread[])(BLASLONG, FLOAT, FLOAT *, BLASLONG, FLOAT *, FLOAT *,
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *a){
++	 FLOAT  *x, blasint *INCX, FLOAT *a, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zhpr2.c b/interface/zhpr2.c
+index c9bfb44b0..ffabb964c 100644
+--- a/interface/zhpr2.c
++++ b/interface/zhpr2.c
+@@ -76,7 +76,7 @@ static int (*hpr2_thread[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLOAT *, BLASL
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a){
++	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zsbmv.c b/interface/zsbmv.c
+index cd5cefed9..dcb561c18 100644
+--- a/interface/zsbmv.c
++++ b/interface/zsbmv.c
+@@ -82,7 +82,7 @@ static  int (*sbmv_thread[])(BLASLONG, BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLO
+ #endif
+ 
+ void NAME(char *UPLO, blasint *N, blasint *K, FLOAT  *ALPHA, FLOAT *a, blasint *LDA,
+-            FLOAT  *b, blasint *INCX, FLOAT *BETA, FLOAT *c, blasint *INCY){
++            FLOAT  *b, blasint *INCX, FLOAT *BETA, FLOAT *c, blasint *INCY, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n	= *N;
+diff --git a/interface/zspmv.c b/interface/zspmv.c
+index be11463c0..d881cba6b 100644
+--- a/interface/zspmv.c
++++ b/interface/zspmv.c
+@@ -74,7 +74,7 @@ static  int (*spmv_thread[])(BLASLONG, FLOAT *, FLOAT *, FLOAT *, BLASLONG, FLOA
+ #endif
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA, FLOAT *a,
+-            FLOAT  *b, blasint *INCX, FLOAT *BETA, FLOAT *c, blasint *INCY){
++            FLOAT  *b, blasint *INCX, FLOAT *BETA, FLOAT *c, blasint *INCY, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zspr.c b/interface/zspr.c
+index 574b59aa2..d21006557 100644
+--- a/interface/zspr.c
++++ b/interface/zspr.c
+@@ -74,7 +74,7 @@ static int (*spr_thread[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLOAT *, FLOAT
+ #endif
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *a){
++	 FLOAT  *x, blasint *INCX, FLOAT *a, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zspr2.c b/interface/zspr2.c
+index 44c36d553..c726d264b 100644
+--- a/interface/zspr2.c
++++ b/interface/zspr2.c
+@@ -74,7 +74,7 @@ static int (*spr2_thread[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLOAT *, BLASL
+ #endif
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a){
++	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zsymv.c b/interface/zsymv.c
+index 1d6ff1f34..fb693ab90 100644
+--- a/interface/zsymv.c
++++ b/interface/zsymv.c
+@@ -52,7 +52,7 @@
+ #endif
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA, FLOAT *a, blasint *LDA,
+-            FLOAT  *b, blasint *INCX, FLOAT *BETA, FLOAT *c, blasint *INCY){
++            FLOAT  *b, blasint *INCX, FLOAT *BETA, FLOAT *c, blasint *INCY, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zsyr.c b/interface/zsyr.c
+index 51cca84ee..44fd7be5c 100644
+--- a/interface/zsyr.c
++++ b/interface/zsyr.c
+@@ -77,7 +77,7 @@ static int (*syr_thread[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLOAT *, BLASLO
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *a, blasint *LDA){
++	 FLOAT  *x, blasint *INCX, FLOAT *a, blasint *LDA, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/zsyr2.c b/interface/zsyr2.c
+index 7c81c2093..5fe6db279 100644
+--- a/interface/zsyr2.c
++++ b/interface/zsyr2.c
+@@ -74,7 +74,7 @@ static int (*syr2_thread[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLOAT *, BLASL
+ #endif
+ 
+ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
+-	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a, blasint *LDA){
++	 FLOAT  *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *a, blasint *LDA, int dummy_len){
+ 
+   char uplo_arg = *UPLO;
+   blasint n		= *N;
+diff --git a/interface/ztbmv.c b/interface/ztbmv.c
+index d56620c5b..62bd0e3c2 100644
+--- a/interface/ztbmv.c
++++ b/interface/ztbmv.c
+@@ -95,7 +95,7 @@ static int (*tbmv_thread[])(BLASLONG, BLASLONG, FLOAT *, BLASLONG, FLOAT *, BLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+ 	 blasint *N, blasint *K,
+-	 FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX){
++	 FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+diff --git a/interface/ztbsv.c b/interface/ztbsv.c
+index 7e144ce75..84c551e3b 100644
+--- a/interface/ztbsv.c
++++ b/interface/ztbsv.c
+@@ -74,7 +74,7 @@ static int (*tbsv[])(BLASLONG, BLASLONG, FLOAT *, BLASLONG, FLOAT *, BLASLONG, v
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+ 	 blasint *N, blasint *K,
+-	 FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX){
++	 FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+@@ -135,7 +135,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
+ 
+   FLOAT *a = (FLOAT*) va;
+   FLOAT *x = (FLOAT*) vx;
+-  
++
+   int trans, uplo, unit;
+   blasint info;
+   FLOAT *buffer;
+diff --git a/interface/ztpmv.c b/interface/ztpmv.c
+index 3791d1602..cc39eea2e 100644
+--- a/interface/ztpmv.c
++++ b/interface/ztpmv.c
+@@ -94,7 +94,7 @@ static int (*tpmv_thread[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, FLOAT *, int)
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+-	   blasint *N, FLOAT *a, FLOAT *x, blasint *INCX){
++	   blasint *N, FLOAT *a, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+@@ -154,7 +154,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
+ 
+   FLOAT *a = (FLOAT*) va;
+   FLOAT *x = (FLOAT*) vx;
+-  
++
+   int trans, uplo, unit;
+   blasint info;
+   FLOAT *buffer;
+diff --git a/interface/ztpsv.c b/interface/ztpsv.c
+index fa706b565..cae3b811b 100644
+--- a/interface/ztpsv.c
++++ b/interface/ztpsv.c
+@@ -73,7 +73,7 @@ static int (*tpsv[])(BLASLONG, FLOAT *, FLOAT *, BLASLONG, void *) = {
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+-	   blasint *N, FLOAT *a, FLOAT *x, blasint *INCX){
++	   blasint *N, FLOAT *a, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+@@ -130,7 +130,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
+ 
+   FLOAT *a = (FLOAT*) va;
+   FLOAT *x = (FLOAT*) vx;
+-  
++
+   int trans, uplo, unit;
+   blasint info;
+   FLOAT *buffer;
+diff --git a/interface/ztrmv.c b/interface/ztrmv.c
+index 4c47e9e91..492476427 100644
+--- a/interface/ztrmv.c
++++ b/interface/ztrmv.c
+@@ -94,7 +94,7 @@ static int (*trmv_thread[])(BLASLONG, FLOAT *, BLASLONG, FLOAT *, BLASLONG, FLOA
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+-	   blasint *N, FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX){
++	   blasint *N, FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+@@ -156,7 +156,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
+ 
+   FLOAT *a = (FLOAT*) va;
+   FLOAT *x = (FLOAT*) vx;
+-  
++
+   int trans, uplo, unit, buffer_size;
+   blasint info;
+   FLOAT *buffer;
+diff --git a/interface/ztrsv.c b/interface/ztrsv.c
+index cbb7bba13..d8f451060 100644
+--- a/interface/ztrsv.c
++++ b/interface/ztrsv.c
+@@ -73,7 +73,7 @@ static int (*trsv[])(BLASLONG, FLOAT *, BLASLONG, FLOAT *, BLASLONG, void *) = {
+ #ifndef CBLAS
+ 
+ void NAME(char *UPLO, char *TRANS, char *DIAG,
+-	   blasint *N, FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX){
++	   blasint *N, FLOAT *a, blasint *LDA, FLOAT *x, blasint *INCX, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+   char uplo_arg  = *UPLO;
+   char trans_arg = *TRANS;
+@@ -134,7 +134,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
+ 
+   FLOAT *a = (FLOAT*) va;
+   FLOAT *x = (FLOAT*) vx;
+-  
++
+   int trans, uplo, unit;
+   blasint info;
+   FLOAT *buffer;
+diff --git a/kernel/generic/lsame.c b/kernel/generic/lsame.c
+index 83fff1798..eb1f1dbbd 100644
+--- a/kernel/generic/lsame.c
++++ b/kernel/generic/lsame.c
+@@ -38,7 +38,7 @@
+ 
+ #include <ctype.h>
+ 
+-int NAME(const char *A, const char *B){
++int NAME(const char *A, const char *B, int dummy_len0, int dummy_len1){
+ 
+   char a = *A;
+   char b = *B;
+-- 
+2.51.0
+

--- a/recipes/recipes_emscripten/openblas-flang/patches/0005-Return-void-not-int.patch
+++ b/recipes/recipes_emscripten/openblas-flang/patches/0005-Return-void-not-int.patch
@@ -1,0 +1,1304 @@
+From 2403ac3eb0fc5831358ba1c2753579eceb9ac091 Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Mon, 8 Dec 2025 08:00:00 +0000
+Subject: [PATCH 5/8] Return void not int
+
+---
+ common_interface.h        | 240 +++++++++++++++++++-------------------
+ driver/others/xerbla.c    |   8 +-
+ interface/lapack/gesv.c   |  14 +--
+ interface/lapack/getf2.c  |   8 +-
+ interface/lapack/getrf.c  |   8 +-
+ interface/lapack/getrs.c  |   8 +-
+ interface/lapack/laswp.c  |   6 +-
+ interface/lapack/lauu2.c  |   8 +-
+ interface/lapack/lauum.c  |   8 +-
+ interface/lapack/potf2.c  |   8 +-
+ interface/lapack/potrf.c  |   8 +-
+ interface/lapack/potri.c  |   8 +-
+ interface/lapack/trti2.c  |   8 +-
+ interface/lapack/trtri.c  |  10 +-
+ interface/lapack/trtrs.c  |  10 +-
+ interface/lapack/zgetf2.c |   8 +-
+ interface/lapack/zgetrf.c |   8 +-
+ interface/lapack/zgetrs.c |   8 +-
+ interface/lapack/zlaswp.c |   6 +-
+ interface/lapack/zlauu2.c |   8 +-
+ interface/lapack/zlauum.c |   8 +-
+ interface/lapack/zpotf2.c |   8 +-
+ interface/lapack/zpotrf.c |   8 +-
+ interface/lapack/zpotri.c |   8 +-
+ interface/lapack/ztrti2.c |   8 +-
+ interface/lapack/ztrtri.c |  10 +-
+ interface/lapack/ztrtrs.c |  10 +-
+ 27 files changed, 229 insertions(+), 229 deletions(-)
+
+diff --git a/common_interface.h b/common_interface.h
+index e35a21ac6..160c9b2c8 100644
+--- a/common_interface.h
++++ b/common_interface.h
+@@ -43,7 +43,7 @@ extern "C" {
+ 	/* Assume C declarations for C++ */
+ #endif  /* __cplusplus */
+ 
+-int    BLASFUNC(xerbla)(char *, blasint *info, blasint);
++void    BLASFUNC(xerbla)(char *, blasint *info, blasint);
+ 
+ void    openblas_set_num_threads_(int *);
+ 
+@@ -441,10 +441,10 @@ void BLASFUNC(zhpmv) (char *, blasint *, double  *, double *,
+ void BLASFUNC(xhpmv) (char *, blasint *, xdouble  *, xdouble *,
+ 		     xdouble  *, blasint *, xdouble *, xdouble *, blasint *, int);
+ 
+-int BLASFUNC(snorm)(char *, blasint *, blasint *, float  *, blasint *, int);
+-int BLASFUNC(dnorm)(char *, blasint *, blasint *, double *, blasint *, int);
+-int BLASFUNC(cnorm)(char *, blasint *, blasint *, float  *, blasint *, int);
+-int BLASFUNC(znorm)(char *, blasint *, blasint *, double *, blasint *, int);
++void BLASFUNC(snorm)(char *, blasint *, blasint *, float  *, blasint *, int);
++void BLASFUNC(dnorm)(char *, blasint *, blasint *, double *, blasint *, int);
++void BLASFUNC(cnorm)(char *, blasint *, blasint *, float  *, blasint *, int);
++void BLASFUNC(znorm)(char *, blasint *, blasint *, double *, blasint *, int);
+ 
+ void BLASFUNC(sgbmv)(char *, blasint *, blasint *, blasint *, blasint *, float  *, float  *, blasint *,
+ 		    float  *, blasint *, float  *, float  *, blasint *, int);
+@@ -512,16 +512,16 @@ void BLASFUNC(cgemmt)(char*, char *, char *, blasint *, blasint *, float *,
+ void BLASFUNC(zgemmt)(char*, char *, char *, blasint *, blasint *, double *,
+ 	   double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int, int);
+ 
+-int BLASFUNC(sge2mm)(char *, char *, char *, blasint *, blasint *,
++void BLASFUNC(sge2mm)(char *, char *, char *, blasint *, blasint *,
+ 		     float *, float  *, blasint *, float  *, blasint *,
+ 		     float *, float  *, blasint *, int, int, int);
+-int BLASFUNC(dge2mm)(char *, char *, char *, blasint *, blasint *,
++void BLASFUNC(dge2mm)(char *, char *, char *, blasint *, blasint *,
+ 		     double *, double  *, blasint *, double  *, blasint *,
+ 		     double *, double  *, blasint *, int, int, int);
+-int BLASFUNC(cge2mm)(char *, char *, char *, blasint *, blasint *,
++void BLASFUNC(cge2mm)(char *, char *, char *, blasint *, blasint *,
+ 		     float *, float  *, blasint *, float  *, blasint *,
+ 		     float *, float  *, blasint *, int, int, int);
+-int BLASFUNC(zge2mm)(char *, char *, char *, blasint *, blasint *,
++void BLASFUNC(zge2mm)(char *, char *, char *, blasint *, blasint *,
+ 		     double *, double  *, blasint *, double  *, blasint *,
+ 		     double *, double  *, blasint *, int, int, int);
+ 
+@@ -625,145 +625,145 @@ void BLASFUNC(zher2k)(char *, char *, blasint *, blasint *, double *, double *,
+ void BLASFUNC(xher2k)(char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+ 	   xdouble*, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+-int BLASFUNC(cher2m)(char *, char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
++void BLASFUNC(cher2m)(char *, char *, char *, blasint *, blasint *, float  *, float  *, blasint *,
+ 	   float *, blasint *, float  *, float  *, blasint *, int, int, int);
+-int BLASFUNC(zher2m)(char *, char *, char *, blasint *, blasint *, double *, double *, blasint *,
++void BLASFUNC(zher2m)(char *, char *, char *, blasint *, blasint *, double *, double *, blasint *,
+ 	   double*, blasint *, double *, double *, blasint *, int, int, int);
+-int BLASFUNC(xher2m)(char *, char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
++void BLASFUNC(xher2m)(char *, char *, char *, blasint *, blasint *, xdouble *, xdouble *, blasint *,
+ 	   xdouble*, blasint *, xdouble *, xdouble *, blasint *, int, int, int);
+ 
+-int BLASFUNC(sgemt)(char *, blasint *, blasint *, float  *, float  *, blasint *,
++void BLASFUNC(sgemt)(char *, blasint *, blasint *, float  *, float  *, blasint *,
+ 		    float  *, blasint *, int);
+-int BLASFUNC(dgemt)(char *, blasint *, blasint *, double *, double *, blasint *,
++void BLASFUNC(dgemt)(char *, blasint *, blasint *, double *, double *, blasint *,
+ 		    double *, blasint *, int);
+-int BLASFUNC(cgemt)(char *, blasint *, blasint *, float  *, float  *, blasint *,
++void BLASFUNC(cgemt)(char *, blasint *, blasint *, float  *, float  *, blasint *,
+ 		    float  *, blasint *, int);
+-int BLASFUNC(zgemt)(char *, blasint *, blasint *, double *, double *, blasint *,
++void BLASFUNC(zgemt)(char *, blasint *, blasint *, double *, double *, blasint *,
+ 		    double *, blasint *, int);
+ 
+-int BLASFUNC(sgema)(char *, char *, blasint *, blasint *, float  *,
++void BLASFUNC(sgema)(char *, char *, blasint *, blasint *, float  *,
+ 		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *, int, int);
+-int BLASFUNC(dgema)(char *, char *, blasint *, blasint *, double *,
++void BLASFUNC(dgema)(char *, char *, blasint *, blasint *, double *,
+ 		    double *, blasint *, double*, double *, blasint *, double*, blasint *, int, int);
+-int BLASFUNC(cgema)(char *, char *, blasint *, blasint *, float  *,
++void BLASFUNC(cgema)(char *, char *, blasint *, blasint *, float  *,
+ 		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *, int, int);
+-int BLASFUNC(zgema)(char *, char *, blasint *, blasint *, double *,
++void BLASFUNC(zgema)(char *, char *, blasint *, blasint *, double *,
+ 		    double *, blasint *, double*, double *, blasint *, double*, blasint *, int, int);
+ 
+-int BLASFUNC(sgems)(char *, char *, blasint *, blasint *, float  *,
++void BLASFUNC(sgems)(char *, char *, blasint *, blasint *, float  *,
+ 		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *, int, int);
+-int BLASFUNC(dgems)(char *, char *, blasint *, blasint *, double *,
++void BLASFUNC(dgems)(char *, char *, blasint *, blasint *, double *,
+ 		    double *, blasint *, double*, double *, blasint *, double*, blasint *, int, int);
+-int BLASFUNC(cgems)(char *, char *, blasint *, blasint *, float  *,
++void BLASFUNC(cgems)(char *, char *, blasint *, blasint *, float  *,
+ 		    float  *, blasint *, float *, float  *, blasint *, float *, blasint *, int, int);
+-int BLASFUNC(zgems)(char *, char *, blasint *, blasint *, double *,
++void BLASFUNC(zgems)(char *, char *, blasint *, blasint *, double *,
+ 		    double *, blasint *, double*, double *, blasint *, double*, blasint *, int, int);
+ 
+-int BLASFUNC(sgemc)(char *, char *, blasint *, blasint *, blasint *, float *,
++void BLASFUNC(sgemc)(char *, char *, blasint *, blasint *, blasint *, float *,
+ 	   float  *, blasint *, float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *, int, int);
+-int BLASFUNC(dgemc)(char *, char *, blasint *, blasint *, blasint *, double *,
++void BLASFUNC(dgemc)(char *, char *, blasint *, blasint *, blasint *, double *,
+ 	   double *, blasint *, double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int);
+-int BLASFUNC(qgemc)(char *, char *, blasint *, blasint *, blasint *, xdouble *,
++void BLASFUNC(qgemc)(char *, char *, blasint *, blasint *, blasint *, xdouble *,
+ 	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *,  xdouble *, xdouble *, blasint *, int, int);
+-int BLASFUNC(cgemc)(char *, char *, blasint *, blasint *, blasint *, float *,
++void BLASFUNC(cgemc)(char *, char *, blasint *, blasint *, blasint *, float *,
+ 	   float  *, blasint *, float  *, blasint *, float  *, blasint *, float  *, float  *, blasint *, int, int);
+-int BLASFUNC(zgemc)(char *, char *, blasint *, blasint *, blasint *, double *,
++void BLASFUNC(zgemc)(char *, char *, blasint *, blasint *, blasint *, double *,
+ 	   double *, blasint *, double *, blasint *, double *, blasint *, double *, double *, blasint *, int, int);
+-int BLASFUNC(xgemc)(char *, char *, blasint *, blasint *, blasint *, xdouble *,
++void BLASFUNC(xgemc)(char *, char *, blasint *, blasint *, blasint *, xdouble *,
+ 	   xdouble *, blasint *, xdouble *, blasint *, xdouble *, blasint *, xdouble *, xdouble *, blasint *, int, int);
+ 
+ /* Lapack routines */
+ 
+-int BLASFUNC(sgetf2)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
+-int BLASFUNC(dgetf2)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
+-int BLASFUNC(qgetf2)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
+-int BLASFUNC(cgetf2)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
+-int BLASFUNC(zgetf2)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
+-int BLASFUNC(xgetf2)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
+-
+-int BLASFUNC(sgetrf)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
+-int BLASFUNC(dgetrf)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
+-int BLASFUNC(qgetrf)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
+-int BLASFUNC(cgetrf)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
+-int BLASFUNC(zgetrf)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
+-int BLASFUNC(xgetrf)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
+-
+-int BLASFUNC(slaswp)(blasint *, float  *, blasint *, blasint *, blasint *, blasint *, blasint *);
+-int BLASFUNC(dlaswp)(blasint *, double *, blasint *, blasint *, blasint *, blasint *, blasint *);
+-int BLASFUNC(qlaswp)(blasint *, xdouble *, blasint *, blasint *, blasint *, blasint *, blasint *);
+-int BLASFUNC(claswp)(blasint *, float  *, blasint *, blasint *, blasint *, blasint *, blasint *);
+-int BLASFUNC(zlaswp)(blasint *, double *, blasint *, blasint *, blasint *, blasint *, blasint *);
+-int BLASFUNC(xlaswp)(blasint *, xdouble *, blasint *, blasint *, blasint *, blasint *, blasint *);
+-
+-int BLASFUNC(sgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(dgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(qgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *, int);
+-int BLASFUNC(cgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(zgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(xgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *, int);
+-
+-int BLASFUNC(sgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float *, blasint *, blasint *);
+-int BLASFUNC(dgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
+-int BLASFUNC(qgesv)(blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble*, blasint *, blasint *);
+-int BLASFUNC(cgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float *, blasint *, blasint *);
+-int BLASFUNC(zgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
+-int BLASFUNC(xgesv)(blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble*, blasint *, blasint *);
+-
+-int BLASFUNC(spotf2)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(dpotf2)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(qpotf2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-int BLASFUNC(cpotf2)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(zpotf2)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(xpotf2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-
+-int BLASFUNC(spotrf)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(dpotrf)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(qpotrf)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-int BLASFUNC(cpotrf)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(zpotrf)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(xpotrf)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-
+-int BLASFUNC(spotri)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(dpotri)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(qpotri)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-int BLASFUNC(cpotri)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(zpotri)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(xpotri)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-
+-int BLASFUNC(spotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *, int);
+-int BLASFUNC(dpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *, int);
+-int BLASFUNC(qpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *, int);
+-int BLASFUNC(cpotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *, int);
+-int BLASFUNC(zpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *, int);
+-int BLASFUNC(xpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *, int);
+-
+-int BLASFUNC(slauu2)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(dlauu2)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(qlauu2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-int BLASFUNC(clauu2)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(zlauu2)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(xlauu2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-
+-int BLASFUNC(slauum)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(dlauum)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(qlauum)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-int BLASFUNC(clauum)(char *, blasint *, float  *, blasint *, blasint *, int);
+-int BLASFUNC(zlauum)(char *, blasint *, double *, blasint *, blasint *, int);
+-int BLASFUNC(xlauum)(char *, blasint *, xdouble *, blasint *, blasint *, int);
+-
+-int BLASFUNC(strti2)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
+-int BLASFUNC(dtrti2)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
+-int BLASFUNC(qtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
+-int BLASFUNC(ctrti2)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
+-int BLASFUNC(ztrti2)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
+-int BLASFUNC(xtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
+-
+-int BLASFUNC(strtri)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
+-int BLASFUNC(dtrtri)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
+-int BLASFUNC(qtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
+-int BLASFUNC(ctrtri)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
+-int BLASFUNC(ztrtri)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
+-int BLASFUNC(xtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
++void BLASFUNC(sgetf2)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
++void BLASFUNC(dgetf2)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
++void BLASFUNC(qgetf2)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
++void BLASFUNC(cgetf2)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
++void BLASFUNC(zgetf2)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
++void BLASFUNC(xgetf2)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
++
++void BLASFUNC(sgetrf)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
++void BLASFUNC(dgetrf)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
++void BLASFUNC(qgetrf)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
++void BLASFUNC(cgetrf)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
++void BLASFUNC(zgetrf)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
++void BLASFUNC(xgetrf)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
++
++void BLASFUNC(slaswp)(blasint *, float  *, blasint *, blasint *, blasint *, blasint *, blasint *);
++void BLASFUNC(dlaswp)(blasint *, double *, blasint *, blasint *, blasint *, blasint *, blasint *);
++void BLASFUNC(qlaswp)(blasint *, xdouble *, blasint *, blasint *, blasint *, blasint *, blasint *);
++void BLASFUNC(claswp)(blasint *, float  *, blasint *, blasint *, blasint *, blasint *, blasint *);
++void BLASFUNC(zlaswp)(blasint *, double *, blasint *, blasint *, blasint *, blasint *, blasint *);
++void BLASFUNC(xlaswp)(blasint *, xdouble *, blasint *, blasint *, blasint *, blasint *, blasint *);
++
++void BLASFUNC(sgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(dgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(qgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *, int);
++void BLASFUNC(cgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(zgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(xgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *, int);
++
++void BLASFUNC(sgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float *, blasint *, blasint *);
++void BLASFUNC(dgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
++void BLASFUNC(qgesv)(blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble*, blasint *, blasint *);
++void BLASFUNC(cgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float *, blasint *, blasint *);
++void BLASFUNC(zgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
++void BLASFUNC(xgesv)(blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble*, blasint *, blasint *);
++
++void BLASFUNC(spotf2)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(dpotf2)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(qpotf2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++void BLASFUNC(cpotf2)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(zpotf2)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(xpotf2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++void BLASFUNC(spotrf)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(dpotrf)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(qpotrf)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++void BLASFUNC(cpotrf)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(zpotrf)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(xpotrf)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++void BLASFUNC(spotri)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(dpotri)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(qpotri)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++void BLASFUNC(cpotri)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(zpotri)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(xpotri)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++void BLASFUNC(spotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *, int);
++void BLASFUNC(dpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *, int);
++void BLASFUNC(qpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *, int);
++void BLASFUNC(cpotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *, int);
++void BLASFUNC(zpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *, int);
++void BLASFUNC(xpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *, int);
++
++void BLASFUNC(slauu2)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(dlauu2)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(qlauu2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++void BLASFUNC(clauu2)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(zlauu2)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(xlauu2)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++void BLASFUNC(slauum)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(dlauum)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(qlauum)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++void BLASFUNC(clauum)(char *, blasint *, float  *, blasint *, blasint *, int);
++void BLASFUNC(zlauum)(char *, blasint *, double *, blasint *, blasint *, int);
++void BLASFUNC(xlauum)(char *, blasint *, xdouble *, blasint *, blasint *, int);
++
++void BLASFUNC(strti2)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
++void BLASFUNC(dtrti2)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
++void BLASFUNC(qtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
++void BLASFUNC(ctrti2)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
++void BLASFUNC(ztrti2)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
++void BLASFUNC(xtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
++
++void BLASFUNC(strtri)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
++void BLASFUNC(dtrtri)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
++void BLASFUNC(qtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
++void BLASFUNC(ctrtri)(char *, char *, blasint *, float  *, blasint *, blasint *, int, int);
++void BLASFUNC(ztrtri)(char *, char *, blasint *, double *, blasint *, blasint *, int, int);
++void BLASFUNC(xtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *, int, int);
+ 
+ 
+ FLOATRET  BLASFUNC(slamch)(char *, int);
+diff --git a/driver/others/xerbla.c b/driver/others/xerbla.c
+index 290f2833c..1d88c366d 100644
+--- a/driver/others/xerbla.c
++++ b/driver/others/xerbla.c
+@@ -47,7 +47,7 @@
+ #endif
+ 
+ #ifdef INTERFACE64
+-#define MSGFMT " ** On entry to %6s parameter number %2ld had an illegal value\n" 
++#define MSGFMT " ** On entry to %6s parameter number %2ld had an illegal value\n"
+ #else
+ #define MSGFMT " ** On entry to %6s parameter number %2d had an illegal value\n"
+ #endif
+@@ -58,19 +58,19 @@ int __xerbla(char *message, blasint *info, blasint length){
+   printf(MSGFMT,
+ 	  message, *info);
+ 
+-  return 0;
++  return;
+ }
+ 
+ int BLASFUNC(xerbla)(char *, blasint *, blasint) __attribute__ ((weak, alias ("__xerbla")));
+ 
+ #else
+ 
+-int BLASFUNC(xerbla)(char *message, blasint *info, blasint length){
++void BLASFUNC(xerbla)(char *message, blasint *info, blasint length){
+ 
+   printf(MSGFMT,
+ 	  message, *info);
+ 
+-  return 0;
++  return;
+ }
+ 
+ #endif
+diff --git a/interface/lapack/gesv.c b/interface/lapack/gesv.c
+index 21fcc2097..a008a7238 100644
+--- a/interface/lapack/gesv.c
++++ b/interface/lapack/gesv.c
+@@ -60,7 +60,7 @@
+ #endif
+ #endif
+ 
+-int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
++void NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
+          FLOAT *b, blasint *ldB, blasint *Info){
+ 
+   blas_arg_t args;
+@@ -91,7 +91,7 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   args.alpha = NULL;
+@@ -99,7 +99,7 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
+ 
+   *Info = 0;
+ 
+-  if (args.m == 0 || args.n == 0) return 0;
++  if (args.m == 0 || args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -107,7 +107,7 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
+ 
+ #ifndef PPC440
+   buffer = (FLOAT *)blas_memory_alloc(1);
+-  
++
+   sa = (FLOAT *)((BLASLONG)buffer + GEMM_OFFSET_A);
+   sb = (FLOAT *)(((BLASLONG)sa + ((GEMM_P * GEMM_Q * COMPSIZE * SIZE + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
+ #endif
+@@ -117,9 +117,9 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
+ 
+ #if defined(_WIN64) && defined(_M_ARM64)
+   #ifdef COMPLEX
+-    if (args.m * args.n <= 300) 
++    if (args.m * args.n <= 300)
+   #else
+-    if (args.m * args.n <= 500) 
++    if (args.m * args.n <= 500)
+   #endif
+       args.nthreads = 1;
+   else if (args.m * args.n <= 1000)
+@@ -171,5 +171,5 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/getf2.c b/interface/lapack/getf2.c
+index 8506feca9..26f40df4e 100644
+--- a/interface/lapack/getf2.c
++++ b/interface/lapack/getf2.c
+@@ -50,7 +50,7 @@
+ #define ERROR_NAME "SGETF2"
+ #endif
+ 
+-int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
++void NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
+ 
+   blas_arg_t args;
+ 
+@@ -76,11 +76,11 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+-  if (args.m == 0 || args.n == 0) return 0;
++  if (args.m == 0 || args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -105,5 +105,5 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/getrf.c b/interface/lapack/getrf.c
+index 4a58774d1..e62158e61 100644
+--- a/interface/lapack/getrf.c
++++ b/interface/lapack/getrf.c
+@@ -50,7 +50,7 @@
+ #define ERROR_NAME "SGETRF"
+ #endif
+ 
+-int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
++void NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
+ 
+   blas_arg_t args;
+ 
+@@ -76,11 +76,11 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+-  if (args.m == 0 || args.n == 0) return 0;
++  if (args.m == 0 || args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -129,5 +129,5 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/getrs.c b/interface/lapack/getrs.c
+index ef3f341f4..1c1f71aeb 100644
+--- a/interface/lapack/getrs.c
++++ b/interface/lapack/getrs.c
+@@ -60,7 +60,7 @@ static blasint (*getrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
++void NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+   blasint *ipiv, FLOAT *b, blasint *ldB, blasint *Info, int dummy_len){
+ 
+   char trans_arg = *TRANS;
+@@ -103,7 +103,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+ 
+   if (info != 0) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+-    return 0;
++    return;
+   }
+ 
+   args.alpha = NULL;
+@@ -111,7 +111,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+ 
+   *Info = info;
+ 
+-  if (args.m == 0 || args.n == 0) return 0;
++  if (args.m == 0 || args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -147,6 +147,6 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ 
+ }
+diff --git a/interface/lapack/laswp.c b/interface/lapack/laswp.c
+index 6544dbc5b..6b017469d 100644
+--- a/interface/lapack/laswp.c
++++ b/interface/lapack/laswp.c
+@@ -52,7 +52,7 @@ static int (*laswp[])(BLASLONG, BLASLONG, BLASLONG, FLOAT, FLOAT *, BLASLONG, FL
+ #endif
+ };
+ 
+-int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *ipiv, blasint *INCX){
++void NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *ipiv, blasint *INCX){
+ 
+   blasint n    = *N;
+   blasint lda  = *LDA;
+@@ -68,7 +68,7 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
+ 
+   PRINT_DEBUG_NAME;
+ 
+-  if (incx == 0 || n <= 0) return 0;
++  if (incx == 0 || n <= 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -105,6 +105,6 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ 
+ }
+diff --git a/interface/lapack/lauu2.c b/interface/lapack/lauu2.c
+index 74ddb0831..1b463200a 100644
+--- a/interface/lapack/lauu2.c
++++ b/interface/lapack/lauu2.c
+@@ -60,7 +60,7 @@ static blasint (*lauu2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -92,12 +92,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n <= 0) return 0;
++  if (args.n <= 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -124,5 +124,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/lauum.c b/interface/lapack/lauum.c
+index 760cf21c1..508eaa5ae 100644
+--- a/interface/lapack/lauum.c
++++ b/interface/lapack/lauum.c
+@@ -60,7 +60,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -92,12 +92,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n == 0) return 0;
++  if (args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -135,5 +135,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/potf2.c b/interface/lapack/potf2.c
+index cfd116ba1..7e6a385b5 100644
+--- a/interface/lapack/potf2.c
++++ b/interface/lapack/potf2.c
+@@ -60,7 +60,7 @@ static blasint (*potf2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -92,12 +92,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n <= 0) return 0;
++  if (args.n <= 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -124,5 +124,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/potrf.c b/interface/lapack/potrf.c
+index 3f994e7f6..fe8577ccd 100644
+--- a/interface/lapack/potrf.c
++++ b/interface/lapack/potrf.c
+@@ -60,7 +60,7 @@ static blasint (*potrf_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -92,12 +92,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n == 0) return 0;
++  if (args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -146,5 +146,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/potri.c b/interface/lapack/potri.c
+index 51eb4fb2e..7a828876d 100644
+--- a/interface/lapack/potri.c
++++ b/interface/lapack/potri.c
+@@ -68,7 +68,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -101,12 +101,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n == 0) return 0;
++  if (args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -159,5 +159,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/trti2.c b/interface/lapack/trti2.c
+index bd32dc433..adef0d25d 100644
+--- a/interface/lapack/trti2.c
++++ b/interface/lapack/trti2.c
+@@ -60,7 +60,7 @@ static blasint (*trti2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
++void NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
+ 
+   blas_arg_t args;
+ 
+@@ -98,12 +98,12 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n <= 0) return 0;
++  if (args.n <= 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -130,5 +130,5 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/trtri.c b/interface/lapack/trtri.c
+index 8a4716090..ae8f4ccfd 100644
+--- a/interface/lapack/trtri.c
++++ b/interface/lapack/trtri.c
+@@ -61,7 +61,7 @@ static blasint (*trtri_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ #endif
+ 
+ 
+-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
++void NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
+ 
+   blas_arg_t args;
+ 
+@@ -101,17 +101,17 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n == 0) return 0;
++  if (args.n == 0) return;
+ 
+   if (diag) {
+     if (AMIN_K(args.n, args.a, args.lda + 1) == ZERO) {
+       *Info = IAMIN_K(args.n, args.a, args.lda + 1);
+-      return 0;
++      return;
+     }
+   }
+ 
+@@ -155,5 +155,5 @@ else
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/trtrs.c b/interface/lapack/trtrs.c
+index 069bdbd2d..a594b4eca 100644
+--- a/interface/lapack/trtrs.c
++++ b/interface/lapack/trtrs.c
+@@ -60,7 +60,7 @@ static blasint (*trtrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
++void NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+   FLOAT *b, blasint *ldB, blasint *Info, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+     char uplo_arg = *UPLO;
+@@ -116,7 +116,7 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
+   if (info != 0) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   args.alpha = NULL;
+@@ -124,12 +124,12 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
+ 
+   *Info = 0;
+ 
+-  if (args.m == 0) return 0;
++  if (args.m == 0) return;
+ 
+   if (diag) {
+     if (AMIN_K(args.m, args.a, args.lda + 1) == ZERO) {
+       *Info = IAMIN_K(args.m, args.a, args.lda + 1);
+-      return 0;
++      return;
+     }
+   }
+ 
+@@ -168,6 +168,6 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ 
+ }
+diff --git a/interface/lapack/zgetf2.c b/interface/lapack/zgetf2.c
+index 68b9a7e4b..772115f5f 100644
+--- a/interface/lapack/zgetf2.c
++++ b/interface/lapack/zgetf2.c
+@@ -50,7 +50,7 @@
+ #define ERROR_NAME "CGETF2"
+ #endif
+ 
+-int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
++void NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
+ 
+   blas_arg_t args;
+ 
+@@ -76,11 +76,11 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+-  if (args.m == 0 || args.n == 0) return 0;
++  if (args.m == 0 || args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -105,5 +105,5 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/zgetrf.c b/interface/lapack/zgetrf.c
+index d03541fad..bea44cf78 100644
+--- a/interface/lapack/zgetrf.c
++++ b/interface/lapack/zgetrf.c
+@@ -50,7 +50,7 @@
+ #define ERROR_NAME "CGETRF"
+ #endif
+ 
+-int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
++void NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
+ 
+   blas_arg_t args;
+ 
+@@ -76,11 +76,11 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+-  if (args.m == 0 || args.n == 0) return 0;
++  if (args.m == 0 || args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -121,5 +121,5 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/zgetrs.c b/interface/lapack/zgetrs.c
+index 18914ecff..d8da8ffa2 100644
+--- a/interface/lapack/zgetrs.c
++++ b/interface/lapack/zgetrs.c
+@@ -60,7 +60,7 @@ static blasint (*getrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
++void NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+ 	    blasint *ipiv, FLOAT *b, blasint *ldB, blasint *Info, int dummy_len){
+ 
+   char trans_arg = *TRANS;
+@@ -103,7 +103,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+ 
+   if (info != 0) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+-    return 0;
++    return;
+   }
+ 
+   args.alpha = NULL;
+@@ -111,7 +111,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+ 
+   *Info = info;
+ 
+-  if (args.m == 0 || args.n == 0) return 0;
++  if (args.m == 0 || args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -148,6 +148,6 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ 
+ }
+diff --git a/interface/lapack/zlaswp.c b/interface/lapack/zlaswp.c
+index 7bb4a659e..536d69e4f 100644
+--- a/interface/lapack/zlaswp.c
++++ b/interface/lapack/zlaswp.c
+@@ -52,7 +52,7 @@ static int (*laswp[])(BLASLONG, BLASLONG, BLASLONG, FLOAT, FLOAT, FLOAT *, BLASL
+ #endif
+ };
+ 
+-int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *ipiv, blasint *INCX){
++void NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *ipiv, blasint *INCX){
+ 
+   blasint n    = *N;
+   blasint lda  = *LDA;
+@@ -69,7 +69,7 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
+ 
+   PRINT_DEBUG_NAME;
+ 
+-  if (incx == 0 || n <= 0) return 0;
++  if (incx == 0 || n <= 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -104,5 +104,5 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/zlauu2.c b/interface/lapack/zlauu2.c
+index 2385b5ff6..81b5e6360 100644
+--- a/interface/lapack/zlauu2.c
++++ b/interface/lapack/zlauu2.c
+@@ -61,7 +61,7 @@ static blasint (*lauu2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -93,12 +93,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n <= 0) return 0;
++  if (args.n <= 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -125,5 +125,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/zlauum.c b/interface/lapack/zlauum.c
+index 03ed0241d..5be8dbf14 100644
+--- a/interface/lapack/zlauum.c
++++ b/interface/lapack/zlauum.c
+@@ -60,7 +60,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -92,12 +92,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n == 0) return 0;
++  if (args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -137,5 +137,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/zpotf2.c b/interface/lapack/zpotf2.c
+index 490f0ceae..349a98597 100644
+--- a/interface/lapack/zpotf2.c
++++ b/interface/lapack/zpotf2.c
+@@ -61,7 +61,7 @@ static blasint (*potf2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0){
+ 
+   blas_arg_t args;
+ 
+@@ -93,12 +93,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n <= 0) return 0;
++  if (args.n <= 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -125,5 +125,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/zpotrf.c b/interface/lapack/zpotrf.c
+index dd80b9678..9074a1e34 100644
+--- a/interface/lapack/zpotrf.c
++++ b/interface/lapack/zpotrf.c
+@@ -60,7 +60,7 @@ static blasint (*potrf_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -92,12 +92,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n == 0) return 0;
++  if (args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -144,5 +144,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/zpotri.c b/interface/lapack/zpotri.c
+index 6d789d7a4..cfc25f2d3 100644
+--- a/interface/lapack/zpotri.c
++++ b/interface/lapack/zpotri.c
+@@ -68,7 +68,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
++void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len){
+ 
+   blas_arg_t args;
+ 
+@@ -101,12 +101,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n == 0) return 0;
++  if (args.n == 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -165,5 +165,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dumm
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/ztrti2.c b/interface/lapack/ztrti2.c
+index b8085d387..1f3b5d1b6 100644
+--- a/interface/lapack/ztrti2.c
++++ b/interface/lapack/ztrti2.c
+@@ -60,7 +60,7 @@ static blasint (*trti2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
+ #endif
+   };
+ 
+-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
++void NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
+ 
+   blas_arg_t args;
+ 
+@@ -98,12 +98,12 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n <= 0) return 0;
++  if (args.n <= 0) return;
+ 
+   IDEBUG_START;
+ 
+@@ -130,5 +130,5 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/ztrtri.c b/interface/lapack/ztrtri.c
+index a5cb8448c..223c31bba 100644
+--- a/interface/lapack/ztrtri.c
++++ b/interface/lapack/ztrtri.c
+@@ -60,7 +60,7 @@ static blasint (*trtri_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
++void NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info, int dummy_len0, int dummy_len1){
+ 
+   blas_arg_t args;
+ 
+@@ -98,17 +98,17 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
+   if (info) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   *Info = 0;
+ 
+-  if (args.n == 0) return 0;
++  if (args.n == 0) return;
+ 
+   if (diag) {
+     if (AMIN_K(args.n, args.a, args.lda + 1) == ZERO) {
+       *Info = IAMIN_K(args.n, args.a, args.lda + 1);
+-      return 0;
++      return;
+     }
+   }
+ 
+@@ -150,5 +150,5 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ }
+diff --git a/interface/lapack/ztrtrs.c b/interface/lapack/ztrtrs.c
+index 2b195e615..da1ae7ded 100644
+--- a/interface/lapack/ztrtrs.c
++++ b/interface/lapack/ztrtrs.c
+@@ -60,7 +60,7 @@ static blasint (*trtrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
+ };
+ #endif
+ 
+-int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
++void NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+   FLOAT *b, blasint *ldB, blasint *Info, int dummy_len0, int dummy_len1, int dummy_len2){
+ 
+     char uplo_arg = *UPLO;
+@@ -116,7 +116,7 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
+   if (info != 0) {
+     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
+     *Info = - info;
+-    return 0;
++    return;
+   }
+ 
+   args.alpha = NULL;
+@@ -124,12 +124,12 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
+ 
+   *Info = 0;
+ 
+-  if (args.m == 0) return 0;
++  if (args.m == 0) return;
+ 
+   if (diag) {
+     if (AMIN_K(args.m, args.a, args.lda + 1) == ZERO) {
+       *Info = IAMIN_K(args.m, args.a, args.lda + 1);
+-      return 0;
++      return;
+     }
+   }
+ 
+@@ -168,6 +168,6 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
+ 
+   IDEBUG_END;
+ 
+-  return 0;
++  return;
+ 
+ }
+-- 
+2.51.0
+

--- a/recipes/recipes_emscripten/openblas-flang/patches/0006-Int-to-void-return-types-of-lapack-functions-used-by.patch
+++ b/recipes/recipes_emscripten/openblas-flang/patches/0006-Int-to-void-return-types-of-lapack-functions-used-by.patch
@@ -1,0 +1,288 @@
+From 77a699b83932388688254b8b16a69efa71ceca13 Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Mon, 8 Dec 2025 08:07:39 +0000
+Subject: [PATCH 6/8] Int to void return types of lapack functions used by
+ lapacke
+
+---
+ lapack-netlib/LAPACKE/include/lapack.h | 66 +++++++++++++-------------
+ 1 file changed, 33 insertions(+), 33 deletions(-)
+
+diff --git a/lapack-netlib/LAPACKE/include/lapack.h b/lapack-netlib/LAPACKE/include/lapack.h
+index 0ed9ad01a..88393b787 100644
+--- a/lapack-netlib/LAPACKE/include/lapack.h
++++ b/lapack-netlib/LAPACKE/include/lapack.h
+@@ -3538,28 +3538,28 @@ void LAPACK_zgedmdq_base(
+ #endif
+ 
+ #define LAPACK_cgesv LAPACK_GLOBAL(cgesv,CGESV)
+-lapack_int LAPACK_cgesv(
++void LAPACK_cgesv(
+     lapack_int const* n, lapack_int const* nrhs,
+     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_complex_float* B, lapack_int const* ldb,
+     lapack_int* info );
+ 
+ #define LAPACK_dgesv LAPACK_GLOBAL(dgesv,DGESV)
+-lapack_int LAPACK_dgesv(
++void LAPACK_dgesv(
+     lapack_int const* n, lapack_int const* nrhs,
+     double* A, lapack_int const* lda, lapack_int* ipiv,
+     double* B, lapack_int const* ldb,
+     lapack_int* info );
+ 
+ #define LAPACK_sgesv LAPACK_GLOBAL(sgesv,SGESV)
+-lapack_int LAPACK_sgesv(
++void LAPACK_sgesv(
+     lapack_int const* n, lapack_int const* nrhs,
+     float* A, lapack_int const* lda, lapack_int* ipiv,
+     float* B, lapack_int const* ldb,
+     lapack_int* info );
+ 
+ #define LAPACK_zgesv LAPACK_GLOBAL(zgesv,ZGESV)
+-lapack_int LAPACK_zgesv(
++void LAPACK_zgesv(
+     lapack_int const* n, lapack_int const* nrhs,
+     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_complex_double* B, lapack_int const* ldb,
+@@ -4158,49 +4158,49 @@ void LAPACK_zgesvxx_base(
+ #endif
+ 
+ #define LAPACK_cgetf2 LAPACK_GLOBAL(cgetf2,CGETF2)
+-lapack_int LAPACK_cgetf2(
++void LAPACK_cgetf2(
+     lapack_int const* m, lapack_int const* n,
+     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_int* info );
+ 
+ #define LAPACK_dgetf2 LAPACK_GLOBAL(dgetf2,DGETF2)
+-lapack_int LAPACK_dgetf2(
++void LAPACK_dgetf2(
+     lapack_int const* m, lapack_int const* n,
+     double* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_int* info );
+ 
+ #define LAPACK_sgetf2 LAPACK_GLOBAL(sgetf2,SGETF2)
+-lapack_int LAPACK_sgetf2(
++void LAPACK_sgetf2(
+     lapack_int const* m, lapack_int const* n,
+     float* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_int* info );
+ 
+ #define LAPACK_zgetf2 LAPACK_GLOBAL(zgetf2,ZGETF2)
+-lapack_int LAPACK_zgetf2(
++void LAPACK_zgetf2(
+     lapack_int const* m, lapack_int const* n,
+     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_int* info );
+ 
+ #define LAPACK_cgetrf LAPACK_GLOBAL(cgetrf,CGETRF)
+-lapack_int LAPACK_cgetrf(
++void LAPACK_cgetrf(
+     lapack_int const* m, lapack_int const* n,
+     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_int* info );
+ 
+ #define LAPACK_dgetrf LAPACK_GLOBAL(dgetrf,DGETRF)
+-lapack_int LAPACK_dgetrf(
++void LAPACK_dgetrf(
+     lapack_int const* m, lapack_int const* n,
+     double* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_int* info );
+ 
+ #define LAPACK_sgetrf LAPACK_GLOBAL(sgetrf,SGETRF)
+-lapack_int LAPACK_sgetrf(
++void LAPACK_sgetrf(
+     lapack_int const* m, lapack_int const* n,
+     float* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_int* info );
+ 
+ #define LAPACK_zgetrf LAPACK_GLOBAL(zgetrf,ZGETRF)
+-lapack_int LAPACK_zgetrf(
++void LAPACK_zgetrf(
+     lapack_int const* m, lapack_int const* n,
+     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
+     lapack_int* info );
+@@ -4258,7 +4258,7 @@ void LAPACK_zgetri(
+     lapack_int* info );
+ 
+ #define LAPACK_cgetrs_base LAPACK_GLOBAL(cgetrs,CGETRS)
+-lapack_int LAPACK_cgetrs_base(
++void LAPACK_cgetrs_base(
+     char const* trans,
+     lapack_int const* n, lapack_int const* nrhs,
+     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
+@@ -4275,7 +4275,7 @@ lapack_int LAPACK_cgetrs_base(
+ #endif
+ 
+ #define LAPACK_dgetrs_base LAPACK_GLOBAL(dgetrs,DGETRS)
+-lapack_int LAPACK_dgetrs_base(
++void LAPACK_dgetrs_base(
+     char const* trans,
+     lapack_int const* n, lapack_int const* nrhs,
+     double const* A, lapack_int const* lda, lapack_int const* ipiv,
+@@ -4292,7 +4292,7 @@ lapack_int LAPACK_dgetrs_base(
+ #endif
+ 
+ #define LAPACK_sgetrs_base LAPACK_GLOBAL(sgetrs,SGETRS)
+-lapack_int LAPACK_sgetrs_base(
++void LAPACK_sgetrs_base(
+     char const* trans,
+     lapack_int const* n, lapack_int const* nrhs,
+     float const* A, lapack_int const* lda, lapack_int const* ipiv,
+@@ -4309,7 +4309,7 @@ lapack_int LAPACK_sgetrs_base(
+ #endif
+ 
+ #define LAPACK_zgetrs_base LAPACK_GLOBAL(zgetrs,ZGETRS)
+-lapack_int LAPACK_zgetrs_base(
++void LAPACK_zgetrs_base(
+     char const* trans,
+     lapack_int const* n, lapack_int const* nrhs,
+     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
+@@ -11160,22 +11160,22 @@ void LAPACK_zlassq(
+     double* sumsq );
+ 
+ #define LAPACK_claswp LAPACK_GLOBAL(claswp,CLASWP)
+-lapack_int LAPACK_claswp(
++void LAPACK_claswp(
+     lapack_int const* n,
+     lapack_complex_float* A, lapack_int const* lda, lapack_int const* k1, lapack_int const* k2, lapack_int const* ipiv, lapack_int const* incx );
+ 
+ #define LAPACK_dlaswp LAPACK_GLOBAL(dlaswp,DLASWP)
+-lapack_int LAPACK_dlaswp(
++void LAPACK_dlaswp(
+     lapack_int const* n,
+     double* A, lapack_int const* lda, lapack_int const* k1, lapack_int const* k2, lapack_int const* ipiv, lapack_int const* incx );
+ 
+ #define LAPACK_slaswp LAPACK_GLOBAL(slaswp,SLASWP)
+-lapack_int LAPACK_slaswp(
++void LAPACK_slaswp(
+     lapack_int const* n,
+     float* A, lapack_int const* lda, lapack_int const* k1, lapack_int const* k2, lapack_int const* ipiv, lapack_int const* incx );
+ 
+ #define LAPACK_zlaswp LAPACK_GLOBAL(zlaswp,ZLASWP)
+-lapack_int LAPACK_zlaswp(
++void LAPACK_zlaswp(
+     lapack_int const* n,
+     lapack_complex_double* A, lapack_int const* lda, lapack_int const* k1, lapack_int const* k2, lapack_int const* ipiv, lapack_int const* incx );
+ 
+@@ -11268,7 +11268,7 @@ void LAPACK_zlatms_base(
+ #endif
+ 
+ #define LAPACK_clauum_base LAPACK_GLOBAL(clauum,CLAUUM)
+-lapack_int LAPACK_clauum_base(
++void LAPACK_clauum_base(
+     char const* uplo,
+     lapack_int const* n,
+     lapack_complex_float* A, lapack_int const* lda,
+@@ -11284,7 +11284,7 @@ lapack_int LAPACK_clauum_base(
+ #endif
+ 
+ #define LAPACK_dlauum_base LAPACK_GLOBAL(dlauum,DLAUUM)
+-lapack_int LAPACK_dlauum_base(
++void LAPACK_dlauum_base(
+     char const* uplo,
+     lapack_int const* n,
+     double* A, lapack_int const* lda,
+@@ -11300,7 +11300,7 @@ lapack_int LAPACK_dlauum_base(
+ #endif
+ 
+ #define LAPACK_slauum_base LAPACK_GLOBAL(slauum,SLAUUM)
+-lapack_int LAPACK_slauum_base(
++void LAPACK_slauum_base(
+     char const* uplo,
+     lapack_int const* n,
+     float* A, lapack_int const* lda,
+@@ -11316,7 +11316,7 @@ lapack_int LAPACK_slauum_base(
+ #endif
+ 
+ #define LAPACK_zlauum_base LAPACK_GLOBAL(zlauum,ZLAUUM)
+-lapack_int LAPACK_zlauum_base(
++void LAPACK_zlauum_base(
+     char const* uplo,
+     lapack_int const* n,
+     lapack_complex_double* A, lapack_int const* lda,
+@@ -11332,7 +11332,7 @@ lapack_int LAPACK_zlauum_base(
+ #endif
+ 
+ #define LAPACK_ilaver LAPACK_GLOBAL(ilaver,ILAVER)
+-lapack_int LAPACK_ilaver(
++void LAPACK_ilaver(
+     lapack_int* vers_major, lapack_int* vers_minor, lapack_int* vers_patch );
+ 
+ #define LAPACK_dopgtr_base LAPACK_GLOBAL(dopgtr,DOPGTR)
+@@ -13609,7 +13609,7 @@ void LAPACK_zpotf2_base(
+ #endif
+ 
+ #define LAPACK_cpotrf_base LAPACK_GLOBAL(cpotrf,CPOTRF)
+-lapack_int LAPACK_cpotrf_base(
++void LAPACK_cpotrf_base(
+     char const* uplo,
+     lapack_int const* n,
+     lapack_complex_float* A, lapack_int const* lda,
+@@ -13625,7 +13625,7 @@ lapack_int LAPACK_cpotrf_base(
+ #endif
+ 
+ #define LAPACK_dpotrf_base LAPACK_GLOBAL(dpotrf,DPOTRF)
+-lapack_int LAPACK_dpotrf_base(
++void LAPACK_dpotrf_base(
+     char const* uplo,
+     lapack_int const* n,
+     double* A, lapack_int const* lda,
+@@ -13641,7 +13641,7 @@ lapack_int LAPACK_dpotrf_base(
+ #endif
+ 
+ #define LAPACK_spotrf_base LAPACK_GLOBAL(spotrf,SPOTRF)
+-lapack_int LAPACK_spotrf_base(
++void LAPACK_spotrf_base(
+     char const* uplo,
+     lapack_int const* n,
+     float* A, lapack_int const* lda,
+@@ -13657,7 +13657,7 @@ lapack_int LAPACK_spotrf_base(
+ #endif
+ 
+ #define LAPACK_zpotrf_base LAPACK_GLOBAL(zpotrf,ZPOTRF)
+-lapack_int LAPACK_zpotrf_base(
++void LAPACK_zpotrf_base(
+     char const* uplo,
+     lapack_int const* n,
+     lapack_complex_double* A, lapack_int const* lda,
+@@ -22315,7 +22315,7 @@ void LAPACK_ztrsyl3_base(
+ #endif
+ 
+ #define LAPACK_ctrtri_base LAPACK_GLOBAL(ctrtri,CTRTRI)
+-lapack_int LAPACK_ctrtri_base(
++void LAPACK_ctrtri_base(
+     char const* uplo, char const* diag,
+     lapack_int const* n,
+     lapack_complex_float* A, lapack_int const* lda,
+@@ -22331,7 +22331,7 @@ lapack_int LAPACK_ctrtri_base(
+ #endif
+ 
+ #define LAPACK_dtrtri_base LAPACK_GLOBAL(dtrtri,DTRTRI)
+-lapack_int LAPACK_dtrtri_base(
++void LAPACK_dtrtri_base(
+     char const* uplo, char const* diag,
+     lapack_int const* n,
+     double* A, lapack_int const* lda,
+@@ -22347,7 +22347,7 @@ lapack_int LAPACK_dtrtri_base(
+ #endif
+ 
+ #define LAPACK_strtri_base LAPACK_GLOBAL(strtri,STRTRI)
+-lapack_int LAPACK_strtri_base(
++void LAPACK_strtri_base(
+     char const* uplo, char const* diag,
+     lapack_int const* n,
+     float* A, lapack_int const* lda,
+@@ -22363,7 +22363,7 @@ lapack_int LAPACK_strtri_base(
+ #endif
+ 
+ #define LAPACK_ztrtri_base LAPACK_GLOBAL(ztrtri,ZTRTRI)
+-lapack_int LAPACK_ztrtri_base(
++void LAPACK_ztrtri_base(
+     char const* uplo, char const* diag,
+     lapack_int const* n,
+     lapack_complex_double* A, lapack_int const* lda,
+-- 
+2.51.0
+

--- a/recipes/recipes_emscripten/openblas-flang/patches/0007-Enable-LAPACK_FORTRAN_STDLEN_END-for-lapacke-calling.patch
+++ b/recipes/recipes_emscripten/openblas-flang/patches/0007-Enable-LAPACK_FORTRAN_STDLEN_END-for-lapacke-calling.patch
@@ -1,0 +1,29 @@
+From 079299a27d6bc71a287f479d75230dc1b7c30133 Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Mon, 8 Dec 2025 17:10:40 +0000
+Subject: [PATCH 7/8] Enable LAPACK_FORTRAN_STDLEN_END for lapacke calling
+ lapack
+
+---
+ lapack-netlib/LAPACKE/include/lapack.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lapack-netlib/LAPACKE/include/lapack.h b/lapack-netlib/LAPACKE/include/lapack.h
+index 88393b787..2c437314c 100644
+--- a/lapack-netlib/LAPACKE/include/lapack.h
++++ b/lapack-netlib/LAPACKE/include/lapack.h
+@@ -17,9 +17,9 @@
+ /* It seems all current Fortran compilers put strlen at end.
+ *  Some historical compilers put strlen after the str argument
+ *  or make the str argument into a struct. */
+-#ifndef __EMSCRIPTEN__
++
+ #define LAPACK_FORTRAN_STRLEN_END
+-#endif
++
+ 
+ #ifndef FORTRAN_STRLEN
+   #define FORTRAN_STRLEN size_t
+-- 
+2.51.0
+

--- a/recipes/recipes_emscripten/openblas-flang/patches/0008-Use-openblas-flang-in-pkgconfig-and-cmake-config.patch
+++ b/recipes/recipes_emscripten/openblas-flang/patches/0008-Use-openblas-flang-in-pkgconfig-and-cmake-config.patch
@@ -1,0 +1,59 @@
+From ffcef24b913aa023b31a09dabfef74afb78f85da Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Mon, 5 Jan 2026 11:20:41 +0000
+Subject: [PATCH 8/8] Use openblas-flang in pkgconfig and cmake config
+
+---
+ CMakeLists.txt       | 4 ++--
+ cmake/openblas.pc.in | 4 ++--
+ openblas.pc.in       | 4 ++--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ce583cc0b..119324359 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -703,8 +703,8 @@ if(NOT NO_LAPACKE)
+ endif()
+ 
+ # Install pkg-config files
+-configure_file(${PROJECT_SOURCE_DIR}/cmake/openblas.pc.in ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc @ONLY)
+-install (FILES ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
++configure_file(${PROJECT_SOURCE_DIR}/cmake/openblas.pc.in ${PROJECT_BINARY_DIR}/openblas-flang${SUFFIX64}.pc @ONLY)
++install (FILES ${PROJECT_BINARY_DIR}/openblas-flang${SUFFIX64}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
+ 
+ 
+ set(PN OpenBLAS)
+diff --git a/cmake/openblas.pc.in b/cmake/openblas.pc.in
+index 374221b47..1a0f2967c 100644
+--- a/cmake/openblas.pc.in
++++ b/cmake/openblas.pc.in
+@@ -5,9 +5,9 @@ libsuffix=@SUFFIX64_UNDERSCORE@
+ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+ openblas_config=USE_64BITINT=@INTERFACE64@ NO_CBLAS=@NO_CBLAS@ NO_LAPACK=@NO_LAPACK@ NO_LAPACKE=@NO_LAPACKE@ DYNAMIC_ARCH=@DYNAMIC_ARCH@ DYNAMIC_OLDER=@DYNAMIC_OLDER@ NO_AFFINITY=@NO_AFFINITY@ USE_OPENMP=@USE_OPENMP@ @CORE@ MAX_THREADS=@NUM_THREADS@ 
+-Name: OpenBLAS
++Name: OpenBLAS-flang
+ Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version
+ Version: @OpenBLAS_VERSION@
+ URL: https://github.com/OpenMathLib/OpenBLAS
+-Libs: -L${libdir} -l${libnameprefix}openblas${libnamesuffix}${libsuffix} 
++Libs: -L${libdir} -l${libnameprefix}openblas-flang${libnamesuffix}${libsuffix} 
+ Cflags: -I${includedir} @OpenMP_C_FLAGS@ 
+diff --git a/openblas.pc.in b/openblas.pc.in
+index fe2f08720..59c742edd 100644
+--- a/openblas.pc.in
++++ b/openblas.pc.in
+@@ -1,7 +1,7 @@
+-Name: openblas
++Name: openblas-flang
+ Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version
+ Version: ${version}
+ URL: https://github.com/xianyi/OpenBLAS
+-Libs: -L${libdir} -l${libprefix}openblas${libsuffix}${libnamesuffix}
++Libs: -L${libdir} -l${libprefix}openblas-flang${libsuffix}${libnamesuffix}
+ Libs.private: ${extralib}
+ Cflags: -I${includedir} ${omp_opt}
+-- 
+2.51.0
+

--- a/recipes/recipes_emscripten/openblas-flang/recipe.yaml
+++ b/recipes/recipes_emscripten/openblas-flang/recipe.yaml
@@ -10,12 +10,18 @@ source:
   url: https://github.com/OpenMathLib/OpenBLAS/archive/v${{ version }}.tar.gz
   sha256: 27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d
   patches:
+  # Branch containing these patches is v0.3.30-emforge-4x at https://github.com/ianthomas23/OpenBLAS
   - patches/0001-Remove-march-flags.patch
   - patches/0002-Skip-linktest.patch
   - patches/0003-Add-emscripten-as-supported-arch.patch
+  - patches/0004-Add-dummy-length-arguments-for-char-arguments.patch
+  - patches/0005-Return-void-not-int.patch
+  - patches/0006-Int-to-void-return-types-of-lapack-functions-used-by.patch
+  - patches/0007-Enable-LAPACK_FORTRAN_STDLEN_END-for-lapacke-calling.patch
+  - patches/0008-Use-openblas-flang-in-pkgconfig-and-cmake-config.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -28,12 +34,23 @@ requirements:
 
 tests:
 - package_contents:
-    lib:
-    - libopenblas.a
-    - libopenblas.so
     include:
     - cblas.h
+    - f77blas.h
     - lapack.h
+    - lapacke.h
+    lib:
+    - libopenblas-flang.a
+    - libopenblas-flang.so
+- script: pytester
+  files:
+    recipe:
+    - test_openblas.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
 
 about:
   homepage: http://www.openblas.net/
@@ -47,3 +64,4 @@ extra:
   - DerThorsten
   - anutosh491
   - IsabelParedes
+  - ianthomas23

--- a/recipes/recipes_emscripten/openblas-flang/test_openblas.py
+++ b/recipes/recipes_emscripten/openblas-flang/test_openblas.py
@@ -1,0 +1,6 @@
+import pyjs
+
+def test_dummy():
+    # This doesn't run any actual tests, but it forces the testing framework to load
+    # libopenblas-flang.so which will identify if there are any missing symbols.
+    pass


### PR DESCRIPTION
This builds `openblas-flang`, i.e. `openblas` using the `flang` Fortran compiler, on the `main` branch. It is a port of PR #4185 from the `emscripten-4x` branch using `-fexceptions` instead of `-fwasm-exceptions`. Needed for upcoming `scipy 1.15.2` build.