### PR TITLE
Reduce biopython package size

### DIFF
--- a/recipes/recipes_emscripten/biopython/recipe.yaml
+++ b/recipes/recipes_emscripten/biopython/recipe.yaml
@@ -11,8 +11,18 @@ source:
   sha256: 93a50b586a4d2cec68ab2f99d03ef583c5761d8fba5535cb8e81da781d0d92ff
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.typed'
+    - '**/__pycache__/**'
+    - '**/test_*.py'
+    - '**.dist-info/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_emscripten-wasm32


### PR DESCRIPTION
This reduces the package content (once unzipped) by 6.36207MB