### PR TITLE
Avoid propagation of R dependencies in non R packages for Arrow

### DIFF
--- a/recipes/recipes_emscripten/arrow/recipe.yaml
+++ b/recipes/recipes_emscripten/arrow/recipe.yaml
@@ -70,7 +70,7 @@ cache:
     ignore_run_exports:
       from_package:
         - cross-r-base_${{ target_platform }}
-        - python_abi
+        - python
   build:
     script: build.sh
 


### PR DESCRIPTION
Avoid the propagation of R dependencies in non R packages for Arrow packages like Python or C++