### PR TITLE
Reduce ruamel.yaml.clib package size

### DIFF
--- a/recipes/recipes_emscripten/ruamel.yaml.clib/recipe.yaml
+++ b/recipes/recipes_emscripten/ruamel.yaml.clib/recipe.yaml
@@ -11,9 +11,13 @@ source:
   sha256: 803f5044b13602d58ea378576dd75aa759f52116a0232608e8fdada4da33752e
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/test_*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.005633MB