### PR TITLE
Add memory-allocator [emscripten-3x]

### DIFF
--- a/recipes/recipes_emscripten/memory-allocator/build.sh
+++ b/recipes/recipes_emscripten/memory-allocator/build.sh
@@ -1,0 +1,11 @@
+cp $RECIPE_DIR/emscripten.meson.cross $SRC_DIR
+
+# write out the cross file
+sed "s|@(PYTHON)|${PYTHON}|g" $SRC_DIR/emscripten.meson.cross > $SRC_DIR/emscripten.meson.new
+mv $SRC_DIR/emscripten.meson.new $SRC_DIR/emscripten.meson.cross
+
+cat $SRC_DIR/emscripten.meson.cross
+
+${PYTHON} -m pip install . -vvv --no-deps --no-build-isolation \
+          -Csetup-args="--cross-file=$SRC_DIR/emscripten.meson.cross" \
+          -Csetup-args="-Dc_thread_count=0"

--- a/recipes/recipes_emscripten/memory-allocator/emscripten.meson.cross
+++ b/recipes/recipes_emscripten/memory-allocator/emscripten.meson.cross
@@ -1,0 +1,17 @@
+# binaries section is at the end as may want to append python binary.
+
+[properties]
+needs_exe_wrapper = true
+skip_sanity_check = true
+longdouble_format = 'IEEE_QUAD_LE' # for numpy
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm'
+endian = 'little'
+
+[binaries]
+exe_wrapper = 'node'
+pkgconfig = 'pkg-config'
+python = '@(PYTHON)'

--- a/recipes/recipes_emscripten/memory-allocator/recipe.yaml
+++ b/recipes/recipes_emscripten/memory-allocator/recipe.yaml
@@ -1,0 +1,66 @@
+context:
+  version: 0.2.0
+
+package:
+  name: memory-allocator
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/m/memory-allocator/memory_allocator-${{ version }}.tar.gz
+  sha256: 675d3c91019db98c97441de73d5c648821e5ae813f3f54cd09863d474b48fe26
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - ${{ compiler('c') }}
+  - cython
+  - cross-python_${{ target_platform }}
+  - python
+  - pip
+  - meson-python
+  - pkg-config
+  host:
+  - python
+  run:
+  - python
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_import_memory_allocator.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+
+about:
+  homepage: https://github.com/sagemath/memory_allocator
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+  description: |
+    # MemoryAllocator
+    An extension class to allocate memory easily with cython.
+
+    This extension class started as part of the [Sage](https://sagemath.org) software.
+
+    It provides a single extension class `MemoryAllocator` with `cdef` methods
+
+    - `malloc`,
+    - `calloc`,
+    - `allocarray`,
+    - `realloc`,
+    - `reallocarray`,
+    - `aligned_malloc`,
+    - `aligned_calloc`,
+    - `aligned_allocarray`.
+
+    Memory is freed when the instance of `MemoryAllocator` is deallocated.
+    On failure to allocate the memory, a proper error is raised.
+
+extra:
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/memory-allocator/test_import_memory_allocator.py
+++ b/recipes/recipes_emscripten/memory-allocator/test_import_memory_allocator.py
@@ -1,0 +1,2 @@
+def test_import_memory_allocator():
+    import memory_allocator


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: memory-allocator
- **Version**: 0.2.0

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

Backport from main without changes