### PR TITLE
Reduce expat package size

### DIFF
--- a/recipes/recipes_emscripten/expat/recipe.yaml
+++ b/recipes/recipes_emscripten/expat/recipe.yaml
@@ -12,8 +12,11 @@ source:
   sha256: 8dc480b796163d4436e6f1352e71800a774f73dbae213f1860b60607d2a83ada
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ninja
@@ -32,10 +35,10 @@ tests:
     include:
     - expat.h
 - script:
-    - node $PREFIX/bin/xmlwf -h
+  - node $PREFIX/bin/xmlwf -h
   requirements:
     build:
-      - nodejs
+    - nodejs
 
 about:
   license: MIT


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.010946MB