### PR TITLE
Reduce pythran package size

### DIFF
--- a/recipes/recipes_emscripten/pythran/recipe.yaml
+++ b/recipes/recipes_emscripten/pythran/recipe.yaml
@@ -15,8 +15,17 @@ source:
   - patches/0001-remove-strip-all.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.89717MB