### PR TITLE
Pin rattler-build in pixi.toml to <0.58

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -8,7 +8,7 @@ platforms = ["osx-arm64", "osx-64", "linux-64"]
 
 # default environment
 [dependencies]
-rattler-build = ">=0.34.1"
+rattler-build = ">=0.57.0,<0.58.0"
 curl = "*"
 
 ############################################
@@ -18,7 +18,7 @@ curl = "*"
 [feature.feature_rattler_build.dependencies]
 git = "*"
 patch = "*"
-rattler-build = ">=0.34.1"
+rattler-build = ">=0.57.0,<0.58.0"
 python = "3.11.*"
 typer = "*"
 curl = "*"


### PR DESCRIPTION
Follow-up to #4965, pinning `rattler-build` in `pixi.toml` the same as in `ci_env.yml` which is `>=0.57.0,<0.58.0`. I've confirmed that this works locally for me.