### PR TITLE
[Emscripten 3.x] Reduce nlopt package size

### DIFF
--- a/recipes/recipes_emscripten/nlopt/recipe.yaml
+++ b/recipes/recipes_emscripten/nlopt/recipe.yaml
@@ -11,8 +11,17 @@ source:
 - path: src/setup.py
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_emscripten-wasm32


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.050232MB