### PR TITLE
Add soplex

### DIFF
--- a/recipes/recipes_emscripten/soplex/build.sh
+++ b/recipes/recipes_emscripten/soplex/build.sh
@@ -1,0 +1,25 @@
+mkdir build
+cd build
+mkdir -p $PREFIX
+
+export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
+export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
+
+# Configure step
+cmake ${CMAKE_ARGS} ..                          \
+    -GNinja                                     \
+    -DCMAKE_PREFIX_PATH:PATH=${PREFIX}          \
+    -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX}       \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
+    -DCMAKE_BUILD_TYPE=Release                  \
+    -DZLIB_LIBRARY="${PREFIX}/lib/libz.a"       \
+    -DZLIB_INCLUDE_DIR="${PREFIX}/include"      \
+    -DGMP_INCLUDE_DIRS="${PREFIX}/include"      \
+    -DGMP_LIBRARIES="${PREFIX}/lib/libgmp.a"    \
+    -DMPFR_INCLUDE_DIRS="${PREFIX}/include"     \
+    -DMPFR_LIBRARIES="${PREFIX}/lib/libmpfr.a"
+
+ninja install
+
+# Copy wasm files also
+cp bin/*.wasm $PREFIX/bin/

--- a/recipes/recipes_emscripten/soplex/recipe.yaml
+++ b/recipes/recipes_emscripten/soplex/recipe.yaml
@@ -1,0 +1,43 @@
+context:
+  version: 8.0.1
+
+package:
+  name: soplex
+  version: ${{ version }}
+
+source:
+  url: https://github.com/scipopt/soplex/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: f989f650e0d489f4e84037af2a50b1d0928f62ab79179ef566111d9197c2b6c8
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - ${{ compiler("cxx") }}
+  - cmake
+  - ninja
+  host:
+  - boost-cpp
+  - gmp
+  - mpfr
+  - zlib
+  - bzip2
+  # omitted for now: papilo
+
+tests:
+- script:
+  - test -d ${PREFIX}/include/soplex
+- package_contents:
+    files:
+      - lib/libsoplex.a
+
+about:
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Linear optimization solver using the revised simplex method
+  homepage: https://github.com/scipopt/soplex
+
+extra:
+  recipe-maintainers:
+  - mkoeppe


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: soplex
- **Version**: 8.0.1

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

