### PR TITLE
Reduce arrow-cpp package size

### DIFF
--- a/recipes/recipes_emscripten/arrow-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/arrow-cpp/recipe.yaml
@@ -10,8 +10,15 @@ source:
   sha256: 12f6844a0ba3b99645cd2bc6cc4f44f6a174ab90da37e474f08b7d073433cb60
 
 build:
-  number: 2
+  number: 3
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("cxx") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.122077MB