### PR TITLE
Reduce libgdal-core-static package size

### DIFF
--- a/recipes/recipes_emscripten/libgdal-core-static/recipe.yaml
+++ b/recipes/recipes_emscripten/libgdal-core-static/recipe.yaml
@@ -11,8 +11,12 @@ source:
   sha256: 266cbadf8534d1de831db8834374afd95603e0a6af4f53d0547ae0d46bd3d2d1
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
+    - '**/*.ini'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.42399MB