### PR TITLE
Reduce qutip package size

### DIFF
--- a/recipes/recipes_emscripten/qutip/recipe.yaml
+++ b/recipes/recipes_emscripten/qutip/recipe.yaml
@@ -11,9 +11,23 @@ source:
   sha256: 39435fe006213c116314fe46509e3f35d39c0ba897d633af172125056f893a11
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . -vvv --no-deps --no-build-isolation
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**/tests/**'
+    - '**/*.pxd'
+    - '**.dist-info/**'
+    - '**/*.ini'
+    - '**/*.pyx'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 5.166389MB