### PR TITLE
pyb2d3 0.10.0

### DIFF
--- a/recipes/recipes_emscripten/pyb2d3/recipe.yaml
+++ b/recipes/recipes_emscripten/pyb2d3/recipe.yaml
@@ -1,10 +1,10 @@
 context:
-  version: 0.9.0
+  version: 0.10.0
   name: pyb2d3
 
 source:
 - url: https://github.com/DerThorsten/pyb2d3/archive/refs/tags/v${{version}}.tar.gz
-  sha256: b61a3eaccf5cd44f8a3bfda81cf273deb68d9028e96d27f6ce443dd69212ac4f
+  sha256: eda1c65fa9d160a14b594ae27f2397dc9cf6dcb31eeeb125df715e208d848bd9
 
 build:
   number: 0
@@ -25,7 +25,7 @@ outputs:
     - cmake>=4.0
     - ninja
     - numpy
-    - nanobind
+    - nanobind <2.10.2
     - scikit-build-core
     - python
     - pip


### PR DESCRIPTION
the [old pr ](https://github.com/emscripten-forge/recipes/pull/4096)to updae pyb2d3 has a somewhat broken ci. 
An explantion could be that https://github.com/emscripten-forge/recipes/pull/4096 was created before the emscripten-4x branch has been promoted to main