### PR TITLE
Reduce r-arrow package size

### DIFF
--- a/recipes/recipes_emscripten/r-arrow/recipe.yaml
+++ b/recipes/recipes_emscripten/r-arrow/recipe.yaml
@@ -14,9 +14,16 @@ source:
   - patches/0001-Add-parquet-variable.patch
 
 build:
-  number: 0
+  number: 1
   script: cd r && $R CMD INSTALL $R_ARGS .
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-r-base_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.006539MB