### PR TITLE
Reduce boost-histogram package size

### DIFF
--- a/recipes/recipes_emscripten/boost-histogram/recipe.yaml
+++ b/recipes/recipes_emscripten/boost-histogram/recipe.yaml
@@ -13,9 +13,20 @@ source:
   - patches/patch_allow_shared.patch
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.typed'
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.24562MB