### PR TITLE
git2cpp: rebuild with latest libgit2

### DIFF
--- a/recipes/recipes_emscripten/git2cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/git2cpp/recipe.yaml
@@ -13,7 +13,7 @@ source:
   - patches/0001-Simplify-string-split-code.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Rebuild `git2cpp` with the latest `libgit2` that has mmap disabled.