### PR TITLE
Reduce astropy package size

### DIFF
--- a/recipes/recipes_emscripten/astropy/recipe.yaml
+++ b/recipes/recipes_emscripten/astropy/recipe.yaml
@@ -13,8 +13,20 @@ source:
   # - patches/skip_ep.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**/tests/**'
+    - '**.dist-info/**'
+    - '**/*.pyx'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("cxx") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 28.564007MB