### PR TITLE
Reduce scikit-learn package size

### DIFF
--- a/recipes/recipes_emscripten/scikit-learn/recipe.yaml
+++ b/recipes/recipes_emscripten/scikit-learn/recipe.yaml
@@ -13,18 +13,26 @@ source:
   - patches/0001-Patch-away-urllib.patch
 
 build:
-  number: 1
+  number: 2
   # Removing tests and `__pycache__` from the source directory
   # halves the size of the decompressed package and reduces
   # the number of files to extract and to link in the prefix.
   files:
     exclude:
-      - "**/tests/"
-      - "**/__pycache__/"
+    - '**/tests/'
+    - '**/__pycache__/'
+    - '**/tests/**'
+    - '**/*.pxd'
+    - '**/*.pxi'
+    - '**.dist-info/**'
+    - '**/*.pyx'
+    - '**/*.tp'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
   python:
     skip_pyc_compilation:
-      - "**/*.py"
-
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 21.335245MB