### PR TITLE
Reduce lakers-python package size

### DIFF
--- a/recipes/recipes_emscripten/lakers-python/recipe.yaml
+++ b/recipes/recipes_emscripten/lakers-python/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: fac63f3f5679a04d9277311c1f3e8eacee02a10e456547187f1a9695b6b3a333
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.002672MB