### PR TITLE
Reduce tiktoken package size

### DIFF
--- a/recipes/recipes_emscripten/tiktoken/recipe.yaml
+++ b/recipes/recipes_emscripten/tiktoken/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{target_platform}}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.063637MB