### PR TITLE
Reduce yarl package size

### DIFF
--- a/recipes/recipes_emscripten/yarl/recipe.yaml
+++ b/recipes/recipes_emscripten/yarl/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyx'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('cxx')}}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.193158MB