### PR TITLE
Reduce cffi package size

### DIFF
--- a/recipes/recipes_emscripten/cffi/recipe.yaml
+++ b/recipes/recipes_emscripten/cffi/recipe.yaml
@@ -11,8 +11,17 @@ source:
 - path: setup.py
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.434736MB