### PR TITLE
Reduce libnetcdf package size

### DIFF
--- a/recipes/recipes_emscripten/libnetcdf/recipe.yaml
+++ b/recipes/recipes_emscripten/libnetcdf/recipe.yaml
@@ -10,27 +10,30 @@ source:
   url: https://github.com/Unidata/netcdf-c/archive/refs/tags/v${{ version }}.tar.gz
   sha256: 990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff
   patches:
-    - patches/parallel-disable.patch
-    - patches/hdf5-parallel-disable.patch
+  - patches/parallel-disable.patch
+  - patches/hdf5-parallel-disable.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
-    - python
-    - cross-python_${{ target_platform }}
-    - ${{ compiler('c') }}
-    - pip
-    - m4
-    - make
+  - python
+  - cross-python_${{ target_platform }}
+  - ${{ compiler('c') }}
+  - pip
+  - m4
+  - make
   host:
-    - python
-    - libxml2 >=2.15
-    - hdf5
-    - zlib
+  - python
+  - libxml2 >=2.15
+  - hdf5
+  - zlib
   run:
-    - python
+  - python
 
 tests:
 - package_contents:


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.09286MB