### PR TITLE
Reduce clarabel package size

### DIFF
--- a/recipes/recipes_emscripten/clarabel/recipe.yaml
+++ b/recipes/recipes_emscripten/clarabel/recipe.yaml
@@ -13,9 +13,18 @@ source:
   - patches/0001-Update-faer-and-faer-traits-versions.patch
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.01351MB