### PR TITLE
Reduce matplotlib package size

### DIFF
--- a/recipes/recipes_emscripten/matplotlib/recipe.yaml
+++ b/recipes/recipes_emscripten/matplotlib/recipe.yaml
@@ -8,7 +8,7 @@ source:
   - patches/fix-threading-and-font-cache.patch
   - patches/static-cast.patch
 build:
-  number: 3
+  number: 4
   files:
     exclude:
     - '**/test_*.py'
@@ -20,15 +20,15 @@ outputs:
     script: build-base.sh
     files:
       exclude:
-      - "**/*.pyi"
-      - "**/tests/**"
-      - "**.dist-info/**"
-      - "**/*.ini"
-      - "**/__pycache__/**"
-      - "**/*.pyx"
-      - "**/*.pxd"
-      - "**/*.pyc"
-      - "**/test_*.py"
+      - '**/*.pyi'
+      - '**/tests/**'
+      - '**.dist-info/**'
+      - '**/*.ini'
+      - '**/__pycache__/**'
+      - '**/*.pyx'
+      - '**/*.pxd'
+      - '**/*.pyc'
+      - '**/test_*.py'
     python:
       skip_pyc_compilation:
       - '**/*.py'


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.000571MB