### PR TITLE
Reduce lfortran package size

### DIFF
--- a/recipes/recipes_emscripten/lfortran/recipe.yaml
+++ b/recipes/recipes_emscripten/lfortran/recipe.yaml
@@ -11,8 +11,16 @@ source:
   sha256: 6cd36a260fd24f7bba8817d1d21a8eb29e5bebbea4241bf7ce71572cd3c8f7ba
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.017392MB