### PR TITLE
Reduce octave package size

### DIFF
--- a/recipes/recipes_emscripten/octave/recipe.yaml
+++ b/recipes/recipes_emscripten/octave/recipe.yaml
@@ -33,8 +33,11 @@ source:
   - patches/0019-FIXME-memory-leaks.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/tests/**'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 2.841399MB