### PR TITLE
Reduce xxhash package size

### DIFF
--- a/recipes/recipes_emscripten/xxhash/recipe.yaml
+++ b/recipes/recipes_emscripten/xxhash/recipe.yaml
@@ -11,8 +11,11 @@ source:
   sha256: aae608dfe8213dfd05d909a57718ef82f30722c392344583d3f39050c7f29a80
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.02423MB