### PR TITLE
libgit2: improve build flags

### DIFF
--- a/recipes/recipes_emscripten/libgit2/build.sh
+++ b/recipes/recipes_emscripten/libgit2/build.sh
@@ -1,36 +1,26 @@
 # Replace src/libgit2/transports/http.c with emscripten-based implementation.
 cp $RECIPE_DIR/http.c src/libgit2/transports/
 
-# Could patch these instead of using sed.
-sed -iE 's/\(GIT_CONFIG_FILE_MODE\) 0666/\1 0644/g'     src/libgit2/config.h
-sed -iE 's/\(GIT_INDEX_FILE_MODE\) 0666/\1 0644/g'      src/libgit2/index.h
-sed -iE 's/\(GIT_OBJECT_DIR_MODE\) 0777/\1 0755/g'      src/libgit2/odb.h
-sed -iE 's/\(GIT_OBJECT_FILE_MODE\) 0444/\1 0644/g'     src/libgit2/odb.h
-sed -iE 's/\(GIT_PACK_FILE_MODE\) 0444/\1 0644/g'       src/libgit2/pack.h
-sed -iE 's/\(GIT_REFLOG_DIR_MODE\) 0777/\1 0755/g'      src/libgit2/reflog.h
-sed -iE 's/\(GIT_REFLOG_FILE_MODE\) 0666/\1 0644/g'     src/libgit2/reflog.h
-sed -iE 's/\(GIT_REFS_DIR_MODE\) 0777/\1 0755/g'        src/libgit2/refs.h
-sed -iE 's/\(GIT_REFS_FILE_MODE\) 0666/\1 0644/g'       src/libgit2/refs.h
-sed -iE 's/\(GIT_PACKEDREFS_FILE_MODE\) 0666/\1 0644/g' src/libgit2/refs.h
-sed -iE 's/\(GIT_BARE_DIR_MODE\) 0777/\1 0755/g'        src/libgit2/repository.h
-
 mkdir build
 cd build
 
-# incompatible-pointer-types warnings do not appear to be a real problem.
-export CFLAGS="$CFLAGS     -Wno-incompatible-pointer-types -DNO_MMAP"
-export CXXFLAGS="$CXXFLAGS -Wno-incompatible-pointer-types -DNO_MMAP"
+export ALLOWED_WARNINGS="-Wno-builtin-macro-redefined -Wno-incompatible-pointer-types-discards-qualifiers -Wno-unused-parameter"
 
 emcmake cmake ${CMAKE_ARGS} .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH=$PREFIX \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_C_FLAGS="${EM_FORGE_CFLAGS_BASE} -fPIC ${ALLOWED_WARNINGS}" \
+    -DCMAKE_C_STANDARD="99" \
+    -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
+    -DBUILD_CLI=OFF \
     -DBUILD_EXAMPLES=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
     -DBUILD_TESTS=OFF \
     -DUSE_HTTPS=OFF \
-    -DUSE_THREADS=OFF
+    -DUSE_NSEC=OFF \
+    -DUSE_THREADS=OFF \
+    -DZLIB_INCLUDE_DIR=${PREFIX}/include \
+    -DZLIB_LIBRARY=${PREFIX}/lib/libz.a
 
 emmake make install -j$CPU_COUNT
-
-# Install .wasm files as well
-cp git2.wasm ${PREFIX}/bin

--- a/recipes/recipes_emscripten/libgit2/http.c
+++ b/recipes/recipes_emscripten/libgit2/http.c
@@ -201,7 +201,7 @@ static int emforge_http_stream_write(
 
 static void emforge_http_stream_free(git_smart_subtransport_stream* s)
 {
-    emforge_http_stream* stream = GIT_CONTAINER_OF(s, emforge_http_stream, parent);
+    //emforge_http_stream* stream = GIT_CONTAINER_OF(s, emforge_http_stream, parent);
     git__free(s);
 }
 
@@ -277,9 +277,9 @@ static int emforge_http_action(
     return 0;
 }
 
-static int emforge_http_close(git_smart_subtransport* t)
+static int emforge_http_close([[maybe_unused]] git_smart_subtransport* t)
 {
-    emforge_http_subtransport* transport = GIT_CONTAINER_OF(t, emforge_http_subtransport, parent);
+    //emforge_http_subtransport* transport = GIT_CONTAINER_OF(t, emforge_http_subtransport, parent);
     return 0;
 }
 

--- a/recipes/recipes_emscripten/libgit2/patches/0001-Disable-use-of-builtin-intrinsics.patch
+++ b/recipes/recipes_emscripten/libgit2/patches/0001-Disable-use-of-builtin-intrinsics.patch
@@ -1,0 +1,29 @@
+From 7fd3df86308e1c84b1dc43570707c38b2ab13ebf Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Tue, 27 Jan 2026 15:42:23 +0000
+Subject: [PATCH] Disable use of builtin intrinsics
+
+These cause problems with different type sizes
+---
+ src/util/git2_util.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/util/git2_util.h b/src/util/git2_util.h
+index d47ce5f43..0d6800323 100644
+--- a/src/util/git2_util.h
++++ b/src/util/git2_util.h
+@@ -27,9 +27,9 @@ typedef struct git_str git_str;
+ #endif
+ 
+ /** Support for gcc/clang __has_builtin intrinsic */
+-#ifndef __has_builtin
++//#ifndef __has_builtin
+ # define __has_builtin(x) 0
+-#endif
++//#endif
+ 
+ /**
+  * Declare that a function's return value must be used.
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipes/recipes_emscripten/libgit2/recipe.yaml
+++ b/recipes/recipes_emscripten/libgit2/recipe.yaml
@@ -9,20 +9,22 @@ package:
 source:
   url: https://github.com/${{ name }}/${{ name }}/archive/refs/tags/v${{ version }}.tar.gz
   sha256: 6f097c82fc06ece4f40539fb17e9d41baf1a5a2fc26b1b8562d21b89bc355fe6
+  patches:
+  - patches/0001-Disable-use-of-builtin-intrinsics.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
   - ${{ compiler('c') }}
   - cmake
   - pkg-config
+  host:
+  - zlib
 
 tests:
 - script:
-  - test -f ${PREFIX}/bin/git2.js
-  - test -f ${PREFIX}/bin/git2.wasm
   - test -f ${PREFIX}/include/git2.h
   - test -f ${PREFIX}/lib/libgit2.a
   - test -f ${PREFIX}/lib/pkgconfig/libgit2.pc


### PR DESCRIPTION
Rebuild `libgit2` with improved build flags and using system `zlib`. All warnings are treated as errors except for some specific warnings, and there is a patch to avoid use of builtin intrinsics which are optional and cause problems with integer type sizes. This can probably be fixed eventually.