### PR TITLE
Reduce libarchive package size

### DIFF
--- a/recipes/recipes_emscripten/libarchive/recipe.yaml
+++ b/recipes/recipes_emscripten/libarchive/recipe.yaml
@@ -11,8 +11,11 @@ source:
   sha256: 3877c692621d8fbe9512592cf824c98c4b393525ab96735616ff628086158777
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.058133MB