### PR TITLE
Setup CI permissions for trusted publishers

### DIFF
--- a/.github/workflows/build_recipes.yaml
+++ b/.github/workflows/build_recipes.yaml
@@ -49,7 +49,7 @@ jobs:
           libgles2 \
           gstreamer1.0-libav \
           libgtk-4-1 \
-          libwayland-server0  
+          libwayland-server0
       ################################################################
       # CONFIG
       ################################################################
@@ -99,8 +99,6 @@ jobs:
       - name: Upload packages to prefix channel
         if: (github.event_name == 'push' && github.repository == 'emscripten-forge/recipes')
         shell: bash -l {0}
-        env:
-          PREFIX_DEV_API_KEY: ${{ secrets.PREFIX_DEV_API_KEY }}
         run: |
           overall_success=true
 
@@ -115,7 +113,6 @@ jobs:
 
                   rattler-build upload prefix \
                     --channel emscripten-forge-4x \
-                    -a $PREFIX_DEV_API_KEY \
                     ${package}
 
                   RETURNCODE=$?


### PR DESCRIPTION
This is enough for now. 

It seems we're still using the token for deleting packages, not sure we can use trusted publishers for this. Let's keep the token