### PR TITLE
Reduce libxslt package size

### DIFF
--- a/recipes/recipes_emscripten/libxslt/recipe.yaml
+++ b/recipes/recipes_emscripten/libxslt/recipe.yaml
@@ -11,8 +11,11 @@ source:
   sha256: 9acfe68419c4d06a45c550321b3212762d92f41465062ca4ea19e632ee5d216e
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.009848MB