### PR TITLE
Reduce sympy package size

### DIFF
--- a/recipes/recipes_emscripten/sympy/recipe.yaml
+++ b/recipes/recipes_emscripten/sympy/recipe.yaml
@@ -11,9 +11,20 @@ source:
   sha256: 813eecbf60fdf4c692cc1cdb30b940072160f4ab0421fa5d7aaa7a8a8c596615
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - share/man/man1/**
+    - '**/tests/**'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 52.287012MB