### PR TITLE
Rebuild scikit-learn 1.8.0 on main against new scipy-with-flang package

### DIFF
--- a/recipes/recipes_emscripten/scikit-learn/recipe.yaml
+++ b/recipes/recipes_emscripten/scikit-learn/recipe.yaml
@@ -13,7 +13,7 @@ source:
   - patches/0001-Patch-away-urllib.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/scikit-learn/test_sklearn.py
+++ b/recipes/recipes_emscripten/scikit-learn/test_sklearn.py
@@ -1,54 +1,67 @@
 import pytest
-import pyjs
 
 
-def  test_numpy_testing():
-    import numpy.testing as npt
-
-
-# @pytest.mark.skip(reason="failing since scipy build is broken atm")
-def test_scikit_learn():
-    print("1.1")
+def test_logistic_regression():
     import numpy as np
+    from numpy.testing import assert_allclose
     import sklearn
     from sklearn.linear_model import LogisticRegression
-    print("1.2")
     rng = np.random.RandomState(42)
     X = rng.rand(100, 20)
     y = rng.randint(5, size=100)
-    print("1.3")
     estimator = LogisticRegression(solver='newton-cholesky')
-    print("1.4")
     estimator.fit(X, y)
-    print(estimator.predict(X))
-    estimator.score(X, y)
-    print("1.5")
-
-# @pytest.mark.skip(reason="failing since scipy build is broken atm")
-def test_logistic_regression():
-    print("2.1")
-    from sklearn.datasets import load_iris
-    print("2.2")
-    from sklearn.linear_model import LogisticRegression
-    print("2.3")
-    X, y = load_iris(return_X_y=True)
-    print("2.4")
-    clf = LogisticRegression(random_state=0, max_iter=1000).fit(X, y)
-    print(clf.predict(X[:2, :]))
-    print("2.5")
-    print(clf.predict_proba(X[:2, :]))
-    print("2.6")
-    print(clf.score(X, y))
+    p = estimator.predict(X)
+    assert_allclose(p, [
+        0, 2, 1, 1, 1, 1, 4, 3, 4, 4, 0, 1, 3, 1, 1, 0, 0, 4, 4, 1, 0, 3, 4, 1, 0, 4, 1, 3, 3,
+        0, 1, 1, 4, 1, 0, 1, 1, 1, 4, 1, 2, 0, 4, 0, 0, 4, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 3,
+        1, 1, 2, 3, 0, 0, 0, 1, 0, 1, 1, 4, 1, 0, 1, 1, 1, 4, 0, 1, 4, 1, 1, 3, 1, 0, 4, 3, 1,
+        0, 1, 1, 3, 3, 0, 0, 1, 1, 3, 1, 0, 1
+    ])
+    s = estimator.score(X, y)
+    assert_allclose(s, 0.57)
 
 
-
-# is_browser_worker = pyjs.js.Function('return typeof importScripts === "function"')()
-# skip_non_worker = pytest.mark.skipif(
-#     not is_browser_worker,
-#     reason="requires browser-worker, not node",
-# )
-
-# @pytest.mark.skip(reason="failing since scipy build is broken atm")
-def test_dl():
+def test_fetch():
     from sklearn import datasets
-    iris = datasets.fetch_california_housing()
+    ds = datasets.fetch_california_housing()
+    assert ds['data'].shape == (20640, 8)
+    assert ds['target'].shape == (20640,)
+
+
+def test_pairwise_distance():
+    from numpy.testing import assert_allclose
+    from sklearn.metrics.pairwise import pairwise_distances
+    x = [[0, 0, 0], [1, 1, 1]]
+    y = [[1, 0, 0], [1, 1, 0]]
+    d = pairwise_distances(x, y, metric='sqeuclidean')
+    assert_allclose(d, [[1.0, 2.0], [2.0, 1.0]])
+
+
+def test_factor_analysis():
+    from numpy.testing import assert_allclose
+    from sklearn.datasets import load_iris
+    from sklearn.decomposition import PCA, FactorAnalysis
+    from sklearn.preprocessing import StandardScaler
+
+    data = load_iris()
+    X = StandardScaler().fit_transform(data["data"])
+    feature_names = data["feature_names"]
+
+    n_components = 2
+    pca = PCA(n_components).fit(X)
+    fa_unrotated = FactorAnalysis(n_components).fit(X)
+    fa_rotated = FactorAnalysis(n_components, rotation="varimax").fit(X)
+
+    assert_allclose(pca.components_, [
+        [0.52106591, -0.26934744, 0.580413096, 0.564856546],
+        [0.3774176, 0.92329566, 0.024491609, 0.066941987]
+    ])
+    assert_allclose(fa_unrotated.components_, [
+        [0.880960087, -0.416916045, 0.99918858, 0.96228895],
+        [-0.447286896, -0.55390036, 0.019152833, 0.058402058]
+    ])
+    assert_allclose(fa_rotated.components_, [
+        [0.98633022, -0.16052385, 0.90809432, 0.85857475],
+        [-0.057523335, -0.67443065, 0.41726413, 0.43847489]
+    ])


### PR DESCRIPTION
Rebuild `scikit-learn 1.8.0` on `main` branch so that uses the new `scipy` package that was built using `openblas-flang`. This fixes a problem where some `cython` files in `scikit-learn` use `cython` files from`scipy` whose interface has changed following the switch to use `openblas-flang`.

Also improved the tests to include the problematic scenario, and test numeric results. The same results occur for me on lite and lab deployments now, within `1e-7` numerical tolerances.

Will need to check other libraries downstream of `scipy` in case they suffer from the same build-time dependency.