### PR TITLE
Add passagemath-{environment,setup,objects,repl} [emscripten-3x]

### DIFF
--- a/recipes/recipes_emscripten/passagemath-environment/recipe.yaml
+++ b/recipes/recipes_emscripten/passagemath-environment/recipe.yaml
@@ -1,0 +1,58 @@
+context:
+  version: 10.8.1
+
+package:
+  name: passagemath-environment
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/p/passagemath-environment/passagemath_environment-${{ version }}.tar.gz
+  sha256: 51477339171cdfa88aaae838d77f244f3fbae75293794078153eeffa80fa7d65
+
+build:
+  script: ${{ PYTHON }} -m pip install .
+  noarch: python
+
+requirements:
+  build:
+  - python
+  - crossenv >=1.2
+  - cross-python_emscripten-wasm32
+  - ${{ compiler("c") }}
+  - pip
+  host:
+  - python
+  - setuptools
+  - wheel
+  - pip
+  run:
+  - python
+  - packaging
+  - platformdirs
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_passagemath_environment.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+
+about:
+  summary: 'passagemath: System and software environment'
+  license: GPL-2.0-or-later
+  license_file: README.rst
+  description: |
+    Distribution of a small part of the Sage library.
+    It provides the connection to the system and software environment.
+
+extra:
+  emscripten_tests:
+    python:
+      pytest_files:
+      - test_passagemath_environment.py
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/passagemath-environment/test_passagemath_environment.py
+++ b/recipes/recipes_emscripten/passagemath-environment/test_passagemath_environment.py
@@ -1,0 +1,2 @@
+def test_import_passagemath_environment():
+    import sage.all__sagemath_environment

--- a/recipes/recipes_emscripten/passagemath-objects/recipe.yaml
+++ b/recipes/recipes_emscripten/passagemath-objects/recipe.yaml
@@ -1,0 +1,69 @@
+context:
+  version: 10.8.1
+
+package:
+  name: passagemath-objects
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/p/passagemath-objects/passagemath_objects-${{ version }}.tar.gz
+  sha256: 6823a0665f187a729bf34d941db0afb31190e56647d2b2315bac4b76574dba2a
+
+build:
+  script: ${{ PYTHON }} -m pip install .
+  noarch: python
+
+requirements:
+  build:
+  - python
+  - crossenv >=1.2
+  - cross-python_emscripten-wasm32
+  - ${{ compiler("c") }}
+  - ${{ compiler("cxx") }}
+  - pip
+  - passagemath-setup
+  - passagemath-environment
+  - cython
+  - gmpy2
+  - cysignals
+  - pkgconfig
+  host:
+  - python
+  - gmp
+  - mpfr
+  - mpc
+  run:
+  - python
+  - gmpy2
+  - cysignals
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_passagemath_objects.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+
+about:
+  summary: 'passagemath: Sage objects, elements, parents, categories, coercion, metaclasses'
+  license: GPL-2.0-or-later
+  license_file: README.rst
+  description: |
+    Distribution of a small part of the Sage library.
+    Sage extends Python's object system by dynamic mix-in classes that are driven by categories
+    and axioms. It is loosely modeled on concepts of category theory and inspired by
+    Scratchpad/Axiom/FriCAS, Magma, and MuPAD. This distribution package makes Sage objects,
+    the element/parent framework, basic categories and functors, the coercion system and the
+    related metaclasses available. It only depends on the basic arithmetic libraries.
+
+extra:
+  emscripten_tests:
+    python:
+      pytest_files:
+      - test_passagemath_objects.py
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/passagemath-objects/test_passagemath_objects.py
+++ b/recipes/recipes_emscripten/passagemath-objects/test_passagemath_objects.py
@@ -1,0 +1,2 @@
+def test_import_passagemath_objects():
+    import passagemath_objects

--- a/recipes/recipes_emscripten/passagemath-repl/recipe.yaml
+++ b/recipes/recipes_emscripten/passagemath-repl/recipe.yaml
@@ -1,0 +1,64 @@
+context:
+  version: 10.8.1
+
+package:
+  name: passagemath-repl
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/p/passagemath-repl/passagemath_repl-${{ version }}.tar.gz
+  sha256: a27e3e56c024fd05721eb95aa57f0261bf85e16ec0a0b354003f96b6d64686b5
+
+build:
+  script: ${{ PYTHON }} -m pip install .
+  noarch: python
+
+requirements:
+  build:
+  - python
+  - crossenv >=1.2
+  - cross-python_emscripten-wasm32
+  - ${{ compiler("c") }}
+  - pip
+  - passagemath-setup
+  - passagemath-environment
+  - pkgconfig
+  host:
+  - python
+  - setuptools
+  - wheel
+  - pip
+  run:
+  - python
+  - passagemath-environment
+  - passagemath-objects
+  - ipython
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_passagemath_repl.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+
+about:
+  summary: 'passagemath: IPython kernel, Sage preparser, doctester'
+  license: GPL-2.0-or-later
+  license_file: README.rst
+  description: |
+    Distribution of a small part of the Sage library.
+    It provides the top-level interactive environment with the preparser that defines the surface
+    language of Sage. This distribution also includes the doctesting facilities, as the doctests
+    are written in the surface language, as well as the IPython kernel.
+
+extra:
+  emscripten_tests:
+    python:
+      pytest_files:
+      - test_passagemath_repl.py
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/passagemath-repl/test_passagemath_repl.py
+++ b/recipes/recipes_emscripten/passagemath-repl/test_passagemath_repl.py
@@ -1,0 +1,2 @@
+def test_import_passagemath_repl():
+    import sage.all__sagemath_repl

--- a/recipes/recipes_emscripten/passagemath-setup/recipe.yaml
+++ b/recipes/recipes_emscripten/passagemath-setup/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  version: 10.8.1
+
+package:
+  name: passagemath-setup
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/p/passagemath-setup/passagemath_setup-${{ version }}.tar.gz
+  sha256: f2bfa93c8bcb77b7ae68c8f2b8ef83851248b201e2f0b56efe8c1588f5c8d420
+
+build:
+  script: ${{ PYTHON }} -m pip install .
+  noarch: python
+
+requirements:
+  build:
+  - python
+  - crossenv >=1.2
+  - cross-python_emscripten-wasm32
+  - ${{ compiler("c") }}
+  - pip
+  host:
+  - python
+  - setuptools
+  - wheel
+  - pip
+  run:
+  - python
+  - setuptools
+  - jinja2
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_passagemath_setup.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+
+about:
+  summary: 'passagemath: Build system of the Sage library'
+  license: GPL-2.0-or-later
+  license_file: README.rst
+  description: |
+    sage-setup: Build system of the Sage library
+    ================================================
+
+    This is the build system of the Sage library, based on setuptools.
+
+extra:
+  emscripten_tests:
+    python:
+      pytest_files:
+      - test_passagemath_setup.py
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/passagemath-setup/test_passagemath_setup.py
+++ b/recipes/recipes_emscripten/passagemath-setup/test_passagemath_setup.py
@@ -1,0 +1,2 @@
+def test_import_passagemath_setup():
+    import sage_setup


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: passagemath-{environment,setup,objects,repl}
- **Version**: 10.8.1

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

Backport from main without changes