### PR TITLE
Reduce pytest package size

### DIFF
--- a/recipes/recipes_emscripten/pytest/recipe.yaml
+++ b/recipes/recipes_emscripten/pytest/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: 75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . --no-deps
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.646047MB