### PR TITLE
Reduce rustworkx package size

### DIFF
--- a/recipes/recipes_emscripten/rustworkx/recipe.yaml
+++ b/recipes/recipes_emscripten/rustworkx/recipe.yaml
@@ -11,8 +11,18 @@ source:
   sha256: dc248da9cc364b81ac67f5d67b626ee3f03a1f6299f7a9b4d0a0501548715365
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.265998MB