### PR TITLE
Add cysignals [emscripten-3x]

### DIFF
--- a/recipes/recipes_emscripten/cysignals/build.sh
+++ b/recipes/recipes_emscripten/cysignals/build.sh
@@ -1,0 +1,11 @@
+cp $RECIPE_DIR/emscripten.meson.cross $SRC_DIR
+
+# write out the cross file
+sed "s|@(PYTHON)|${PYTHON}|g" $SRC_DIR/emscripten.meson.cross > $SRC_DIR/emscripten.meson.new
+mv $SRC_DIR/emscripten.meson.new $SRC_DIR/emscripten.meson.cross
+
+cat $SRC_DIR/emscripten.meson.cross
+
+${PYTHON} -m pip install . -vvv --no-deps --no-build-isolation \
+          -Csetup-args="--cross-file=$SRC_DIR/emscripten.meson.cross" \
+          -Csetup-args="-Dc_thread_count=0"

--- a/recipes/recipes_emscripten/cysignals/emscripten.meson.cross
+++ b/recipes/recipes_emscripten/cysignals/emscripten.meson.cross
@@ -1,0 +1,17 @@
+# binaries section is at the end as may want to append python binary.
+
+[properties]
+needs_exe_wrapper = true
+skip_sanity_check = true
+longdouble_format = 'IEEE_QUAD_LE' # for numpy
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm'
+endian = 'little'
+
+[binaries]
+exe_wrapper = 'node'
+pkgconfig = 'pkg-config'
+python = '@(PYTHON)'

--- a/recipes/recipes_emscripten/cysignals/patches/0001-src-cysignals-implementation.c-Only-use-backtrace-wh.patch
+++ b/recipes/recipes_emscripten/cysignals/patches/0001-src-cysignals-implementation.c-Only-use-backtrace-wh.patch
@@ -1,0 +1,26 @@
+From 4bc25048707657e93bfd0169a0bb0bad7421773c Mon Sep 17 00:00:00 2001
+From: Matthias Koeppe <mkoeppe@math.ucdavis.edu>
+Date: Mon, 9 Feb 2026 18:25:33 -0800
+Subject: [PATCH 1/3] src/cysignals/implementation.c: Only use backtrace when
+ both HAVE_BACKTRACE and HAVE_EXECINFO_H
+
+---
+ src/cysignals/implementation.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cysignals/implementation.c b/src/cysignals/implementation.c
+index 88dee66..5f8f3e5 100644
+--- a/src/cysignals/implementation.c
++++ b/src/cysignals/implementation.c
+@@ -719,7 +719,7 @@ static void print_sep(void)
+ /* Print a backtrace if supported by libc */
+ static void print_backtrace()
+ {
+-#if HAVE_BACKTRACE
++#if HAVE_BACKTRACE && HAVE_EXECINFO_H
+     void* backtracebuffer[BACKTRACELEN];
+     int btsize = backtrace(backtracebuffer, BACKTRACELEN);
+     if (btsize)
+-- 
+2.51.1
+

--- a/recipes/recipes_emscripten/cysignals/patches/0002-meson.build-Do-not-use-threads-on-emscripten.patch
+++ b/recipes/recipes_emscripten/cysignals/patches/0002-meson.build-Do-not-use-threads-on-emscripten.patch
@@ -1,0 +1,33 @@
+From fb6cde9a76a6245adfdf2a905d28797b7dd8aaec Mon Sep 17 00:00:00 2001
+From: Matthias Koeppe <mkoeppe@math.ucdavis.edu>
+Date: Wed, 11 Feb 2026 10:50:16 -0800
+Subject: [PATCH 2/3] meson.build: Do not use threads on emscripten
+
+---
+ meson.build | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 2253bcd..8082e2d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -15,6 +15,7 @@ is_windows = host_machine.system() == 'windows'
+ is_cygwin = host_machine.system() == 'cygwin'
+ is_msvc = cc.get_id() == 'msvc'
+ is_mingw = cc.get_id()=='gcc' and host_machine.system()=='windows'
++is_emscripten = host_machine.system() == 'emscripten'
+ 
+ # Set preprocessor macros
+ # Disable .c line numbers in exception tracebacks
+@@ -94,7 +95,7 @@ config.set('CYSIGNALS_STD_ATOMIC', cxx.links('#include <atomic>\nint main() { st
+ # for std::atomic with OpenMP in C++ code
+ config.set('CYSIGNALS_STD_ATOMIC_WITH_OPENMP', cxx.links('#include <atomic>\nint main() { static std::atomic<int> x; return 0; }', args: ['-fopenmp']) ? 1 : 0)
+ 
+-if is_windows
++if is_windows or is_emscripten
+   threads_dep = []
+ else
+   threads_dep = dependency('threads')
+-- 
+2.51.1
+

--- a/recipes/recipes_emscripten/cysignals/patches/0003-src-cysignals-implementation.c-EMSCRIPTEN-Do-not-use.patch
+++ b/recipes/recipes_emscripten/cysignals/patches/0003-src-cysignals-implementation.c-EMSCRIPTEN-Do-not-use.patch
@@ -1,0 +1,36 @@
+From 2ce8b6b240072d218ece162fb3705ad318472a46 Mon Sep 17 00:00:00 2001
+From: Matthias Koeppe <mkoeppe@math.ucdavis.edu>
+Date: Wed, 24 Jan 2024 23:24:45 -0800
+Subject: [PATCH 3/3] src/cysignals/implementation.c [EMSCRIPTEN]: Do not use
+ sigaltstack
+
+---
+ src/cysignals/implementation.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/cysignals/implementation.c b/src/cysignals/implementation.c
+index 5f8f3e5..ae27eee 100644
+--- a/src/cysignals/implementation.c
++++ b/src/cysignals/implementation.c
+@@ -632,7 +632,7 @@ static void _sig_off_warning(const char* file, int line)
+ 
+ static void setup_alt_stack(void)
+ {
+-#if HAVE_SIGALTSTACK
++#if HAVE_SIGALTSTACK && !defined(__EMSCRIPTEN__)
+     /* Space for the alternate signal stack. The size should be
+      * of the form MINSIGSTKSZ + constant. The constant is chosen rather
+      * ad hoc but sufficiently large. */
+@@ -675,7 +675,9 @@ static void setup_cysignals_handlers(void)
+      * After setting up the trampoline, we reset the signal mask. */
+     sigprocmask(SIG_BLOCK, &sa.sa_mask, &default_sigmask);
+ #endif
++#if !defined(__EMSCRIPTEN__)
+     setup_trampoline();
++#endif
+ #if HAVE_SIGPROCMASK
+     sigprocmask(SIG_SETMASK, &default_sigmask, &sigmask_with_sigint);
+ #endif
+-- 
+2.51.1
+

--- a/recipes/recipes_emscripten/cysignals/recipe.yaml
+++ b/recipes/recipes_emscripten/cysignals/recipe.yaml
@@ -1,0 +1,66 @@
+context:
+  name: cysignals
+  version: 1.12.6
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 3ef3a37bdb244821b85475a08e2762ca1019570b369e321504995fa9a54675ce
+  patches:  # from https://github.com/passagemath/upstream-cysignals
+  - 'patches/0001-src-cysignals-implementation.c-Only-use-backtrace-wh.patch'
+  - 'patches/0002-meson.build-Do-not-use-threads-on-emscripten.patch'
+  - 'patches/0003-src-cysignals-implementation.c-EMSCRIPTEN-Do-not-use.patch'
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - ${{ compiler('c') }}
+  - cython
+  - cross-python_${{ target_platform }}
+  - python
+  - pip
+  - meson-python
+  - pkg-config
+  host:
+  - python
+  run:
+  - python
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_import_cysignals.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+
+about:
+  homepage: https://github.com/sagemath/cysignals
+  license: LGPL-3.0-or-later
+  license_file: LICENSE
+  summary: Interrupt and signal handling for Cython
+  description: |
+    When writing Cython code, special care must be taken to ensure that the code
+    can be interrupted with CTRL-C. Since Cython optimizes for speed, Cython
+    normally does not check for interrupts. For example, code like the following
+    cannot be interrupted in Cython:
+
+    cdef long i
+    for i in range(2^63):
+        if i > 2^60:
+            print i
+
+    The cysignals package provides mechanisms to handle interrupts (and other
+    signals and errors) in Cython code.
+
+extra:
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/cysignals/test_import_cysignals.py
+++ b/recipes/recipes_emscripten/cysignals/test_import_cysignals.py
@@ -1,0 +1,2 @@
+def test_import_cysignals():
+    import cysignals


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: cysignals
- **Version**: 1.12.6

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

Backport from main without changes