### PR TITLE
.github/workflows/build_recipes.yaml: Upload packages as an artifact

### DIFF
--- a/.github/workflows/build_recipes.yaml
+++ b/.github/workflows/build_recipes.yaml
@@ -85,6 +85,13 @@ jobs:
       ################################################################
       # UPLOAD
       ################################################################
+      - name: Create artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: output
+          path: output
+        continue-on-error: true
+
       - name: Upload packages to prefix channel
         if: (github.event_name == 'push' && github.repository == 'emscripten-forge/recipes')
         shell: bash -l {0}


### PR DESCRIPTION
So that contributors can download and inspect or test the built packages on PRs.

Preview of the workflow run: https://github.com/emscripten-forge/recipes/actions/runs/22009704864/job/63600884353?pr=4446#step:8:39