### PR TITLE
Reduce pyiceberg package size

### DIFF
--- a/recipes/recipes_emscripten/pyiceberg/recipe.yaml
+++ b/recipes/recipes_emscripten/pyiceberg/recipe.yaml
@@ -11,9 +11,20 @@ source:
   sha256: 095bbafc87d204cf8d3ffc1c434e07cf9a67a709192ac0b11dcb0f8251f7ad4e
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**.dist-info/**'
+    - '**/*.pyx'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 6.504099MB