### PR TITLE
Reduce jpeg package size

### DIFF
--- a/recipes/recipes_emscripten/jpeg/recipe.yaml
+++ b/recipes/recipes_emscripten/jpeg/recipe.yaml
@@ -10,8 +10,11 @@ source:
   sha256: 8b9eaa13242690ebd03e1728ab1edf97a81a78ed6e83624d493655f31ac95ab5
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - libtool


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.03726MB