### PR TITLE
Reduce docutils package size

### DIFF
--- a/recipes/recipes_emscripten/docutils/recipe.yaml
+++ b/recipes/recipes_emscripten/docutils/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: 4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 2.180756MB