### PR TITLE
[Emscripten 3.x] Reduce pcre2 package size

### DIFF
--- a/recipes/recipes_emscripten/pcre2/recipe.yaml
+++ b/recipes/recipes_emscripten/pcre2/recipe.yaml
@@ -11,8 +11,11 @@ source:
   sha256: 409c443549b13b216da40049850a32f3e6c57d4224ab11553ab5a786878a158e
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.153073MB