### PR TITLE
Reduce pydro package size

### DIFF
--- a/recipes/recipes_emscripten/pydro/recipe.yaml
+++ b/recipes/recipes_emscripten/pydro/recipe.yaml
@@ -12,8 +12,17 @@ source:
 # - path: setup.py
 
 build:
-  number: 3
+  number: 4
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.003701MB