### PR TITLE
Reduce pandas package size

### DIFF
--- a/recipes/recipes_emscripten/pandas/recipe.yaml
+++ b/recipes/recipes_emscripten/pandas/recipe.yaml
@@ -11,8 +11,19 @@ source:
   sha256: e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**/tests/**'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 41.10266MB