### PR TITLE
Reduce photutils package size

### DIFF
--- a/recipes/recipes_emscripten/photutils/recipe.yaml
+++ b/recipes/recipes_emscripten/photutils/recipe.yaml
@@ -11,30 +11,40 @@ source:
   sha256: 947527f77794469f960d51e6fd7add2fd531b16f2369d4541b1441eb81b3d9f7
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**/tests/**'
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
-    - python
-    - cross-python_${{ target_platform }}
-    - cython >=3.1.0,<4
-    - numpy
-    - ${{ compiler("c") }}
+  - python
+  - cross-python_${{ target_platform }}
+  - cython >=3.1.0,<4
+  - numpy
+  - ${{ compiler("c") }}
   host:
-    - python
-    - pip
-    - setuptools >=77.0
-    - setuptools_scm >=8.0
-    - cython >=3.1.0,<4
-    - extension-helpers >=1.3,<2
-    - astropy >=5.3
-    - numpy
+  - python
+  - pip
+  - setuptools >=77.0
+  - setuptools_scm >=8.0
+  - cython >=3.1.0,<4
+  - extension-helpers >=1.3,<2
+  - astropy >=5.3
+  - numpy
   run:
-    - python
-    - numpy >=1.25
-    - astropy >=5.3
-    - scipy >=1.11.1  # Note: scipy has broken exports in emscripten-wasm32, affecting some photutils features
+  - python
+  - numpy >=1.25
+  - astropy >=5.3
+  - scipy >=1.11.1    # Note: scipy has broken exports in emscripten-wasm32, affecting some photutils features
     # - matplotlib >=3.8  # Available but built for emscripten-abi 3.1.73, incompatible with 4.x
     # - regions >=0.9  # Recipe not yet available in emscripten-forge
     # - scikit-image >=0.21  # Available but depends on matplotlib-base with incompatible emscripten-abi 3.1.73
@@ -42,7 +52,7 @@ requirements:
     # - bottleneck >=1.3.6  # Recipe not yet available in emscripten-forge
     # - tqdm >=4.65  # Recipe not yet available in emscripten-forge (pure Python, should be easy to add)
     # - rasterio >=1.3.7  # Recipe not yet available in emscripten-forge
-    - shapely >=2.0.0
+  - shapely >=2.0.0
 
 tests:
 - script: pytester
@@ -67,4 +77,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - mmesch
+  - mmesch


### PR DESCRIPTION
This reduces the package content (once unzipped) by 3.619036MB