### PR TITLE
[Emscripten 3.x] Reduce libjpeg-turbo package size

### DIFF
--- a/recipes/recipes_emscripten/libjpeg-turbo/recipe.yaml
+++ b/recipes/recipes_emscripten/libjpeg-turbo/recipe.yaml
@@ -11,8 +11,11 @@ source:
   sha256: 3a13a5ba767dc8264bc40b185e41368a80d5d5f945944d1dbaa4b2fb0099f4e5
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - share/man/man1/**
 requirements:
   build:
   - ${{ compiler("cxx") }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.045224MB