### PR TITLE
Reduce dtks package size

### DIFF
--- a/recipes/recipes_emscripten/dtks/recipe.yaml
+++ b/recipes/recipes_emscripten/dtks/recipe.yaml
@@ -11,8 +11,16 @@ source:
   sha256: cf86bd419231e2f976fcfbd0a7fbee308e77f7cc29b20c55e7cfc384c84a9d11
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("cxx") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.000419MB