### PR TITLE
Add cmr, passagemath-cmr [emscripten-3x]

### DIFF
--- a/recipes/recipes_emscripten/cmr/build.sh
+++ b/recipes/recipes_emscripten/cmr/build.sh
@@ -1,0 +1,16 @@
+mkdir build
+cd build
+mkdir -p $PREFIX
+
+# Configure step
+cmake ${CMAKE_ARGS} ..                    \
+    -GNinja                               \
+    -DCMAKE_PREFIX_PATH:PATH=${PREFIX}    \
+    -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON  \
+    -DCMAKE_BUILD_TYPE=Release
+
+ninja install
+
+# Copy wasm files also
+cp *.wasm $PREFIX/bin/

--- a/recipes/recipes_emscripten/cmr/recipe.yaml
+++ b/recipes/recipes_emscripten/cmr/recipe.yaml
@@ -1,0 +1,35 @@
+context:
+  version: 1.4
+
+package:
+  name: cmr
+  version: ${{ version }}
+
+source:
+  url: https://github.com/discopt/cmr/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 956a6114d7ee2d3176376660ab1221306da9b2f6de985825d8e60c9cbdf41c17
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - ${{ compiler("cxx") }}
+  - cmake
+  - ninja
+  - gmp
+  - gtest
+
+tests:
+- script:
+  - test -d ${PREFIX}/include/cmr
+
+about:
+  license: MIT
+  license_file: LICENSE
+  summary: Combinatorial matrix recognition
+  homepage: https://github.com/discopt/cmr
+
+extra:
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/passagemath-cmr/recipe.yaml
+++ b/recipes/recipes_emscripten/passagemath-cmr/recipe.yaml
@@ -1,0 +1,73 @@
+context:
+  version: 10.8.1
+
+package:
+  name: passagemath-cmr
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/p/passagemath-cmr/passagemath_cmr-${{ version }}.tar.gz
+  sha256: 1429150251c554d3457077dc6e73e85a37ec63c5f2f480bfdb65bb33a9ab9d50
+
+build:
+  script: ${{ PYTHON }} -m pip install .
+  noarch: python
+
+requirements:
+  build:
+  - python
+  - crossenv >=1.2
+  - cross-python_emscripten-wasm32
+  - ${{ compiler("c") }}
+  - ${{ compiler("cxx") }}
+  - pip
+  - passagemath-setup
+  - passagemath-environment
+  - cython
+  - gmpy2
+  - cysignals
+  - pkgconfig
+  host:
+  - python
+  - gmp
+  - mpfr
+  - mpc
+  - cmr
+  - passagemath-graphs
+  - passagemath-modules
+  run:
+  - python
+  - gmpy2
+  - cysignals
+  - passagemath-graphs
+  - passagemath-modules
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_passagemath_cmr.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+    - passagemath-repl
+
+about:
+  license: GPL-2.0-or-later
+  license_file: README.rst
+  summary: 'passagemath: Combinatorial matrix recognition'
+  description: |
+    Distribution of a small part of the Sage library for use with passagemath-modules
+    and passagemath-graphs. It provides a Cython interface to the CMR library, which
+    implements recognition and decomposition algorithms for totally unimodular matrices,
+    network matrices, regular matroids, series-parallel matroids, etc.
+
+extra:
+  emscripten_tests:
+    python:
+      pytest_files:
+      - test_passagemath_cmr.py
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/passagemath-cmr/test_passagemath_cmr.py
+++ b/recipes/recipes_emscripten/passagemath-cmr/test_passagemath_cmr.py
@@ -1,0 +1,5 @@
+import pytest
+
+
+def test_import_passagemath_cmr():
+    import passagemath_cmr


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: cmr, passagemath-cmr
- **Version**: 1.4, 10.8.1

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

