### PR TITLE
Reduce statsmodels package size

### DIFF
--- a/recipes/recipes_emscripten/statsmodels/recipe.yaml
+++ b/recipes/recipes_emscripten/statsmodels/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: 4d17873d3e607d398b85126cd4ed7aad89e4e9d89fc744cdab1af3189a996c2a
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . -vvv --no-deps --no-build-isolation
 
+  files:
+    exclude:
+    - '**/tests/**'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 31.6972MB