### PR TITLE
Reduce sparrow-ipc package size

### DIFF
--- a/recipes/recipes_emscripten/sparrow-ipc/recipe.yaml
+++ b/recipes/recipes_emscripten/sparrow-ipc/recipe.yaml
@@ -13,8 +13,11 @@ source:
   - patches/0002-add-lz4-zstd-dependencies-to-config.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/tests/**'
 requirements:
   build:
   - ${{ compiler("cxx") }}
@@ -43,7 +46,7 @@ tests:
     - share/cmake/sparrow-ipc/sparrow-ipcConfigVersion.cmake
     - share/cmake/sparrow-ipc/sparrow-ipcTargets.cmake
 - script:
-    - build_tests.sh
+  - build_tests.sh
   requirements:
     build:
     - ${{ compiler("cxx") }}
@@ -51,8 +54,8 @@ tests:
     - make
   files:
     recipe:
-      - build_tests.sh
-      - tests/
+    - build_tests.sh
+    - tests/
 
 about:
   summary: C++20 idiomatic APIs for the Apache Arrow IPC


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.002916MB