### PR TITLE
Reduce zstd package size

### DIFF
--- a/recipes/recipes_emscripten/zstd/recipe.yaml
+++ b/recipes/recipes_emscripten/zstd/recipe.yaml
@@ -11,8 +11,11 @@ source:
   sha256: 37d7284556b20954e56e1ca85b80226768902e2edabd3b649e9e72c0c9012ee3
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.108379MB