### PR TITLE
Update scipy from 1.16.0 to 1.16.1

### DIFF
--- a/recipes/recipes_emscripten/scipy/recipe.yaml
+++ b/recipes/recipes_emscripten/scipy/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: scipy
-  version: 1.16.0
+  version: 1.16.1
 
 package:
   name: ${{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
 - url: https://pypi.org/packages/source/s/scipy/scipy-${{ version }}.tar.gz
-  sha256: b5ef54021e832869c8cfb03bc3bf20366cbcd426e02a58e8a58d7584dfbb8f62
+  sha256: 44c76f9e8b6e8e488a586190ab38016e4ed2f8a038af7cd3defa903c0a2238b3
   patches:
   # Patches for subprojects
   - patches/0001-Disable-threads.patch


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [ ] ⚠️ Bump build number if the version remains unchanged
- [x] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: 
- **Version**: 

## Build Notes

Continuing update of `scipy` on `main` branch, this is 1.16.0 to 1.16.1 which is trivial as there are no changes to patches.

Test pass locally for me on Ubuntu, and I can run it in xeus-python-lite without any problems.