### PR TITLE
[Emscripten 3.x] Reduce leafmap package size

### DIFF
--- a/recipes/recipes_emscripten/leafmap/recipe.yaml
+++ b/recipes/recipes_emscripten/leafmap/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: 234d1e2a90b595e2a407862c1ebc952edcd82db807f7481a0cadf299af5bd327
 
 build:
-  number: 0
+  number: 1
   script: $PYTHON -m pip install . -vv
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 2.69537MB