### PR TITLE
Reduce boost-cpp package size

### DIFF
--- a/recipes/recipes_emscripten/boost-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/boost-cpp/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "1.87.0"
+  version: 1.87.0
   filename: boost_${{ version | replace('.', '_') }}.tar.bz2
 
 package:
@@ -12,8 +12,11 @@ source:
   # - 0001-config-libcpp15.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/test/**'
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.160173MB