### PR TITLE
Reduce pyerfa package size

### DIFF
--- a/recipes/recipes_emscripten/pyerfa/recipe.yaml
+++ b/recipes/recipes_emscripten/pyerfa/recipe.yaml
@@ -12,8 +12,18 @@ source:
 
 
 build:
-  number: 2
+  number: 3
 
+  files:
+    exclude:
+    - '**/tests/**'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_emscripten-wasm32


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.1727MB