### PR TITLE
[Emscripten 3.x] Reduce h5py package size

### DIFF
--- a/recipes/recipes_emscripten/h5py/recipe.yaml
+++ b/recipes/recipes_emscripten/h5py/recipe.yaml
@@ -7,51 +7,62 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/03/2e/a22d6a8bfa6f8be33e7febd985680fba531562795f0a9077ed1eb047bfb0/h5py-${{version}}.tar.gz
+  url: 
+    https://files.pythonhosted.org/packages/03/2e/a22d6a8bfa6f8be33e7febd985680fba531562795f0a9077ed1eb047bfb0/h5py-${{version}}.tar.gz
   sha256: 1870e46518720023da85d0895a1960ff2ce398c5671eac3b1a41ec696b7105c3
 
   patches:
-    - patches/0001-Fix-incompatible-pointer-type.patch
-    - patches/configure.patch
+  - patches/0001-Fix-incompatible-pointer-type.patch
+  - patches/configure.patch
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
-    - cross-python_${{ target_platform }}
-    - ${{ compiler('cxx') }}
-    - python
-    - pkgconfig
-    - cython
-    - pip
-    - setuptools
-    - numpy
+  - cross-python_${{ target_platform }}
+  - ${{ compiler('cxx') }}
+  - python
+  - pkgconfig
+  - cython
+  - pip
+  - setuptools
+  - numpy
   host:
-    - numpy
-    - hdf5
-    - python
+  - numpy
+  - hdf5
+  - python
   run:
-    - numpy
-    - hdf5
+  - numpy
+  - hdf5
 
 tests:
-  - script: pytester
-    files:
-      recipe:
-      - test_h5py.py
-    requirements:
-      build:
-      - pytester
-      run:
-      - pytester-run
+- script: pytester
+  files:
+    recipe:
+    - test_h5py.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
 
 about:
   homepage: https://www.h5py.org/
-  license:  BSD-3-Clause
+  license: BSD-3-Clause
   license_file: licenses/license.txt
   summary: python bindings to hdf5
 
 
 extra:
   recipe-maintainers:
-    - DerThorsten
+  - DerThorsten


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.447045MB