### PR TITLE
[Emscripten 3.x] Reduce qutip package size

### DIFF
--- a/recipes/recipes_emscripten/qutip/recipe.yaml
+++ b/recipes/recipes_emscripten/qutip/recipe.yaml
@@ -10,8 +10,22 @@ source:
   sha256: 39435fe006213c116314fe46509e3f35d39c0ba897d633af172125056f893a11
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.ini'
+    - '**/__pycache__/**'
+    - '**/*.pyi'
+    - '**/*.pyx'
+    - '**/*.pxd'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 5.166348MB