### PR TITLE
[Emscripten 3.x] Reduce bitarray package size

### DIFF
--- a/recipes/recipes_emscripten/bitarray/recipe.yaml
+++ b/recipes/recipes_emscripten/bitarray/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: 3eae38daffd77c9621ae80c16932eea3fb3a4af141fb7cc724d4ad93eff9210d
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.876154MB