### PR TITLE
[Emscripten 3.x] Reduce pyerfa package size

### DIFF
--- a/recipes/recipes_emscripten/pyerfa/recipe.yaml
+++ b/recipes/recipes_emscripten/pyerfa/recipe.yaml
@@ -12,8 +12,18 @@ source:
 
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_emscripten-wasm32


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.172669MB