### PR TITLE
[Emscripten 3.x] Reduce scikit-image package size

### DIFF
--- a/recipes/recipes_emscripten/scikit-image/recipe.yaml
+++ b/recipes/recipes_emscripten/scikit-image/recipe.yaml
@@ -18,7 +18,6 @@ build:
     exclude:
     - '**.dist-info/**'
     - '**/*.ini'
-    - '**/*.pyi'
     - '**/__pycache__/**'
     - '**/*.pyc'
     - '**/test_*.py'


### PR DESCRIPTION
This reduces the package content (once unzipped) by 2.270571MB