### PR TITLE
[Emscripten 3.x] Reduce libgdal-core package size

### DIFF
--- a/recipes/recipes_emscripten/libgdal-core/recipe.yaml
+++ b/recipes/recipes_emscripten/libgdal-core/recipe.yaml
@@ -11,8 +11,12 @@ source:
   sha256: 458a899feea38000258144517fedc6662ebba255971669d2901ba77e9e8fbf79
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.ini'
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.423989MB