### PR TITLE
Reduce pyproj package size

### DIFF
--- a/recipes/recipes_emscripten/pyproj/recipe.yaml
+++ b/recipes/recipes_emscripten/pyproj/recipe.yaml
@@ -11,8 +11,21 @@ source:
   sha256: 39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**/*.pxi'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyx'
+    - '**/*.pxd'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.560895MB