### PR TITLE
Reduce lpython package size

### DIFF
--- a/recipes/recipes_emscripten/lpython/recipe.yaml
+++ b/recipes/recipes_emscripten/lpython/recipe.yaml
@@ -11,8 +11,15 @@ source:
   sha256: 9dcfe113cd95366ca8e6e7f23e13a60b666243f93e44179a641c6c30f8a02afa
 
 build:
-  number: 2
+  number: 3
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.0101MB