### PR TITLE
[Emscripten 3.x] Reduce zarr package size

### DIFF
--- a/recipes/recipes_emscripten/zarr/recipe.yaml
+++ b/recipes/recipes_emscripten/zarr/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.476637MB