### PR TITLE
Add note about libatomic to documentation

### DIFF
--- a/docs/development/local_builds.md
+++ b/docs/development/local_builds.md
@@ -15,7 +15,7 @@ pixi run build-emscripten-wasm32-pkg recipes/recipes_emscripten/regex
 ```
 
 !!! note
-    When using [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/) (WSL), some local builds might fail due to `libatomic` not be available. For cases like this, developers are required a full Linux machine like a virtual machine or cloud server.
+    When using [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/) (WSL), some local builds might fail due to `libatomic` not being available. For cases like this, developers are required to use a full Linux machine such as a virtual machine or cloud server.
 
 ## Local builds with `rattler-build`
 We recommend using the `pixi` command to build packages locally. However, if you want to use `rattler-build` directly, you can do so with the following steps:


### PR DESCRIPTION
As reported in https://github.com/emscripten-forge/recipes/pull/4305, I observed

```
error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```

when running

```bash
pixi run setup
pixi run build-emscripten-wasm32-pkg recipes/recipes_emscripten/regex
```

on Windows Subsystem for Linux (WSL) running Ubuntu 24.04 and Fedora 42.

I was not able to observe the problem when I used a full virtual machine running Ubuntu 24.04.

<img width="1004" height="875" alt="image" src="https://github.com/user-attachments/assets/136d3a15-0b65-48a7-8a0c-9ddf4cd5bd09" />

This pull request adds a information box about this for any future developer using WSL.

# WSL information

```
WSL version: 2.6.3.0
Kernel version: 6.6.87.2-1
WSLg version: 1.0.71
MSRDC version: 1.2.6353
Direct3D version: 1.611.1-81528511
DXCore version: 10.0.26100.1-240331-1435.ge-release
Windows version: 10.0.26100.7623
```

# Ubuntu 24.04 on WSL information

```
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.3 LTS"
PRETTY_NAME="Ubuntu 24.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.3 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo
```


# Fedora 42 on WSL information

```
Fedora release 42 (Adams)
NAME="Fedora Linux"
VERSION="42 (WSL)"
RELEASE_TYPE=stable
ID=fedora
VERSION_ID=42
VERSION_CODENAME=""
PLATFORM_ID="platform:f42"
PRETTY_NAME="Fedora Linux 42 (WSL)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:42"
DEFAULT_HOSTNAME="fedora"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f42/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=42
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=42
SUPPORT_END=2026-05-13
VARIANT="WSL"
VARIANT_ID=wsl
Fedora release 42 (Adams)
Fedora release 42 (Adams)
```