### PR TITLE
Rebuild cockle_fs with emscripten 4.x

### DIFF
--- a/recipes/recipes_emscripten/cockle_fs/build.sh
+++ b/recipes/recipes_emscripten/cockle_fs/build.sh
@@ -4,6 +4,8 @@ export PATH=$SRC_DIR/node_modules/typescript/bin:$PATH
 
 touch fs.c
 emcc fs.c -o fs.js \
+    -Os \
+    --minify=0 \
     -sALLOW_MEMORY_GROWTH=1 \
     -sEXPORTED_RUNTIME_METHODS=FS,PATH,ERRNO_CODES,PROXYFS \
     -sFORCE_FILESYSTEM=1 \

--- a/recipes/recipes_emscripten/cockle_fs/recipe.yaml
+++ b/recipes/recipes_emscripten/cockle_fs/recipe.yaml
@@ -9,7 +9,7 @@ package:
 source:
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -22,6 +22,7 @@ tests:
     files:
     - bin/fs.js
     - bin/fs.wasm
+    - bin/fs.d.ts
 
 about:
   homepage: https://github.com/jupyterlite/cockle


### PR DESCRIPTION
Rebuild `cockle_fs` with emscripten 4.x and the same optimisation flags as `cockle` WebAssembly commands.