### PR TITLE
Reduce xsimd package size

### DIFF
--- a/recipes/recipes_emscripten/xsimd/recipe.yaml
+++ b/recipes/recipes_emscripten/xsimd/recipe.yaml
@@ -11,8 +11,16 @@ source:
   sha256: 17de0236954955c10c09d6938d4c5f3a3b92d31be5dadd1d5d09fc1b15490dce
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.010944MB