### PR TITLE
Reduce pysocks package size

### DIFF
--- a/recipes/recipes_emscripten/pysocks/recipe.yaml
+++ b/recipes/recipes_emscripten/pysocks/recipe.yaml
@@ -10,9 +10,18 @@ source:
   sha256: 3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.057912MB