### PR TITLE
[Emscripten 3.x] Reduce robotics-toolbox-python package size

### DIFF
--- a/recipes/recipes_emscripten/robotics-toolbox-python/recipe.yaml
+++ b/recipes/recipes_emscripten/robotics-toolbox-python/recipe.yaml
@@ -11,9 +11,17 @@ source:
   rev: swiftless
 
 build:
-  number: 1
+  number: 2
   script: ${{ PYTHON }} -m pip install . -vvv --no-deps
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.919913MB