### PR TITLE
Reduce sparrow package size

### DIFF
--- a/recipes/recipes_emscripten/sparrow/recipe.yaml
+++ b/recipes/recipes_emscripten/sparrow/recipe.yaml
@@ -10,8 +10,11 @@ source:
   sha256: 2d43e256caacbf5f53277dbc4a202faff5476c3588ea1274a20b8670eef5dafa
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/tests/**'
 requirements:
   build:
   - ${{ compiler("cxx") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.00108MB