### PR TITLE
[Emscripten 3.x] Reduce fonttools package size

### DIFF
--- a/recipes/recipes_emscripten/fonttools/recipe.yaml
+++ b/recipes/recipes_emscripten/fonttools/recipe.yaml
@@ -7,13 +7,22 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/fonttools-${{ version
-    }}.zip
+  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/fonttools-${{ version }}.zip
   sha256: dba8d7cdb8e2bac1b3da28c5ed5960de09e59a2fe7e63bb73f5a59e57b0430d2
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - share/man/man1/**
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python                                   # [build_platform != target_platform]


### PR DESCRIPTION
This reduces the package content (once unzipped) by 4.606398MB