### PR TITLE
[Emscripten 3.x] Reduce scipy package size

### DIFF
--- a/recipes/recipes_emscripten/scipy/recipe.yaml
+++ b/recipes/recipes_emscripten/scipy/recipe.yaml
@@ -11,30 +11,43 @@ source:
   sha256: 2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e
   patches:
     # Patches for subprojects
-    - patches/0001-Disable-threads-in-subprojects.patch
+  - patches/0001-Disable-threads-in-subprojects.patch
     # Branch containing following patches is v1.17.0-emforge at https://github.com/ianthomas23/scipy
     # Use `git format-patch v1.17.0...v1.17.0-emforge --start-number 2` to create patch files.
-    - patches/0002-Use-openblas-flang-not-openblas-dependency.patch
-    - patches/0003-Disable-unsupported-ffloat-store.patch
-    - patches/0004-int-size-in-dierckxmodule.patch
-    - patches/0005-Set-fortran-linker-to-emcc.patch
-    - patches/0006-Remove-unsupported-version-script.patch
-    - patches/0007-Remove-chla_transtype.patch
-    - patches/0008-Extra-char-length-arguments-in-linalg-cython-wrapper.patch
-    - patches/0009-Extra-char-length-args-in-_common_array_utils.patch
-    - patches/0010-Extra-char-length-args-in-propack.patch
-    - patches/0011-Change-return-and-char-length-args-in-dsolve.patch
-    - patches/0012-Extra-char-length-args-in-arpack.patch
-    - patches/0013-int-return-for-superlu_utils-and-input_error.patch
-    - patches/0014-Change-return-and-char-length-args-in-optimize.patch
-    - patches/0015-Extra-char-length-args-in-integrate.patch
-    - patches/0016-Disable-threads.patch
-    - patches/0017-Extra-char-length-args-to-f2py-source-files.patch
-    - patches/0018-Replace-dtype-with-numpy-int32.patch
+  - patches/0002-Use-openblas-flang-not-openblas-dependency.patch
+  - patches/0003-Disable-unsupported-ffloat-store.patch
+  - patches/0004-int-size-in-dierckxmodule.patch
+  - patches/0005-Set-fortran-linker-to-emcc.patch
+  - patches/0006-Remove-unsupported-version-script.patch
+  - patches/0007-Remove-chla_transtype.patch
+  - patches/0008-Extra-char-length-arguments-in-linalg-cython-wrapper.patch
+  - patches/0009-Extra-char-length-args-in-_common_array_utils.patch
+  - patches/0010-Extra-char-length-args-in-propack.patch
+  - patches/0011-Change-return-and-char-length-args-in-dsolve.patch
+  - patches/0012-Extra-char-length-args-in-arpack.patch
+  - patches/0013-int-return-for-superlu_utils-and-input_error.patch
+  - patches/0014-Change-return-and-char-length-args-in-optimize.patch
+  - patches/0015-Extra-char-length-args-in-integrate.patch
+  - patches/0016-Disable-threads.patch
+  - patches/0017-Extra-char-length-args-to-f2py-source-files.patch
+  - patches/0018-Replace-dtype-with-numpy-int32.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyi'
+    - '**/*.pyx'
+    - '**/*.pxd'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 43.934443MB