### PR TITLE
Reduce tree-sitter-java package size

### DIFF
--- a/recipes/recipes_emscripten/tree-sitter-java/recipe.yaml
+++ b/recipes/recipes_emscripten/tree-sitter-java/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: cb199e0faae4b2c08425f88cbb51c1a9319612e7b96315a174a624db9bf3d9f0
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . -vv
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.007253MB