### PR TITLE
Reduce openblas package size

### DIFF
--- a/recipes/recipes_emscripten/openblas/recipe.yaml
+++ b/recipes/recipes_emscripten/openblas/recipe.yaml
@@ -22,8 +22,11 @@ source:
   - patches/0008-Use-openblas-flang-in-pkgconfig-and-cmake-config.patch
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**/test_*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.000206MB