### PR TITLE
[Emscripten 3.x] Reduce rustworkx package size

### DIFF
--- a/recipes/recipes_emscripten/rustworkx/recipe.yaml
+++ b/recipes/recipes_emscripten/rustworkx/recipe.yaml
@@ -11,8 +11,18 @@ source:
   sha256: 8bd0c295134e2b0c03808d4e69428b41153849db6488839084a78793c337f191
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.260261MB