### PR TITLE
[Emscripten 3.x] Reduce endf package size

### DIFF
--- a/recipes/recipes_emscripten/endf/recipe.yaml
+++ b/recipes/recipes_emscripten/endf/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: 809840ac95d120e1ba7783d5ef78a38edcf5abd76c39a28b784aa3976a3384a1
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("cxx") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.198255MB