### PR TITLE
Reduce gmpy2 package size

### DIFF
--- a/recipes/recipes_emscripten/gmpy2/recipe.yaml
+++ b/recipes/recipes_emscripten/gmpy2/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: 2d943cc9051fcd6b15b2a09369e2f7e18c526bc04c210782e4da61b62495eb4a
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pxd'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.052569MB