### PR TITLE
[Backport] Add run_exports for cppinterop package

### DIFF
--- a/recipes/recipes_emscripten/cppinterop/recipe.yaml
+++ b/recipes/recipes_emscripten/cppinterop/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: b46c22f23274a9be4868b2d40c4866428816bd591b39449cf65e518744d82495
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -22,6 +22,8 @@ requirements:
   - llvm == ${{ llvm_version }}
   run:
   - clang-resource-headers == ${{ llvm_version }}
+  run_exports:
+  - ${{ pin_subpackage('cppinterop', upper_bound='x.x') }}
 
 tests:
 - package_contents:


### PR DESCRIPTION
## Summary
Backport of PR #4399 to the emscripten-3x branch.

Adds run_exports for the cppinterop package to ensure proper dependency propagation.

## Changes
- Added run_exports with pin_subpackage for cppinterop
- Incremented build number to 1

Closes #4398

🤖 Generated with [Claude Code](https://claude.com/claude-code)