### PR TITLE
Fix libgit2 to work with git2cpp on emscripten-4x

### DIFF
--- a/recipes/recipes_emscripten/libgit2/http.c
+++ b/recipes/recipes_emscripten/libgit2/http.c
@@ -100,7 +100,7 @@ EM_JS(size_t, emforge_js_http_read, (int conn_index, size_t buf_size, char* buff
 EM_JS(size_t, emforge_js_http_write, (int conn_index, size_t len, char* buffer), {
     try {
         const connection = Module["emforge_js_http_cache"][conn_index];
-        const buffer_js = new Uint8Array(Module.HEAPU8.buffer, buffer, len).slice(0);
+        const buffer_js = new Uint8Array(HEAPU8.buffer, buffer, len).slice(0);
         if (!connection.content) {
             connection.content = buffer_js;
         } else {

--- a/recipes/recipes_emscripten/libgit2/recipe.yaml
+++ b/recipes/recipes_emscripten/libgit2/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 6f097c82fc06ece4f40539fb17e9d41baf1a5a2fc26b1b8562d21b89bc355fe6
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Fix `libgit2` to work with `git2cpp` on `emscripten-4x` branch.