### PR TITLE
Reduce regex package size

### DIFF
--- a/recipes/recipes_emscripten/regex/recipe.yaml
+++ b/recipes/recipes_emscripten/regex/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: f7b43acb2c46fb2cd506965b2d9cf4c5e64c9c612bac26c1187933c7296bf08c
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.829559MB