### PR TITLE
[Emscripten 3.x] Reduce proj-static package size

### DIFF
--- a/recipes/recipes_emscripten/proj-static/recipe.yaml
+++ b/recipes/recipes_emscripten/proj-static/recipe.yaml
@@ -11,8 +11,12 @@ source:
   sha256: 6c097dc803c561929cdfcc46e4bf9945ea977611fb31493ad14e88edaeae260f
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.ini'
+    - share/man/man1/**
 requirements:
   build:
   - cmake


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.094267MB