### PR TITLE
Reduce pycdfpp package size

### DIFF
--- a/recipes/recipes_emscripten/pycdfpp/recipe.yaml
+++ b/recipes/recipes_emscripten/pycdfpp/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: 2867bb79303e1b0837f53289a68f656eaba147a9f200aea21fabfce2fe20a5ef
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.060506MB