### PR TITLE
Reduce scikit-image package size

### DIFF
--- a/recipes/recipes_emscripten/scikit-image/recipe.yaml
+++ b/recipes/recipes_emscripten/scikit-image/recipe.yaml
@@ -16,7 +16,6 @@ build:
 
   files:
     exclude:
-    - '**/*.pyi'
     - '**.dist-info/**'
     - '**/*.ini'
     - '**/__pycache__/**'


### PR DESCRIPTION
This reduces the package content (once unzipped) by 2.270571MB