### PR TITLE
Enable fancy logs

### DIFF
--- a/emci/rattler_build.py
+++ b/emci/rattler_build.py
@@ -6,7 +6,7 @@ from .constants import RATTLER_CONDA_BUILD_CONFIG_PATH
 
 def build_with_rattler(recipe=None, recipes_dir=None, emscripten_wasm32=False, skip_existing="local"):
 
-    cmd = ["rattler-build", "build", "--package-format", "tar-bz2", "--log-style", "plain"]
+    cmd = ["rattler-build", "build", "--package-format", "tar-bz2", "--log-style", "fancy"]
 
     # build single recipe or all recipes in a directory ?
     if recipe is not None and recipes_dir is not None:
@@ -23,7 +23,7 @@ def build_with_rattler(recipe=None, recipes_dir=None, emscripten_wasm32=False, s
     # build for emscripten-wasm32?
     if emscripten_wasm32:
         cmd.extend(["--target-platform", "emscripten-wasm32"])
-        # cmd.extend(["--variant-config", str(VARIANT_CONFIG_PATH)]) 
+        # cmd.extend(["--variant-config", str(VARIANT_CONFIG_PATH)])
 
     cmd.extend(["-m", RATTLER_CONDA_BUILD_CONFIG_PATH])
 


### PR DESCRIPTION
Oftentimes, the output is not rendered properly with the plain log style, especially the bold text. Returning to fancy logs for better readability at the expense of copy/paste-ability.

```
    \x1b[0m\x1b[94mdef\x1b[39;49;00m\x1b[90m \x1b[39;49;00m\x1b[92massert_qobj_data\x1b[39;49;00m(q, data, normalize_sign=\x1b[94mFalse\x1b[39;49;00m):\x1b[90m\x1b[39;49;00m
    \x1b[90m    \x1b[39;49;00m\x1b[33m""" Assert that a qobj has the given values. """\x1b[39;49;00m\x1b[90m\x1b[39;49;00m
        \x1b[94mimport\x1b[39;49;00m\x1b[90m \x1b[39;49;00m\x1b[04m\x1b[96mnumpy\x1b[39;49;00m\x1b[90m \x1b[39;49;00m\x1b[94mas\x1b[39;49;00m\x1b[90m \x1b[39;49;00m\x1b[04m\x1b[96mnp\x1b[39;49;00m\x1b[90m\x1b[39;49;00m
        \x1b[94mif\x1b[39;49;00m normalize_sign:\x1b[90m\x1b[39;49;00m
            sign = np.sign(q.full()[\x1b[94m0\x1b[39;49;00m, \x1b[94m0\x1b[39;49;00m])\x1b[90m\x1b[39;49;00m
            q = sign * q\x1b[90m\x1b[39;49;00m
>       np.testing.assert_allclose(q.full(), data)\x1b[90m\x1b[39;49;00m
\x1b[1m\x1b[31mE       AssertionError: \x1b[0m
\x1b[1m\x1b[31mE       Not equal to tolerance rtol=1e-07, atol=0\x1b[0m
\x1b[1m\x1b[31mE       \x1b[0m
\x1b[1m\x1b[31mE       Mismatched elements: 2 / 4 (50%)\x1b[0m
\x1b[1m\x1b[31mE       Mismatch at indices:\x1b[0m
\x1b[1m\x1b[31mE        [0, 1]: -0.01860828800950994j (ACTUAL), (-0-0.018608253517938968j) (DESIRED)\x1b[0m
\x1b[1m\x1b[31mE        [1, 0]: 0.01860828800950994j (ACTUAL), 0.018608253517938968j (DESIRED)\x1b[0m
\x1b[1m\x1b[31mE       Max absolute difference among violations: 3.4491571e-08\x1b[0m
\x1b[1m\x1b[31mE       Max relative difference among violations: 1.85356304e-06\x1b[0m
\x1b[1m\x1b[31mE        ACTUAL: array([[0.505089+0.j      , 0.      -0.018608j],\x1b[0m
\x1b[1m\x1b[31mE              [0.      +0.018608j, 0.494911+0.j      ]])\x1b[0m
\x1b[1m\x1b[31mE        DESIRED: array([[ 0.505089+0.j      , -0.      -0.018608j],\x1b[0m
\x1b[1m\x1b[31mE              [ 0.      +0.018608j,  0.494911+0.j      ]])\x1b[0m
```