### PR TITLE
[Emscripten 3.x] Reduce logbook package size

### DIFF
--- a/recipes/recipes_emscripten/logbook/recipe.yaml
+++ b/recipes/recipes_emscripten/logbook/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: da4c22f8a5b0a0e9cf7b198f2ac935934b933a04b5a2d24ef3b1ffa2faeaa3c1
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_emscripten-wasm32


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.309936MB