### PR TITLE
change order 

### DIFF
--- a/recipes/recipes/pytester/pytester/__main__.py
+++ b/recipes/recipes/pytester/pytester/__main__.py
@@ -68,16 +68,16 @@ def main():
 
     backends = [
         (
-            BackendType.browser_main,
-            lambda: dict(port=find_free_port(), slow_mo=1, headless=True),
+            BackendType.browser_worker,
+            lambda: dict(port=find_free_port(), slow_mo=1, headless=True, preload_shared_libs=False)
         ),
         (
             BackendType.browser_worker,
             lambda: dict(port=find_free_port(), slow_mo=1, headless=True, preload_shared_libs=True)
         ),
         (
-            BackendType.browser_worker,
-            lambda: dict(port=find_free_port(), slow_mo=1, headless=True, preload_shared_libs=False)
+            BackendType.browser_main,
+            lambda: dict(port=find_free_port(), slow_mo=1, headless=True),
         )
     ]
     print(

--- a/recipes/recipes/pytester/recipe.yaml
+++ b/recipes/recipes/pytester/recipe.yaml
@@ -13,7 +13,7 @@ outputs:
       version: ${{ version }}
 
     build:
-      number: 0
+      number: 1
 
       noarch: python
 


### PR DESCRIPTION
we run 3 combination:
* worker, skip preloading
* worker, preloading
* main, preloading

This PR makes sure we `run worker`, skip preloading first, because the other tests may hang and run forever