### PR TITLE
[Emscripten 3.x] Reduce lxml package size

### DIFF
--- a/recipes/recipes_emscripten/lxml/recipe.yaml
+++ b/recipes/recipes_emscripten/lxml/recipe.yaml
@@ -11,9 +11,21 @@ source:
   sha256: cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62
 
 build:
-  number: 0
+  number: 1
   script: ${PYTHON} -m pip install . ${PIP_ARGS}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pxi'
+    - '**/*.pyx'
+    - '**/*.pxd'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.271198MB