### PR TITLE
Reduce obspy package size

### DIFF
--- a/recipes/recipes_emscripten/obspy/recipe.yaml
+++ b/recipes/recipes_emscripten/obspy/recipe.yaml
@@ -48,7 +48,7 @@ requirements:
   - sqlalchemy >=1.4
   - decorator
   - requests
-  - setuptools
+  - setuptools<82
   - jaraco.text
   - platformdirs
 


### PR DESCRIPTION
This reduces the package content (once unzipped) by 31.311221MB