### PR TITLE
Replace project with workspace in Pixi configuration

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "emscripten-forge"
 version = "0.1.0"
 description = "The emscripten-forge for emscripten-wasm32- builds."


### PR DESCRIPTION
Because project field is deprecated.