### PR TITLE
Reduce matplotlib package size

### DIFF
--- a/recipes/recipes_emscripten/matplotlib/recipe.yaml
+++ b/recipes/recipes_emscripten/matplotlib/recipe.yaml
@@ -8,7 +8,10 @@ source:
   - patches/fix-threading-and-font-cache.patch
   - patches/static-cast.patch
 build:
-  number: 1
+  number: 2
+  files:
+    exclude:
+    - '**/test_*.py'
 outputs:
 - package:
     name: matplotlib-base


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.000571MB