### PR TITLE
Reduce fps-kernel-web-worker package size

### DIFF
--- a/recipes/recipes_emscripten/fps-kernel-web-worker/recipe.yaml
+++ b/recipes/recipes_emscripten/fps-kernel-web-worker/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: 97b9c2cc8452207803c670fe16a265e118073c4b6131238a7fcdaf00afba151b
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - pip != 25.1


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.017596MB