### PR TITLE
[Emscripten 3.x] Reduce pycrdt package size

### DIFF
--- a/recipes/recipes_emscripten/pycrdt/recipe.yaml
+++ b/recipes/recipes_emscripten/pycrdt/recipe.yaml
@@ -11,8 +11,18 @@ source:
   sha256: 3ef6666a095b707cccf9d45bb95e36a80e0b7d60fa83d6427602673fe1a42ac0
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{target_platform}}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.170762MB