### PR TITLE
Add run_exports for cppinterop package

### DIFF
--- a/recipes/recipes_emscripten/cppinterop/recipe.yaml
+++ b/recipes/recipes_emscripten/cppinterop/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: b46c22f23274a9be4868b2d40c4866428816bd591b39449cf65e518744d82495
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Close #4398
Must also rebuild `xeus-cpp`