### PR TITLE
[Emscripten 3.x] Reduce wheel package size

### DIFF
--- a/recipes/recipes_emscripten/wheel/recipe.yaml
+++ b/recipes/recipes_emscripten/wheel/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.114205MB