### PR TITLE
[Emscripten 3.x] Reduce contourpy package size

### DIFF
--- a/recipes/recipes_emscripten/contourpy/recipe.yaml
+++ b/recipes/recipes_emscripten/contourpy/recipe.yaml
@@ -11,8 +11,18 @@ source:
   sha256: 083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('cxx') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.174281MB