### PR TITLE
Reduce wordcloud package size

### DIFF
--- a/recipes/recipes_emscripten/wordcloud/recipe.yaml
+++ b/recipes/recipes_emscripten/wordcloud/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: df17c468ff903bd0aba4f87c6540745d13a4931220dd4937cb363ad85a4771b9
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyx'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.073946MB