### PR TITLE
Reduce ruamel.yaml package size

### DIFF
--- a/recipes/recipes_emscripten/ruamel.yaml/recipe.yaml
+++ b/recipes/recipes_emscripten/ruamel.yaml/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: a6e587512f3c998b2225d68aa1f35111c29fad14aed561a26e73fab729ec5e5a
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_emscripten-wasm32


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.68652MB