### PR TITLE
Reduce r-base package size

### DIFF
--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -26,8 +26,11 @@ source:
   - patches/0013-Use-source-files-when-installing.patch
 
 build:
-  number: 2
+  number: 3
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.007145MB