### PR TITLE
Reduce pycrdt package size

### DIFF
--- a/recipes/recipes_emscripten/pycrdt/recipe.yaml
+++ b/recipes/recipes_emscripten/pycrdt/recipe.yaml
@@ -11,8 +11,18 @@ source:
   sha256: 418d11c875a625c5633b88851a815bf6bd3fcb750d43467e8711b7abe4c3c0f8
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.20889MB