### PR TITLE
Reduce google-crc32c package size

### DIFF
--- a/recipes/recipes_emscripten/google-crc32c/recipe.yaml
+++ b/recipes/recipes_emscripten/google-crc32c/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79
 
 build:
-  number: 0
+  number: 1
   script: CRC32C_PURE_PYTHON=1 ${PYTHON} -m pip install .
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.02742MB