### PR TITLE
Reduce boost-cpp package size

### DIFF
--- a/recipes/recipes_emscripten/boost-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/boost-cpp/recipe.yaml
@@ -1,35 +1,30 @@
+about:
+  homepage: http://www.boost.org/
+  license: BSL-1.0
+  license_file: LICENSE_1_0.txt
+  summary: Free peer-reviewed portable C++ source libraries.
+build:
+  files:
+    exclude:
+    - '**/test/**'
+  number: 1
 context:
-  version: "1.87.0"
   filename: boost_${{ version | replace('.', '_') }}.tar.bz2
-
+  version: 1.87.0
+extra:
+  recipe-maintainers:
+  - wolfv
 package:
   name: boost-cpp
   version: ${{ version }}
-source:
-  url: https://archives.boost.io/release/${{ version }}/source/${{filename }}
-  sha256: af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89
-  # patches:
-  # - 0001-config-libcpp15.patch
-
-build:
-  number: 0
-
 requirements:
   build:
   - ${{ compiler('cxx') }}
   host:
   - bzip2
   - zlib
-
   run:
   - bzip2
-
-about:
-  license: BSL-1.0
-  license_file: LICENSE_1_0.txt
-  summary: Free peer-reviewed portable C++ source libraries.
-
-  homepage: http://www.boost.org/
-extra:
-  recipe-maintainers:
-  - wolfv
+source:
+  sha256: af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89
+  url: https://archives.boost.io/release/${{ version }}/source/${{filename }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.160173MB