### PR TITLE
Reduce libiconv package size

### DIFF
--- a/recipes/recipes_emscripten/libiconv/recipe.yaml
+++ b/recipes/recipes_emscripten/libiconv/recipe.yaml
@@ -11,8 +11,11 @@ source:
   sha256: 3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.00444MB