### PR TITLE
Reduce ipython package size

### DIFF
--- a/recipes/recipes_emscripten/ipython/recipe.yaml
+++ b/recipes/recipes_emscripten/ipython/recipe.yaml
@@ -12,8 +12,18 @@ source:
   - patches/0001-Patch-asyncio-tornado.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - share/man/man1/**
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 2.302426MB