### PR TITLE
[Emscripten 3.x] Reduce pure-eval package size

### DIFF
--- a/recipes/recipes_emscripten/pure-eval/recipe.yaml
+++ b/recipes/recipes_emscripten/pure-eval/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: 5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - cross-python_${{ target_platform }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.046188MB