### PR TITLE
Reduce libgdal-core package size

### DIFF
--- a/recipes/recipes_emscripten/libgdal-core/recipe.yaml
+++ b/recipes/recipes_emscripten/libgdal-core/recipe.yaml
@@ -11,8 +11,12 @@ source:
   sha256: 2af3007398dca34561bbcc75ad884e2e256052add8c25b4f5fb1d0f84be5eec1
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
+    - '**/*.ini'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.398131MB