### PR TITLE
[Emscripten 3.x] Reduce sympy package size

### DIFF
--- a/recipes/recipes_emscripten/sympy/recipe.yaml
+++ b/recipes/recipes_emscripten/sympy/recipe.yaml
@@ -10,9 +10,20 @@ source:
   sha256: ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8
 
 build:
-  number: 2
+  number: 3
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - share/man/man1/**
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 47.415458MB