### PR TITLE
Add pyscipopt

### DIFF
--- a/recipes/recipes_emscripten/pyscipopt/recipe.yaml
+++ b/recipes/recipes_emscripten/pyscipopt/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  version: 6.1.0
+
+package:
+  name: pyscipopt
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/p/pyscipopt/pyscipopt-${{ version }}.tar.gz
+  sha256: 7a6b144fd3a7485a85ffa2e6eea71d8251f2ca8bbc84cb2b36d6bb08d1c17e17
+
+build:
+  number: 0
+  script: |
+    ${{ PYTHON }} -m pip install .
+
+requirements:
+  build:
+  - python
+  - crossenv >=1.2
+  - cross-python_emscripten-wasm32
+  - ${{ compiler("c") }}
+  - ${{ compiler("cxx") }}
+  - pip
+  - cython
+  - numpy
+  host:
+  - python
+  - scip
+  - numpy
+  run:
+  - python
+  - numpy
+  - gmp
+  - soplex
+  - scip
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_passagemath_ppl.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+
+about:
+  summary: 'Python interface and modeling environment for SCIP'
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  emscripten_tests:
+    python:
+      pytest_files:
+      - test_pyscipopt.py
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/pyscipopt/test_passagemath_pyscipopt.py
+++ b/recipes/recipes_emscripten/pyscipopt/test_passagemath_pyscipopt.py
@@ -1,0 +1,2 @@
+def test_import_pyscipopt():
+    import pyscipopt


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: pyscipopt
- **Version**: 6.1.0

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

