### PR TITLE
[Emscripten 3.x] Reduce rapidfuzz package size

### DIFF
--- a/recipes/recipes_emscripten/rapidfuzz/recipe.yaml
+++ b/recipes/recipes_emscripten/rapidfuzz/recipe.yaml
@@ -11,8 +11,18 @@ source:
   sha256: 2491937177868bc4b1e469087601d53f925e8d270ccc21e07404b4b5814b7b5f
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.304332MB