### PR TITLE
[Emscripten 3.x] Reduce cartopy package size

### DIFF
--- a/recipes/recipes_emscripten/cartopy/recipe.yaml
+++ b/recipes/recipes_emscripten/cartopy/recipe.yaml
@@ -11,29 +11,40 @@ source:
   sha256: 231f37b35701f2ba31d94959cca75e6da04c2eea3a7f14ce1c75ee3b0eae7676
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyx'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
-    - python                                 
-    - cross-python_${{ target_platform }}     
-    - cython                                 
-    - numpy                                  
-    - ${{ compiler('c') }}
-    - ${{ compiler('cxx') }}
+  - python
+  - cross-python_${{ target_platform }}
+  - cython
+  - numpy
+  - ${{ compiler('c') }}
+  - ${{ compiler('cxx') }}
   host:
-    - python
-    - pip
-    - setuptools >=40.6.0
-    - setuptools-scm >=7.0.0
-    - numpy
+  - python
+  - pip
+  - setuptools >=40.6.0
+  - setuptools-scm >=7.0.0
+  - numpy
   run:
-    - python
-    - matplotlib-base >=3.5
-    - shapely >=1.7
-    - packaging >=20
-    - pyshp >=2.3
-    - pyproj >=3.3.1
+  - python
+  - matplotlib-base >=3.5
+  - shapely >=1.7
+  - packaging >=20
+  - pyshp >=2.3
+  - pyproj >=3.3.1
 
 tests:
 - script: pytester
@@ -45,7 +56,7 @@ tests:
     - pytester
     run:
     - pytester-run
-  
+
 about:
   homepage: http://scitools.org.uk/cartopy
   license: BSD-3-Clause
@@ -57,4 +68,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - KGB99
+  - KGB99


### PR DESCRIPTION
This reduces the package content (once unzipped) by 11.893744MB