### PR TITLE
[Emscripten 3.x] Reduce wrapt package size

### DIFF
--- a/recipes/recipes_emscripten/wrapt/recipe.yaml
+++ b/recipes/recipes_emscripten/wrapt/recipe.yaml
@@ -10,8 +10,18 @@ source:
   sha256: 5fdcb09bf6db023d88f312bd0767594b414655d58090fc1c46b3414415f67fac
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.121261MB