### PR TITLE
Reduce python-sat package size

### DIFF
--- a/recipes/recipes_emscripten/python-sat/recipe.yaml
+++ b/recipes/recipes_emscripten/python-sat/recipe.yaml
@@ -15,9 +15,18 @@ source:
   - patches/dummy_buildhpp.patch
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.296005MB