### PR TITLE
[Emscripten 3.x] Reduce sqlalchemy package size

### DIFF
--- a/recipes/recipes_emscripten/sqlalchemy/recipe.yaml
+++ b/recipes/recipes_emscripten/sqlalchemy/recipe.yaml
@@ -10,9 +10,20 @@ source:
   sha256: c1b88cc8b02b6a5f0efb0345a03672d4c897dc7d92585176f88c67346f565ea8
 
 build:
-  number: 1
+  number: 2
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyx'
+    - '**/*.pxd'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 9.232811MB