### PR TITLE
Reduce tree-sitter-go package size

### DIFF
--- a/recipes/recipes_emscripten/tree-sitter-go/recipe.yaml
+++ b/recipes/recipes_emscripten/tree-sitter-go/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: 2dc241b97872c53195e01b86542b411a3c1a6201d9c946c78d5c60c063bba1ef
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . -vv
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.007136MB