### PR TITLE
Reduce patsy package size

### DIFF
--- a/recipes/recipes_emscripten/patsy/recipe.yaml
+++ b/recipes/recipes_emscripten/patsy/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_emscripten-wasm32


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.182395MB