### PR TITLE
Reduce h5py package size

### DIFF
--- a/recipes/recipes_emscripten/h5py/recipe.yaml
+++ b/recipes/recipes_emscripten/h5py/recipe.yaml
@@ -13,8 +13,18 @@ source:
   - patches/configure.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/tests/**'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.510566MB