### PR TITLE
[Emscripten 3.x] Reduce cytoolz package size

### DIFF
--- a/recipes/recipes_emscripten/cytoolz/recipe.yaml
+++ b/recipes/recipes_emscripten/cytoolz/recipe.yaml
@@ -11,8 +11,20 @@ source:
   sha256: 13a7bf254c3c0d28b12e2290b82aed0f0977a4c2a2bf84854fcdc7796a29f3b0
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyx'
+    - '**/*.pxd'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python                                   # [build_platform != target_platform]


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.455527MB