### PR TITLE
Reduce pycalphad package size

### DIFF
--- a/recipes/recipes_emscripten/pycalphad/recipe.yaml
+++ b/recipes/recipes_emscripten/pycalphad/recipe.yaml
@@ -11,33 +11,44 @@ source:
   sha256: 57b5c8618d7168c02648b99de6545b24dd60591f96bcc3fd2a260e57663e727e
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install .
 
+  files:
+    exclude:
+    - '**/tests/**'
+    - '**/*.pxd'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
-    - cross-python_${{ target_platform }}
-    - ${{ compiler('cxx') }}
-    - python
-    - cython
-    - numpy>=2.0
-    - setuptools-scm
-    - scipy
-    - pip
+  - cross-python_${{ target_platform }}
+  - ${{ compiler('cxx') }}
+  - python
+  - cython
+  - numpy>=2.0
+  - setuptools-scm
+  - scipy
+  - pip
   host:
-    - python
+  - python
   run:
-    - matplotlib
-    - numpy
-    - pint
-    - pyparsing
-    - pytest
-    - python-symengine
-    - runtype
-    - scipy
-    - tinydb
-    - typing-extensions # drop when pycalphad drops support for Python<3.13
-    - xarray
+  - matplotlib
+  - numpy
+  - pint
+  - pyparsing
+  - pytest
+  - python-symengine
+  - runtype
+  - scipy
+  - tinydb
+  - typing-extensions   # drop when pycalphad drops support for Python<3.13
+  - xarray
 
 tests:
 - script: echo "FIXME:"
@@ -59,7 +70,8 @@ about:
   homepage: https://pycalphad.org/
   license: MIT
   license_file: LICENSE.txt
-  summary: CALPHAD tools for designing thermodynamic models, calculating phase diagrams and investigating phase equilibria.
+  summary: CALPHAD tools for designing thermodynamic models, calculating phase diagrams and investigating phase 
+    equilibria.
   description: |
     pycalphad is a free and open-source Python library for designing thermodynamic models, calculating phase diagrams and investigating phase equilibria within the CALPHAD method.
   documentation: https://pycalphad.org/


### PR DESCRIPTION
This reduces the package content (once unzipped) by 2.521529MB