### PR TITLE
[Emscripten 3.x] Reduce traits package size

### DIFF
--- a/recipes/recipes_emscripten/traits/recipe.yaml
+++ b/recipes/recipes_emscripten/traits/recipe.yaml
@@ -10,9 +10,20 @@ source:
   sha256: af4775747e11e05ffe13d3ba463d92f67f1f3d1a9e4f46ba33a44ea22b0c9644
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 3.696528MB