### PR TITLE
Reduce r-data.table package size

### DIFF
--- a/recipes/recipes_emscripten/r-data.table/recipe.yaml
+++ b/recipes/recipes_emscripten/r-data.table/recipe.yaml
@@ -11,9 +11,12 @@ source:
   sha256: 40b6bd3ed8664130d257fa0476d7f65f9327552344d532d77ccc4aa1a8bca09a
 
 build:
-  number: 0
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
+  files:
+    exclude:
+    - '**/tests/**'
 requirements:
   build:
   - cross-r-base_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.972651MB