### PR TITLE
Reduce fonttools package size

### DIFF
--- a/recipes/recipes_emscripten/fonttools/recipe.yaml
+++ b/recipes/recipes_emscripten/fonttools/recipe.yaml
@@ -11,8 +11,18 @@ source:
   sha256: dba8d7cdb8e2bac1b3da28c5ed5960de09e59a2fe7e63bb73f5a59e57b0430d2
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - share/man/man1/**
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 4.606399MB