### PR TITLE
git2cpp: export PROXYFS

### DIFF
--- a/recipes/recipes_emscripten/git2cpp/build.sh
+++ b/recipes/recipes_emscripten/git2cpp/build.sh
@@ -10,21 +10,21 @@ export CONFIG_LDFLAGS="\
     --minify=0 \
     -sALLOW_MEMORY_GROWTH=1 \
     -sEXIT_RUNTIME=1 \
-    -sEXPORTED_RUNTIME_METHODS=FS,ENV,TTY,stringToNewUTF8,writeArrayToMemory \
+    -sEXPORTED_RUNTIME_METHODS=FS,ENV,PROXYFS,TTY,stringToNewUTF8,writeArrayToMemory \
     -sFORCE_FILESYSTEM=1 \
     -sMODULARIZE=1 \
     --pre-js $RECIPE_DIR/pre.js \
     -sSTACK_SIZE=1MB \
+    -lproxyfs.js \
     "
-
-export CXXFLAGS="$CXXFLAGS $CONFIG_CXXFLAGS"
-export LDFLAGS="$LDFLAGS $CONFIG_LDFLAGS"
 
 emcmake cmake \
     -Bbuild \
     -DCMAKE_PREFIX_PATH=$PREFIX \
     -Dlibgit2_DIR=$PREFIX/lib/cmake/libgit2 \
-    -Dtermcolor_DIR=$BUILD_PREFIX/lib/cmake/termcolor
+    -Dtermcolor_DIR=$BUILD_PREFIX/lib/cmake/termcolor \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS $CONFIG_CXXFLAGS" \
+    -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS $CONFIG_LDFLAGS"
 
 cd build
 emmake make -j$CPU_COUNT

--- a/recipes/recipes_emscripten/git2cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/git2cpp/recipe.yaml
@@ -13,7 +13,7 @@ source:
   - patches/0001-Simplify-string-split-code.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -23,6 +23,7 @@ requirements:
   - termcolor-cpp
   host:
   - libgit2>=1.9.0
+  - zlib
 
 tests:
 - script:


### PR DESCRIPTION
Rebuild `git2cpp` to use the latest `libgit2` build and export `PROXYFS` that is needed by `cockle`.