### PR TITLE
Reduce lz4 package size

### DIFF
--- a/recipes/recipes_emscripten/lz4-c/recipe.yaml
+++ b/recipes/recipes_emscripten/lz4-c/recipe.yaml
@@ -12,8 +12,17 @@ source:
   sha256: 537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.040911MB