### PR TITLE
Reduce zarr package size

### DIFF
--- a/recipes/recipes_emscripten/zarr/recipe.yaml
+++ b/recipes/recipes_emscripten/zarr/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: 01342f3e26a02ed5670db608a5576fbdb8d76acb5c280bd2d0082454b1ba6f79
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.431089MB