### PR TITLE
[Emscripten 3.x] Reduce msgspec package size

### DIFF
--- a/recipes/recipes_emscripten/msgspec/recipe.yaml
+++ b/recipes/recipes_emscripten/msgspec/recipe.yaml
@@ -11,9 +11,19 @@ source:
   sha256: 692349e588fde322875f8d3025ac01689fead5901e7fb18d6870a44519d62a29
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.11902MB