### PR TITLE
[Emscripten 3.x] Reduce lz4 package size

### DIFF
--- a/recipes/recipes_emscripten/lz4/recipe.yaml
+++ b/recipes/recipes_emscripten/lz4/recipe.yaml
@@ -11,8 +11,17 @@ source:
   sha256: 5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0
 
 build:
-  number: 0
+  number: 1
 
+  files:
+    exclude:
+    - '**/*.pyc'
+    - '**/__pycache__/**'
+    - '**.dist-info/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
 requirements:
   build:
   - ${{ compiler('c') }}


### PR DESCRIPTION
This reduces the package content (once unzipped) by 0.040911MB