### PR TITLE
[Emscripten 3.x] Reduce joblib package size

### DIFF
--- a/recipes/recipes_emscripten/joblib/recipe.yaml
+++ b/recipes/recipes_emscripten/joblib/recipe.yaml
@@ -12,9 +12,19 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.406601MB