### PR TITLE
Reduce python-symengine package size

### DIFF
--- a/recipes/recipes_emscripten/python-symengine/recipe.yaml
+++ b/recipes/recipes_emscripten/python-symengine/recipe.yaml
@@ -10,8 +10,19 @@ source:
   sha256: 3e79d39af5e9f024cd4b8d1372314ac2b83cace7d49cdbad482b4aec5b04c37b
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/tests/**'
+    - '**/*.pxd'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.556208MB