### PR TITLE
Bump git2cpp to 0.0.6 on main

### DIFF
--- a/recipes/recipes_emscripten/git2cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/git2cpp/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: git2cpp
-  version: 0.0.5
+  version: 0.0.6
 
 package:
   name: ${{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/QuantStack/${{ name }}/archive/refs/tags/${{ version }}.tar.gz
-  sha256: 284474d986b2282dbfc7b57df4d547e80e1e4e528e424e9793644a63a49cb0c9
+  sha256: 5b531e7fa15adfaf13d5020cc257340329da76f9d122e57832a6adbeb8a315c4
 
 build:
   number: 0


### PR DESCRIPTION
Bump `git2cpp` to 0.0.6 on `main` branch. Doing this manually as I need it as soon as possible.