### PR TITLE
[Emscripten 3.x] Reduce lazy-object-proxy package size

### DIFF
--- a/recipes/recipes_emscripten/lazy-object-proxy/recipe.yaml
+++ b/recipes/recipes_emscripten/lazy-object-proxy/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: 1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler("c") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.050161MB