### PR TITLE
[Emscripten 3.x] Reduce pydantic-core package size

### DIFF
--- a/recipes/recipes_emscripten/pydantic-core/recipe.yaml
+++ b/recipes/recipes_emscripten/pydantic-core/recipe.yaml
@@ -11,8 +11,18 @@ source:
   sha256: 08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.210278MB