### PR TITLE
[Emscripten 3.x] Reduce netcdf4 package size

### DIFF
--- a/recipes/recipes_emscripten/netcdf4/recipe.yaml
+++ b/recipes/recipes_emscripten/netcdf4/recipe.yaml
@@ -10,8 +10,19 @@ source:
   url: https://github.com/Unidata/netcdf4-python/archive/refs/tags/v${{ version }}rel.tar.gz
   sha256: c792977eb762fd29fa46b78f44dd8c15729fe7733c2cd2ecd34552089734ce4b
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyx'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.391977MB