### PR TITLE
[Emscripten 3.x] Reduce scikit-image package size

### DIFF
--- a/recipes/recipes_emscripten/scikit-image/recipe.yaml
+++ b/recipes/recipes_emscripten/scikit-image/recipe.yaml
@@ -9,11 +9,22 @@ source:
   url: https://pypi.org/packages/source/s/scikit-image/scikit_image-${{ version }}.tar.gz
   sha256: f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa
   patches:
-    - patches/0001-Make-tifffile-optional.patch
+  - patches/0001-Make-tifffile-optional.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.ini'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 2.270571MB