### PR TITLE
scikit-learn: Exclude `tests` and `__pycache__` folders

### DIFF
--- a/recipes/recipes_emscripten/scikit-learn/recipe.yaml
+++ b/recipes/recipes_emscripten/scikit-learn/recipe.yaml
@@ -13,7 +13,17 @@ source:
   - patches/0001-Patch-away-urllib.patch
 
 build:
-  number: 0
+  number: 1
+  # Removing tests and `__pycache__` from the source directory
+  # halves the size of the decompressed package and reduces
+  # the number of files to extract and to link in the prefix.
+  files:
+    exclude:
+      - "**/tests/"
+      - "**/__pycache__/"
+  python:
+    skip_pyc_compilation:
+      - "**/*.py"
 
 requirements:
   build:


### PR DESCRIPTION
This shrinks this package significantly (by more than 2):
 - compressed: from 8.36MiB to 3.59 MiB
 - uncompressed: from 38.7 MB to 17.65 MiB