### PR TITLE
[Emscripten 3.x] Reduce swiglpk package size

### DIFF
--- a/recipes/recipes_emscripten/swiglpk/recipe.yaml
+++ b/recipes/recipes_emscripten/swiglpk/recipe.yaml
@@ -10,8 +10,17 @@ source:
   sha256: a1930c1682e90368f040f622e066e51a3eac38d782cc7b5b417c0d9b0740e1cc
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.11847MB