### PR TITLE
Update CI environment

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -5,7 +5,7 @@ dependencies:
   - python
   - ruamel.yaml
   - typer
-  - rattler-build >=0.57.0,!=0.58.0
+  - rattler-build >=0.57.0,<0.58.0
   - pixi
   - jinja2
   - curl


### PR DESCRIPTION
`rattler-build` v0.58.0 causes this issue even though the keys exist in `variant.yaml`

```
╭─ Finding outputs from recipe
│ Loading variant config from: variant.yaml
│ ⚠ warning Found 'pin_run_as_build' in variant config - this is not supported and will be ignored
│
╰─────────────────── (took 0 seconds)
Error:   × Failed to render recipe with variants
╰─▶ Variant key 'cxx_compiler_version' not found in configuration
```