### PR TITLE
Reduce dynare-preprocessor-pylib package size

### DIFF
--- a/recipes/recipes_emscripten/dynare-preprocessor-pylib/recipe.yaml
+++ b/recipes/recipes_emscripten/dynare-preprocessor-pylib/recipe.yaml
@@ -11,32 +11,35 @@ source:
   sha256: 66863669aa9ea09c431f28eaabe41d574a758425db77605d52edfb9ff040a038
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/test_*.py'
 requirements:
   build:
-    - cross-python_${{ target_platform }}
-    - ${{ compiler("cxx") }}
-    - bison
-    - flex
-    - meson
-    - pkg-config
+  - cross-python_${{ target_platform }}
+  - ${{ compiler("cxx") }}
+  - bison
+  - flex
+  - meson
+  - pkg-config
   host:
-    - python
-    - pybind11
-    - boost-cpp
-    - libpython
+  - python
+  - pybind11
+  - boost-cpp
+  - libpython
 
 tests:
-  - script: pytester
-    requirements:
-      build:
-        - pytester
-      run:
-        - pytester-run
-    files:
-      recipe:
-        - test_preproc.py
+- script: pytester
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+  files:
+    recipe:
+    - test_preproc.py
 
 about:
   homepage: https://www.dynare.org/
@@ -47,5 +50,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - albop
-    - svillemot
+  - albop
+  - svillemot


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.002192MB