### PR TITLE
[Emscripten 3.x] Reduce cftime package size

### DIFF
--- a/recipes/recipes_emscripten/cftime/recipe.yaml
+++ b/recipes/recipes_emscripten/cftime/recipe.yaml
@@ -12,8 +12,18 @@ source:
 
 build:
   script: $PYTHON -m pip install . -vv
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**.dist-info/**'
+    - '**/__pycache__/**'
+    - '**/*.pyx'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.11416MB