### PR TITLE
Reduce pyrsistent package size

### DIFF
--- a/recipes/recipes_emscripten/pyrsistent/recipe.yaml
+++ b/recipes/recipes_emscripten/pyrsistent/recipe.yaml
@@ -10,9 +10,19 @@ source:
   sha256: 4c48f78f62ab596c679086084d0dd13254ae4f3d6c72a83ffdf5ebdef8f265a4
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.254035MB