### PR TITLE
[Emscripten 3.x] Reduce pillow package size

### DIFF
--- a/recipes/recipes_emscripten/pillow/recipe.yaml
+++ b/recipes/recipes_emscripten/pillow/recipe.yaml
@@ -14,8 +14,18 @@ source:
 - path: src/setup.cfg
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("cxx") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.426934MB