### PR TITLE
Reduce bilby.cython package size

### DIFF
--- a/recipes/recipes_emscripten/bilby.cython/recipe.yaml
+++ b/recipes/recipes_emscripten/bilby.cython/recipe.yaml
@@ -11,37 +11,48 @@ source:
   sha256: 44400b2abc6fa592b13d69f33460cb156d6edb48a783f5539ee0a21e1d0a3508
 
 build:
-  number: 0
+  number: 1
   script: ${{PYTHON}} -m pip install . -vv
 
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyx'
+    - '**/test/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
-    - python
-    - cross-python_emscripten-wasm32
-    - cython >=3
-    - numpy
-    - ${{ compiler('c') }}
+  - python
+  - cross-python_emscripten-wasm32
+  - cython >=3
+  - numpy
+  - ${{ compiler('c') }}
   host:
-    - cython
-    - numpy
-    - pip
-    - python
-    - setuptools
-    - setuptools-scm
+  - cython
+  - numpy
+  - pip
+  - python
+  - setuptools
+  - setuptools-scm
   run:
-    - python
+  - python
 
 tests:
-  - script: pytester
-    requirements:
-      build:
-        - pytester
-      run:
-        - pytester-run
-    files:
-      recipe:
-        - test_bilby_cython.py
+- script: pytester
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+  files:
+    recipe:
+    - test_bilby_cython.py
 
 about:
   homepage: https://git.ligo.org/colm.talbot/bilby-cython
@@ -51,4 +62,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - ColmTalbot
+  - ColmTalbot


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.087783MB