### PR TITLE
[Emscripten 3.x] Reduce numcodecs package size

### DIFF
--- a/recipes/recipes_emscripten/numcodecs/recipe.yaml
+++ b/recipes/recipes_emscripten/numcodecs/recipe.yaml
@@ -21,8 +21,18 @@ source:
 
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/tests/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}
@@ -57,4 +67,5 @@ about:
   homepage: https://github.com/zarr-developers/numcodecs
   license: MIT
   license_file: LICENSE.txt
-  summary: A Python package providing buffer compression and transformation codecs for use in data storage and communication applications.
+  summary: A Python package providing buffer compression and transformation codecs for use in data storage and 
+    communication applications.


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.299956MB