### PR TITLE
Reduce llvm package size

### DIFF
--- a/recipes/recipes_emscripten/llvm/recipe.yaml
+++ b/recipes/recipes_emscripten/llvm/recipe.yaml
@@ -17,8 +17,15 @@ source:
 
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.061574MB