### PR TITLE
Reduce numpy package size

### DIFF
--- a/recipes/recipes_emscripten/numpy/recipe.yaml
+++ b/recipes/recipes_emscripten/numpy/recipe.yaml
@@ -11,8 +11,22 @@ source:
   url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{ version }}.tar.gz
   sha256: 659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**/tests/**'
+    - '**.dist-info/**'
+    - '**/*.ini'
+    - '**/__pycache__/**'
+    - '**/*.pyx'
+    - '**/*.pxd'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 19.56933MB