### PR TITLE
[Emscripten 3.x] Reduce python-sat package size

### DIFF
--- a/recipes/recipes_emscripten/python-sat/recipe.yaml
+++ b/recipes/recipes_emscripten/python-sat/recipe.yaml
@@ -7,7 +7,8 @@ package:
 
 source:
 - sha256: df4752cf290a551aff52f07da3bd8c827f51b286f11e29e67832bb4fffc0e32b
-  url: https://files.pythonhosted.org/packages/f9/35/7ebe9e31e97b3a2b7efaab800bb8a44f1a6179c392f77abf5ce4a0038dd6/python-sat-1.8.dev16.tar.gz
+  url: 
+    https://files.pythonhosted.org/packages/f9/35/7ebe9e31e97b3a2b7efaab800bb8a44f1a6179c392f77abf5ce4a0038dd6/python-sat-1.8.dev16.tar.gz
   patches:
   # - patches/force_malloc.patch
   # - patches/proper_build.patch
@@ -15,8 +16,17 @@ source:
 
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/test_*.py'
+    - '**.dist-info/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}
@@ -37,6 +47,6 @@ tests:
     run:
     - pytester-run
 
-about: 
+about:
   license: MIT
   license_file: LICENSE.txt


### PR DESCRIPTION
This reduces the package content (once unzipped) by 1.124045MB