### PR TITLE
Reduce protobuf package size

### DIFF
--- a/recipes/recipes_emscripten/protobuf/recipe.yaml
+++ b/recipes/recipes_emscripten/protobuf/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: 6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.999473MB