### PR TITLE
Reduce markupsafe package size

### DIFF
--- a/recipes/recipes_emscripten/markupsafe/recipe.yaml
+++ b/recipes/recipes_emscripten/markupsafe/recipe.yaml
@@ -10,8 +10,18 @@ source:
   sha256: f1d9d06c34515dd3ad210ec769da613057b536d11d6c039183b87757a883a254
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.028173MB