### PR TITLE
Add mpfi

### DIFF
--- a/recipes/recipes_emscripten/mpfi/build.sh
+++ b/recipes/recipes_emscripten/mpfi/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/gnuconfig/config.* . || true
+
+emconfigure ./configure \
+    CFLAGS="$CFLAGS -fPIC" \
+    --prefix=$PREFIX \
+    --with-gmp=$PREFIX \
+    --enable-shared=no
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/recipes_emscripten/mpfi/recipe.yaml
+++ b/recipes/recipes_emscripten/mpfi/recipe.yaml
@@ -1,0 +1,41 @@
+context:
+  name: mpfi
+  version: 1.5.2
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/passagemath/passagemath/releases/download/passagemath-10.8.1/mpfi-${{ version }}.tar.bz2
+  sha256: c04f52cb306824b91b6d6eacf4f675b91fdee47c30f14d5b346dbfcd2492d274
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - ${{ compiler('c') }}
+  - libtool
+  - m4
+  - make
+  - gnuconfig
+  host:
+  - gmp
+  - mpfr
+
+tests:
+- package_contents:
+    files:
+    - include/mpfi.h
+    - lib/libmpfi.a
+
+about:
+  license: LGPL-3.0-only
+  license_file: COPYING.LESSER
+  summary: Multiple precision interval arithmetic library based on MPFR
+  homepage: https://gitlab.inria.fr/mpfi/mpfi
+
+extra:
+  recipe-maintainers:
+  - mkoeppe


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: mpfi
- **Version**: 1.5.2

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

- Part of https://github.com/passagemath/passagemath/issues/1863