### PR TITLE
[Emscripten 3.x] Reduce boost-histogram package size

### DIFF
--- a/recipes/recipes_emscripten/boost-histogram/recipe.yaml
+++ b/recipes/recipes_emscripten/boost-histogram/recipe.yaml
@@ -12,10 +12,20 @@ source:
   - patches/patch_allow_shared.patch
 
 build:
-  number: 0
+  number: 1
 #   cxxflags: -fexceptions
 #   ldflags: -fexceptions
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.245625MB