### PR TITLE
Add 4ti2

### DIFF
--- a/recipes/recipes_emscripten/4ti2/build.sh
+++ b/recipes/recipes_emscripten/4ti2/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/gnuconfig/config.* . || true
+
+emconfigure ./configure \
+    CFLAGS="$CFLAGS -fPIC" \
+    --prefix=$PREFIX \
+    --with-gmp=$PREFIX \
+    --with-glpk=$PREFIX \
+    --disable-shared
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/recipes_emscripten/4ti2/recipe.yaml
+++ b/recipes/recipes_emscripten/4ti2/recipe.yaml
@@ -1,0 +1,42 @@
+context:
+  name: 4ti2
+  version: 1.6.15
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/4ti2/4ti2/releases/download/Release_${{ version | replace('.','_') }}/4ti2-${{ version }}.tar.gz
+  sha256: 070e639398fda1a4665b3291e5ea80f2ba280d9bffd50656ad8482d471b96965
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - ${{ compiler('cxx') }}
+  - libtool
+  - m4
+  - make
+  - gnuconfig
+  host:
+  - glpk
+  - gmp
+  - zlib
+
+tests:
+- package_contents:
+    files:
+    - include/4ti2/4ti2.h
+    - lib/lib4ti2gmp.a
+
+about:
+  license: GPL-2.0-or-later
+  license_file: COPYING
+  summary: Algebraic, geometric and combinatorial problems on linear spaces
+  homepage: https://4ti2.github.io/
+
+extra:
+  recipe-maintainers:
+  - mkoeppe


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: 4ti2
- **Version**: 1.6.15

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

