### PR TITLE
[Emscripten 3.x] Reduce scikit-learn package size

### DIFF
--- a/recipes/recipes_emscripten/scikit-learn/recipe.yaml
+++ b/recipes/recipes_emscripten/scikit-learn/recipe.yaml
@@ -13,8 +13,22 @@ source:
   - patches/0001-Patch-away-urllib.patch
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyx'
+    - '**/*.pxd'
+    - '**/*.pxi'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/*.tp'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 21.337605MB