### PR TITLE
[Emscripten 3.x] Reduce galpy package size

### DIFF
--- a/recipes/recipes_emscripten/galpy/recipe.yaml
+++ b/recipes/recipes_emscripten/galpy/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: 58d0d2eccfa8f27603ba4187a53e62399e92233980effd7a006568ac69380e9f
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 3.140711MB