### PR TITLE
Reduce lcms2 package size

### DIFF
--- a/recipes/recipes_emscripten/lcms2/recipe.yaml
+++ b/recipes/recipes_emscripten/lcms2/recipe.yaml
@@ -11,8 +11,11 @@ source:
   sha256: ee67be3566f459362c1ee094fde2c159d33fa0390aa4ed5f5af676f9e5004347
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler("cxx") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.012556MB