### PR TITLE
Reduce unicodedata2 package size

### DIFF
--- a/recipes/recipes_emscripten/unicodedata2/recipe.yaml
+++ b/recipes/recipes_emscripten/unicodedata2/recipe.yaml
@@ -11,8 +11,12 @@ source:
   sha256: ffa2f0d6834642fe996d356e728da887201533bb540974ae7ac975e66ecc0e3a
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/test_*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.015743MB