### PR TITLE
[Emscripten 3.x] Reduce peewee package size

### DIFF
--- a/recipes/recipes_emscripten/peewee/recipe.yaml
+++ b/recipes/recipes_emscripten/peewee/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: f88292a6f0d7b906cb26bca9c8599b8f4d8920ebd36124400d0cbaaaf915511f
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.862055MB