### PR TITLE
[Emscripten 3.x] Reduce pillow-heif package size

### DIFF
--- a/recipes/recipes_emscripten/pillow-heif/recipe.yaml
+++ b/recipes/recipes_emscripten/pillow-heif/recipe.yaml
@@ -13,9 +13,18 @@ source:
   - patches/0001-Do-not-include-system-dirs.patch
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.098925MB