### PR TITLE
Reduce brotli package size

### DIFF
--- a/recipes/recipes_emscripten/brotli/recipe.yaml
+++ b/recipes/recipes_emscripten/brotli/recipe.yaml
@@ -10,8 +10,11 @@ source:
   sha256: 816c96e8e8f193b40151dad7e8ff37b1221d019dbcb9c35cd3fadbfe6477dfec
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.00513MB