### PR TITLE
Reduce jiter package size

### DIFF
--- a/recipes/recipes_emscripten/jiter/recipe.yaml
+++ b/recipes/recipes_emscripten/jiter/recipe.yaml
@@ -11,8 +11,16 @@ source:
   sha256: f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.00793MB