### PR TITLE
Reduce brotli-python package size

### DIFF
--- a/recipes/recipes_emscripten/brotli-python/recipe.yaml
+++ b/recipes/recipes_emscripten/brotli-python/recipe.yaml
@@ -10,8 +10,17 @@ source:
   sha256: 816c96e8e8f193b40151dad7e8ff37b1221d019dbcb9c35cd3fadbfe6477dfec
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("cxx") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.010564MB