### PR TITLE
Reduce qhull package size

### DIFF
--- a/recipes/recipes_emscripten/qhull/recipe.yaml
+++ b/recipes/recipes_emscripten/qhull/recipe.yaml
@@ -11,8 +11,11 @@ source:
   sha256: 59356b229b768e6e2b09a701448bfa222c37b797a84f87f864f97462d8dbc7c5
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.043608MB