### PR TITLE
Reduce pyb2d3 package size

### DIFF
--- a/recipes/recipes_emscripten/pyb2d3/recipe.yaml
+++ b/recipes/recipes_emscripten/pyb2d3/recipe.yaml
@@ -7,8 +7,17 @@ source:
   sha256: 50b56338b1ade7659d36283a68f57f128916c31ebd4dc6478d1c4a2753273a7f
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 outputs:
 - package:
     name: pyb2d3


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.047252MB