### PR TITLE
[Emscripten 3.x] Reduce shapely package size

### DIFF
--- a/recipes/recipes_emscripten/shapely/recipe.yaml
+++ b/recipes/recipes_emscripten/shapely/recipe.yaml
@@ -11,8 +11,19 @@ source:
   sha256: 2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pxd'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.939426MB