### PR TITLE
[Emscripten 3.x] Reduce awkward-cpp package size

### DIFF
--- a/recipes/recipes_emscripten/awkward-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/awkward-cpp/recipe.yaml
@@ -7,13 +7,21 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/awkward-cpp-${{
-    version }}.tar.gz
+  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/awkward-cpp-${{ version }}.tar.gz
   sha256: 1f8b112a597bd2438794e1a721a63aa61869fa9598a17ac6bd811ad6f6400d06
 
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.167693MB