### PR TITLE
Reduce awkward-cpp package size

### DIFF
--- a/recipes/recipes_emscripten/awkward-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/awkward-cpp/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: 1f8b112a597bd2438794e1a721a63aa61869fa9598a17ac6bd811ad6f6400d06
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.167693MB