### PR TITLE
Use CRAN's Archive as backup URL

### DIFF
--- a/recipes/recipes_emscripten/r-askpass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-askpass/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 6c2106a74c44a748f2cea795d9686e27a0058a90debcfd8558b62b06aec0c7dd
 
 build:
@@ -49,4 +51,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - IsabelParedes
+  - IsabelParedes

--- a/recipes/recipes_emscripten/r-base64enc/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base64enc/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 3c7e9d22f7409fa2989008fa6e980c3dd8e2693eb20676acf2470ae7addb0816
 
 build:

--- a/recipes/recipes_emscripten/r-bit/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit/recipe.yaml
@@ -8,8 +8,10 @@ package:
 
 source:
   url:
-    - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-    - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 48fe21c5d04c7b724d695eeb60074395c0c631a7fb234e2075de92471445de08
 
 build:
@@ -40,4 +42,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - IsabelParedes
+  - IsabelParedes

--- a/recipes/recipes_emscripten/r-bit64/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit64/recipe.yaml
@@ -8,8 +8,10 @@ package:
 
 source:
   url:
-    - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-    - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: fbc0ce142fc22c9a9fdcbac930a814dfb648563d4b6a77dff739c23cc81319b7
 
 build:
@@ -41,4 +43,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - IsabelParedes
+  - IsabelParedes

--- a/recipes/recipes_emscripten/r-cachem/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cachem/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 550839fc2ae5d865db475ba2c1714144f07fa0c052c72135b0e4a70287492e21
 
 build:

--- a/recipes/recipes_emscripten/r-cli/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cli/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 8ebe3146e66a285d8ad6ddcff87e2a9790ea7c9cdfce7fdd8bf13095fa459679
 
 build:
@@ -42,5 +44,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - IsabelParedes
-    - anutosh491
+  - IsabelParedes
+  - anutosh491

--- a/recipes/recipes_emscripten/r-colorspace/recipe.yaml
+++ b/recipes/recipes_emscripten/r-colorspace/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: ec71499d33ef5d72b7fb3359b8320639e06e413abad61a070201178a254b153e
 
 build:

--- a/recipes/recipes_emscripten/r-digest/recipe.yaml
+++ b/recipes/recipes_emscripten/r-digest/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 8bf048b49b2d17077138fae758bda56bbd53278d9437f2fdeaedf979c90a13c9
 
 build:

--- a/recipes/recipes_emscripten/r-dplyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-dplyr/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: a82c292f2249d439157986b504edd1d99741f467c75bf08969254ca8d441bfa3
 
 build:

--- a/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: a90266e5eb59c7f419774d5c6d6bd5e09701a26c9218c5933c9bce6765aa1558
 
 build:

--- a/recipes/recipes_emscripten/r-fansi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fansi/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 32a43f073aeb5c1d31c804014b95c2cb644bb4132119fcea313838b7ea4eb792
   patches:
   - patches/0001-Ignore-custom-limit-checks.patch

--- a/recipes/recipes_emscripten/r-farver/recipe.yaml
+++ b/recipes/recipes_emscripten/r-farver/recipe.yaml
@@ -8,8 +8,10 @@ package:
 
 source:
   url:
-  - https://cran.r-project.org//src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  - https://cloud.r-project.org//src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 528823b95daab4566137711f1c842027a952bea1b2ae6ff098e2ca512b17fe25
 
 build:

--- a/recipes/recipes_emscripten/r-fastmap/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fastmap/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: b1da04a2915d1d057f3c2525e295ef15016a64e6667eac83a14641bbd83b9246
 
 build:

--- a/recipes/recipes_emscripten/r-fs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fs/recipe.yaml
@@ -8,7 +8,9 @@ package:
 
 source:
   url:
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 57d3a0844e2fec28e6fe9901d18e07d32a437dfe43c4b547757eb07360f5850a
   patches:
@@ -43,11 +45,10 @@ tests:
 about:
   homepage: https://fs.r-lib.org
   license: MIT
-  summary: A cross-platform interface to file system operations, built on top of the 'libuv'
-    C library.
+  summary: A cross-platform interface to file system operations, built on top of the 'libuv' C library.
   license_family: MIT
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
-    - rgaiacs
+  - rgaiacs

--- a/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 0317dff5e11d9dae7225d5c1794fe16ea1bedc7d535ac98e990925670724c027
 
 build:

--- a/recipes/recipes_emscripten/r-glue/recipe.yaml
+++ b/recipes/recipes_emscripten/r-glue/recipe.yaml
@@ -11,6 +11,7 @@ source:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: c86f364ba899b8662f5da3e1a75f43ae081ab04e0d51171d052356e7ee4b72a0
 
 build:

--- a/recipes/recipes_emscripten/r-haven/recipe.yaml
+++ b/recipes/recipes_emscripten/r-haven/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 9482cd9c3760e1838acf687235317fed97fa6bf79219d3216f0ea447d4b1c9a5
 
 build:

--- a/recipes/recipes_emscripten/r-hexbin/recipe.yaml
+++ b/recipes/recipes_emscripten/r-hexbin/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 2ed087d6399f247d44e555b69d785b48362445c4c8c77330bbd57d282b49d3e6
 
 build:

--- a/recipes/recipes_emscripten/r-htmltools/recipe.yaml
+++ b/recipes/recipes_emscripten/r-htmltools/recipe.yaml
@@ -11,6 +11,7 @@ source:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 19308618da485818f69dcfeeadd2ddc81d43a736a74519df7b3fd98e13128afd
 
 build:

--- a/recipes/recipes_emscripten/r-isoband/recipe.yaml
+++ b/recipes/recipes_emscripten/r-isoband/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: fe8d3d58ca75bbee32f389152ac0058818f3f76f09c9867949531de7abc424ac
 
 build:

--- a/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
+++ b/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 75eb910c82b350ec33f094779da0f87bff154c232e4ae39c9896a9b89f3ac82d
 
 build:
@@ -33,7 +35,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary:  A Simple and Robust JSON Parser and Generator for R
+  summary: A Simple and Robust JSON Parser and Generator for R
   description: |
     A reasonably fast JSON parser and generator, optimized for statistical data
     and the web. Offers simple, flexible tools for working with JSON in R, and

--- a/recipes/recipes_emscripten/r-later/recipe.yaml
+++ b/recipes/recipes_emscripten/r-later/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: ce5d88b3fd1df409eaa21aa53bf20b1a9331f75cd69e7e9b2a27b40d2290d219
   patches:
   - patches/0001-Do-not-link-with-atomic-lib.patch

--- a/recipes/recipes_emscripten/r-lattice/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lattice/recipe.yaml
@@ -8,8 +8,10 @@ package:
 
 source:
   url:
-  - https://cran.r-project.org//src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  - https://cloud.r-project.org//src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: b72ad4ed2e5269fa7cf668e46f83a9b5d9d5f8fdcbc5b9886531ca19dffca4ba
 
 build:

--- a/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: d6904112a21056222cfcd5eb8175a78aa063afe648a562d9c42c6b960a8820d4
 
 build:
@@ -40,4 +42,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - IsabelParedes
+  - IsabelParedes

--- a/recipes/recipes_emscripten/r-lubridate/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lubridate/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 0bc5d10e5a34285d4f9e9c572c058c386b9e1515d8faebc1496b2680138280a8
 
 build:

--- a/recipes/recipes_emscripten/r-magrittr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-magrittr/recipe.yaml
@@ -8,8 +8,10 @@ package:
 
 source:
   url:
-  - https://cran.r-project.org//src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  - https://cloud.r-project.org//src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 6aba790c40de70d8fb4d2db4bebb377418971761b0da7df2141b5d4ad95981f3
 
 build:

--- a/recipes/recipes_emscripten/r-mass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mass/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] | upper }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] | upper }}/${{ name[2:] | upper }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] | upper }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] | upper }}/${{ name[2:] | upper }}_${{ version }}.tar.gz
   sha256: b07ef1e3c364ce56269b4a8a7759cc9f87c876554f91293437bb578cfe38172f
 
 build:

--- a/recipes/recipes_emscripten/r-matrix/recipe.yaml
+++ b/recipes/recipes_emscripten/r-matrix/recipe.yaml
@@ -1,15 +1,17 @@
 context:
-  name: r-matrix
+  name: Matrix
   version: 1.7-5
 
 package:
-  name: ${{ name }}
+  name: r-${{ name | lower }}
   version: ${{ version|replace('-', '_') }}
 
 source:
   url:
-  - https://cran.r-project.org/src/contrib/Matrix_${{ version }}.tar.gz
-  - https://cloud.r-project.org/src/contrib/Matrix_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name }}/${{ name }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name }}/${{ name }}_${{ version }}.tar.gz
   sha256: 308b0edd7bcb023a8bb50cc5cec98e66b3658c94a5badfb1ce6024e595fa8a83
 
 build:
@@ -32,7 +34,7 @@ requirements:
 tests:
 - package_contents:
     lib:
-    - R/library/Matrix/libs/Matrix.so
+    - R/library/${{ name }}/libs/${{ name }}.so
 
 about:
   homepage: http://Matrix.R-forge.R-project.org/

--- a/recipes/recipes_emscripten/r-mgcv/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mgcv/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: a98159698afb269e06a46cac1f945bf2b3427a2dd587c6f2efd67ede90089372
 
 build:

--- a/recipes/recipes_emscripten/r-mime/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mime/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 7132834cf3c3388eff12bad376d69fbcf8275acc37d36c290e59174fe3c7f3eb
 
 build:
@@ -39,4 +41,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - IsabelParedes
+  - IsabelParedes

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 51b92f1b543d2eb5915478965dab05a9094e1675a160138d49963eb3a0e7fdb8
 
 build:

--- a/recipes/recipes_emscripten/r-plyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-plyr/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 15b5e7f711d53bf41b8687923983b8ef424563aa2f74c5195feb5b1df1aee103
 
 build:

--- a/recipes/recipes_emscripten/r-purrr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-purrr/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: b3bb91dbc67a1cc34080eae960d330626cc76585f80360524b5fceb08febf363
 
 build:

--- a/recipes/recipes_emscripten/r-rcpp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rcpp/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: da0c616a71c82150397259516b2ea7558dbd31a5b4a217423ec9666b3a0fcfb7
 
 build:

--- a/recipes/recipes_emscripten/r-readr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-readr/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 8025d797c183e12ad5ebe4af891dbcb5a8e9bd53aa4765006eb25a07f9a9f473
 
 build:

--- a/recipes/recipes_emscripten/r-rlang/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rlang/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 123c91e7eaacd3514a368a31c30617d36a874def37f6cafdacc0c7d1409be373
 
 build:

--- a/recipes/recipes_emscripten/r-sp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sp/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 277a4533bc784a08fdbb710757b6af0c7a492691bfb07d8f0b2aa8ad7c857652
 
 build:

--- a/recipes/recipes_emscripten/r-stringi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-stringi/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 0526decdcd41b7c42278aca96945394c2cb66ba6fdd47fd917b5d3d38ed5c8c6
 
 build:

--- a/recipes/recipes_emscripten/r-sys/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sys/recipe.yaml
@@ -8,8 +8,10 @@ package:
 
 source:
   url:
-    - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-    - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 051e7332e3074db826efef9059067721864f9d70adc55bbcae3a72e5ae83913a
 
 build:
@@ -18,8 +20,8 @@ build:
 
 requirements:
   build:
-    - cross-r-base_${{ target_platform }}
-    - ${{ compiler('c') }}
+  - cross-r-base_${{ target_platform }}
+  - ${{ compiler('c') }}
 
 tests:
 - package_contents:
@@ -34,12 +36,12 @@ about:
   license_file: LICENSE
   summary: Powerful and Reliable Tools for Running System Commands in R
   description: |
-   Drop-in replacements for the base system2() function with fine control and
-   consistent behavior across platforms. Supports clean interruption, timeout,
-   background tasks, and streaming STDIN / STDOUT / STDERR over binary or text
-   connections. Arguments on Windows automatically get encoded and quoted to
-   work on different locales.
+    Drop-in replacements for the base system2() function with fine control and
+    consistent behavior across platforms. Supports clean interruption, timeout,
+    background tasks, and streaming STDIN / STDOUT / STDERR over binary or text
+    connections. Arguments on Windows automatically get encoded and quoted to
+    work on different locales.
 
 extra:
   recipe-maintainers:
-    - IsabelParedes
+  - IsabelParedes

--- a/recipes/recipes_emscripten/r-tibble/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tibble/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: fb309f8a1939021b237c7e85ff7ad6e8ff5acd57a6230d220a452094b492b28f
 
 build:

--- a/recipes/recipes_emscripten/r-tidyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tidyr/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 04c0e6daf0af682af73763a42c027d7171761cdbdbf9ff7a77a0e421343d665a
 
 build:

--- a/recipes/recipes_emscripten/r-timechange/recipe.yaml
+++ b/recipes/recipes_emscripten/r-timechange/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 6dc8ff9d339d3c4cff7ddf3800383f3e94f41c021f6c7bacccf971e187f73feb
 
 build:

--- a/recipes/recipes_emscripten/r-tzdb/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tzdb/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 380d5237dbfa722fddb7d1d9ad8520a2b26331dbbb77d51850ded332fcf347db
 
 build:

--- a/recipes/recipes_emscripten/r-utf8/recipe.yaml
+++ b/recipes/recipes_emscripten/r-utf8/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 4589f8b72291329e70b7f3a8c20f2feb4e7764eebad2e6976bc9a3eee7686ce9
 
 build:

--- a/recipes/recipes_emscripten/r-vctrs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vctrs/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 46452f7f5f800e10ad09c287c488a4f6d887c28ef14bcff4bae4f56e6ba57fce
 
 build:

--- a/recipes/recipes_emscripten/r-vroom/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vroom/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 7d64f6227fdac3ee64c506654bb1d919e407f92fc2d0d5a2398dbb83001e8790
 
 build:

--- a/recipes/recipes_emscripten/r-xfun/recipe.yaml
+++ b/recipes/recipes_emscripten/r-xfun/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 5a0cded15fe21273c6d83dd9b72a1c798a1b43841c2166b563723c2ee4b7f475
 
 build:

--- a/recipes/recipes_emscripten/r-yaml/recipe.yaml
+++ b/recipes/recipes_emscripten/r-yaml/recipe.yaml
@@ -9,7 +9,9 @@ package:
 source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 80ccf3dde851133ef3e333b818a817c296c6ccdacfc4709cd466995289cd556c
 
 build:


### PR DESCRIPTION
Closes https://github.com/emscripten-forge/recipes/issues/5264

I used a small script to add CRAN's Archive as backup URL. The output of the small script was revisited.

Some packages were skipped:

- `r-base`
- `r-data.table`

# Script

```python
import sys

from ruamel.yaml import YAML

if len(sys.argv) < 2:
    quit()

FILEPATH = sys.argv[1]

yaml = YAML()
yaml.width = 1000

with open(FILEPATH, "r") as _file:
    data = yaml.load(_file)

data["source"]["url"] = [
    "https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz",
    "https://cran.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz",
    "https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz",
    "https://cloud.r-project.org/src/contrib/Archive/${{ name[2:] }}/${{ name[2:] }}_${{ version }}.tar.gz",
]

with open(FILEPATH, "w") as _file:
    yaml.dump(data, _file)
```