### PR TITLE
Rebuild xeus-cpp with updated cppinterop

### DIFF
--- a/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-cpp/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3d3b437799e98dc1d23add165a1c1dff77b1251e19646c18fb5f3ad2bd0c47f5
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
## Summary
Increment build number for xeus-cpp to trigger a rebuild with the updated cppinterop package.

## Motivation
The cppinterop package now includes run_exports (see #4400), which means xeus-cpp needs to be rebuilt to pick up the proper dependency propagation.

## Changes
- Increment xeus-cpp build number from 0 to 1

Related: #4400

🤖 Generated with [Claude Code](https://claude.com/claude-code)