### PR TITLE
Reduce tree-sitter package size

### DIFF
--- a/recipes/recipes_emscripten/tree-sitter/recipe.yaml
+++ b/recipes/recipes_emscripten/tree-sitter/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.028548MB