### PR TITLE
[Emscripten 3.x] Reduce protobuf package size

### DIFF
--- a/recipes/recipes_emscripten/protobuf/recipe.yaml
+++ b/recipes/recipes_emscripten/protobuf/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: 6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.999473MB