### PR TITLE
Add recipe for r-sweater

### DIFF
--- a/recipes/recipes_emscripten/r-sweater/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sweater/recipe.yaml
@@ -1,0 +1,66 @@
+context:
+  name: r-sweater
+  version: 0.1.8
+  r_base_version: 4.5.1
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url:
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  sha256: 23cf198ff1edfce86cadd4de23e94dea0acb1310faec77df651366ab1bf4ac10
+
+build:
+  number: 0
+  script: $R CMD INSTALL $R_ARGS .
+
+requirements:
+  build:
+  - ${{ compiler('c') }}
+  - cross-r-base_${{ target_platform }}
+  - r-base == ${{ r_base_version }}
+  host:
+  - r-base == ${{ r_base_version }}
+  - r-base
+  - r-liblinear
+  - r-rcpp
+  - r-cli
+  - r-combinat
+  - r-data.table
+  - r-proxy
+  - r-purrr
+  - r-quanteda
+  run:
+  - r-base == ${{ r_base_version }}
+  - r-liblinear
+  - r-rcpp
+  - r-cli
+  - r-combinat
+  - r-data.table
+  - r-proxy
+  - r-purrr
+  - r-quanteda
+
+tests:
+- package_contents:
+    lib:
+    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+
+about:
+  home: https://github.com/gesistsa/sweater
+  license: GPL-3.0-or-later
+  summary: 'Conduct various tests for evaluating implicit biases in word embeddings: Word Embedding
+    Association Test (Caliskan et al., 2017), <doi:10.1126/science.aal4230>, Relative
+    Norm Distance (Garg et al., 2018), <doi:10.1073/pnas.1720347115>, Mean Average Cosine
+    Similarity (Mazini et al., 2019) <arXiv:1904.04047>, SemAxis (An et al., 2018) <arXiv:1806.05521>,
+    Relative Negative Sentiment Bias (Sweeney & Najafian, 2019) <doi:10.18653/v1/P19-1162>,
+    and Embedding Coherence Test (Dev & Phillips, 2019) <arXiv:1901.07656>.'
+  license_family: GPL3
+  license_file: LICENSE.md
+
+extra:
+  recipe-maintainers:
+    - rgaiacs


### PR DESCRIPTION
During a [conversation on Zulip](https://notebook.zulipchat.com/#narrow/channel/545365-Ask-anything/topic/Support.20to.20R-universe.20in.20environment.2Eyml/with/569529844), @martinRenou recommended that I sent a pull request to this repository.

A recipe for `r-sweater` was contributed to conda-forge, see https://github.com/conda-forge/r-sweater-feedstock/, but part of `sweater` is written in C++, see https://github.com/gesistsa/sweater/tree/c0790cb312503160d3239991e49e9e7b56f101d8/src.

The [Adding packages](https://emscripten-forge.org/development/adding_packages/) section of the documentation is missing a subsection about R packages as mentioned in https://github.com/emscripten-forge/recipes/issues/934. I can use the experience on this pull request a first version of the documentation.