### PR TITLE
[Emscripten 3.x] Reduce apsw package size

### DIFF
--- a/recipes/recipes_emscripten/apsw/recipe.yaml
+++ b/recipes/recipes_emscripten/apsw/recipe.yaml
@@ -10,9 +10,20 @@ source:
   sha256: 916271dcf55fc3fd150354b6dbbf76d75a1a5e77cbefca3c3603a8b9c51f9529
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 2.569622MB