### PR TITLE
Rebuild xeus-cpp with updated cppinterop

### DIFF
--- a/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
@@ -26,9 +26,11 @@ requirements:
   - xeus
   - cpp-argparse
   - pugixml
+  # xeus-cpp 0.8.0 incompatible with cppinterop
   - CppInterOp<1.8.0
   run:
-  - CppInterOp
+  # Must repeat constaint since previous builds of cppinterop had no run export
+  - CppInterOp<1.8.0
   - ${{ pin_compatible('nlohmann_json', upper_bound='x.x.x') }}
 
 tests:


### PR DESCRIPTION
## Summary
Increment build number for xeus-cpp to trigger a rebuild with the updated cppinterop package.

## Motivation
The cppinterop package now includes run_exports (see #4399), which means xeus-cpp needs to be rebuilt to pick up the proper dependency propagation.

## Changes
- Increment xeus-cpp build number from 4 to 5

Related: #4399

🤖 Generated with [Claude Code](https://claude.com/claude-code)