### PR TITLE
Reduce cartopy package size

### DIFF
--- a/recipes/recipes_emscripten/cartopy/recipe.yaml
+++ b/recipes/recipes_emscripten/cartopy/recipe.yaml
@@ -11,8 +11,19 @@ source:
   sha256: 231f37b35701f2ba31d94959cca75e6da04c2eea3a7f14ce1c75ee3b0eae7676
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/tests/**'
+    - '**.dist-info/**'
+    - '**/*.pyx'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 11.893982MB