### PR TITLE
[Emscripten 3.x] Reduce libnetcdf package size

### DIFF
--- a/recipes/recipes_emscripten/libnetcdf/recipe.yaml
+++ b/recipes/recipes_emscripten/libnetcdf/recipe.yaml
@@ -1,6 +1,6 @@
 context:
-  version: "4.9.3"
-  name: "libnetcdf"
+  version: 4.9.3
+  name: libnetcdf
 
 package:
   name: ${{ name }}
@@ -10,26 +10,29 @@ source:
   url: https://github.com/Unidata/netcdf-c/archive/refs/tags/v${{ version }}.tar.gz
   sha256: 990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff
   patches:
-    - parallel-disable.patch
-    - hdf5-parallel-disable.patch
+  - parallel-disable.patch
+  - hdf5-parallel-disable.patch
 build:
-  number: 1
+  number: 2
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
-    - python
-    - cross-python_${{ target_platform }}
-    - ${{ compiler('c') }}
-    - pip
-    - m4
-    - make
+  - python
+  - cross-python_${{ target_platform }}
+  - ${{ compiler('c') }}
+  - pip
+  - m4
+  - make
   host:
-    - python
-    - libxml2
-    - hdf5
-    - zlib
+  - python
+  - libxml2
+  - hdf5
+  - zlib
   run:
-    - python
+  - python
 
 about:
   homepage: http://www.unidata.ucar.edu/software/netcdf/


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.09286MB