### PR TITLE
[Emscripten 3.x] Reduce llvm package size

### DIFF
--- a/recipes/recipes_emscripten/llvm/recipe.yaml
+++ b/recipes/recipes_emscripten/llvm/recipe.yaml
@@ -15,8 +15,15 @@ source:
   - patches/fix_clang_keywords.patch
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.061574MB