### PR TITLE
Reduce sqlite package size

### DIFF
--- a/recipes/recipes_emscripten/sqlite/recipe.yaml
+++ b/recipes/recipes_emscripten/sqlite/recipe.yaml
@@ -12,22 +12,25 @@ source:
 
 
 build:
-  number: 1
+  number: 2
   # run_exports:
   #   # sometimes adds new symbols.  Default behavior is OK.
   #   #    https://abi-laboratory.pro/tracker/timeline/sqlite/
   #   - "{{ pin_subpackage('sqlite') }}"
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler('c') }}
   - make
   - libtool
   host:
-  -  zlib 
+  - zlib
 tests:
-  - script:
-    - test -f ${PREFIX}/lib/libsqlite3.a
+- script:
+  - test -f ${PREFIX}/lib/libsqlite3.a
 
 about:
   license: Unlicense


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.00434MB