### PR TITLE
Reduce tree-sitter-python package size

### DIFF
--- a/recipes/recipes_emscripten/tree-sitter-python/recipe.yaml
+++ b/recipes/recipes_emscripten/tree-sitter-python/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: 4609a3665a620e117acf795ff01b9e965880f81745f287a16336f4ca86cf270c
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . -vv
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.007326MB