### PR TITLE
Reduce pyclipper package size

### DIFF
--- a/recipes/recipes_emscripten/pyclipper/recipe.yaml
+++ b/recipes/recipes_emscripten/pyclipper/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: 42bff0102fa7a7f2abdd795a2594654d62b786d0c6cd67b72d469114fdeb608c
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.013575MB