### PR TITLE
Add gsl [emscripten-3x]

### DIFF
--- a/recipes/recipes_emscripten/gsl/build.sh
+++ b/recipes/recipes_emscripten/gsl/build.sh
@@ -1,0 +1,6 @@
+emconfigure ./configure \
+    CFLAGS="$CFLAGS -fPIC" \
+    --prefix=${PREFIX} \
+    --disable-shared
+emmake make -j${CPU_COUNT}
+emmake make install

--- a/recipes/recipes_emscripten/gsl/recipe.yaml
+++ b/recipes/recipes_emscripten/gsl/recipe.yaml
@@ -1,0 +1,36 @@
+context:
+  version: 2.8
+  name: gsl
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://ftp.gnu.org/gnu/gsl/gsl-${{ version }}.tar.gz
+  sha256: 6a99eeed15632c6354895b1dd542ed5a855c0f15d9ad1326c6fe2b2c9e423190
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - gnuconfig
+    - make
+
+tests:
+- package_contents:
+    files:
+    - include/gsl/gsl_cdf.h
+
+about:
+  homepage: http://www.gnu.org/software/gsl/
+  license: GPL-3.0-or-later
+  license_file: COPYING
+  summary: |
+    The GNU Scientific Library
+
+extra:
+  recipe-maintainers:
+    - mkoeppe


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: gsl
- **Version**: 2.8

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

Backport from main without changes