### PR TITLE
[Emscripten 3.x] Reduce pysocks package size

### DIFF
--- a/recipes/recipes_emscripten/pysocks/recipe.yaml
+++ b/recipes/recipes_emscripten/pysocks/recipe.yaml
@@ -10,9 +10,18 @@ source:
   sha256: 3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0
 
 build:
-  number: 1
+  number: 2
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - python
@@ -36,8 +45,7 @@ tests:
 about:
   license_file: LICENSE
   license: BSD-3-Clause
-  summary: A Python SOCKS client module. See https://github.com/Anorov/PySocks for
-    more information.
+  summary: A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information.
   license_family: BSD
   homepage: https://github.com/Anorov/PySocks
 extra:


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.057911MB