### PR TITLE
Enable variants for R packages

### DIFF
--- a/recipes/recipes_emscripten/r-askpass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-askpass/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 6c2106a74c44a748f2cea795d9686e27a0058a90debcfd8558b62b06aec0c7dd
 
 build:
-  number: 6
+  number: 5
   string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 

--- a/recipes/recipes_emscripten/r-askpass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-askpass/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 6c2106a74c44a748f2cea795d9686e27a0058a90debcfd8558b62b06aec0c7dd
 
 build:
-  number: 4
+  number: 6
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-askpass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-askpass/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - r-sys
   host:

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -26,8 +26,7 @@ source:
   - patches/0013-Use-source-files-when-installing.patch
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
 
   files:
     exclude:

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -26,7 +26,8 @@ source:
   - patches/0013-Use-source-files-when-installing.patch
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
 
   files:
     exclude:

--- a/recipes/recipes_emscripten/r-base64enc/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base64enc/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 3c7e9d22f7409fa2989008fa6e980c3dd8e2693eb20676acf2470ae7addb0816
 
 build:
-  number: 1
+  number: 3
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-base64enc/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base64enc/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 3c7e9d22f7409fa2989008fa6e980c3dd8e2693eb20676acf2470ae7addb0816
 
 build:
-  number: 3
+  number: 2
   string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 

--- a/recipes/recipes_emscripten/r-base64enc/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base64enc/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-bit/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 48fe21c5d04c7b724d695eeb60074395c0c631a7fb234e2075de92471445de08
 
 build:
-  number: 4
+  number: 6
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-bit/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-bit/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 48fe21c5d04c7b724d695eeb60074395c0c631a7fb234e2075de92471445de08
 
 build:
-  number: 6
+  number: 5
   string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 

--- a/recipes/recipes_emscripten/r-bit64/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit64/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - r-bit
   host:

--- a/recipes/recipes_emscripten/r-bit64/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit64/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: fbc0ce142fc22c9a9fdcbac930a814dfb648563d4b6a77dff739c23cc81319b7
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-cachem/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cachem/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 550839fc2ae5d865db475ba2c1714144f07fa0c052c72135b0e4a70287492e21
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-cachem/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cachem/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - r-rlang
   - r-fastmap

--- a/recipes/recipes_emscripten/r-cli/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cli/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 8ebe3146e66a285d8ad6ddcff87e2a9790ea7c9cdfce7fdd8bf13095fa459679
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-cli/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cli/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-colorspace/recipe.yaml
+++ b/recipes/recipes_emscripten/r-colorspace/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: ec71499d33ef5d72b7fb3359b8320639e06e413abad61a070201178a254b153e
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-colorspace/recipe.yaml
+++ b/recipes/recipes_emscripten/r-colorspace/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-data.table/recipe.yaml
+++ b/recipes/recipes_emscripten/r-data.table/recipe.yaml
@@ -20,7 +20,7 @@ build:
     - '**/tests/**'
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   host:
   - zlib

--- a/recipes/recipes_emscripten/r-data.table/recipe.yaml
+++ b/recipes/recipes_emscripten/r-data.table/recipe.yaml
@@ -11,7 +11,8 @@ source:
   sha256: 40b6bd3ed8664130d257fa0476d7f65f9327552344d532d77ccc4aa1a8bca09a
 
 build:
-  number: 2
+  number: 3
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
   files:

--- a/recipes/recipes_emscripten/r-digest/recipe.yaml
+++ b/recipes/recipes_emscripten/r-digest/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 8bf048b49b2d17077138fae758bda56bbd53278d9437f2fdeaedf979c90a13c9
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-digest/recipe.yaml
+++ b/recipes/recipes_emscripten/r-digest/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
 

--- a/recipes/recipes_emscripten/r-dplyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-dplyr/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - r-cli
   - r-generics

--- a/recipes/recipes_emscripten/r-dplyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-dplyr/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 18d66fe2f24cda8b619c177326d39dd015229ab99695fa67d3fa31e4569390e0
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
@@ -15,7 +15,8 @@ source:
 # TODO: remove from emscripten-forge once the noarch version is available on
 # conda-forge
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   noarch: generic
   script: $R CMD INSTALL $R_ARGS .
 

--- a/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
@@ -22,7 +22,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-rlang
   host:
   - r-rlang

--- a/recipes/recipes_emscripten/r-fansi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fansi/recipe.yaml
@@ -15,7 +15,8 @@ source:
   - patches/0001-Ignore-custom-limit-checks.patch
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-fansi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fansi/recipe.yaml
@@ -21,7 +21,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-farver/recipe.yaml
+++ b/recipes/recipes_emscripten/r-farver/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 528823b95daab4566137711f1c842027a952bea1b2ae6ff098e2ca512b17fe25
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-farver/recipe.yaml
+++ b/recipes/recipes_emscripten/r-farver/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-fastmap/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fastmap/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: b1da04a2915d1d057f3c2525e295ef15016a64e6667eac83a14641bbd83b9246
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-fastmap/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fastmap/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
 

--- a/recipes/recipes_emscripten/r-fs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fs/recipe.yaml
@@ -33,7 +33,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - pkg-config
 
 tests:

--- a/recipes/recipes_emscripten/r-fs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fs/recipe.yaml
@@ -19,7 +19,8 @@ source:
   - patches/0003-Set-UNAME-to-Emscripten.patch
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: |
     $R CMD INSTALL \
     --no-docs \

--- a/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 0317dff5e11d9dae7225d5c1794fe16ea1bedc7d535ac98e990925670724c027
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
@@ -21,7 +21,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
   - r-ggplot2
   - r-rcpp

--- a/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
@@ -15,6 +15,8 @@ source:
 build:
   number: 1
   string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  # TODO: flang needs to be rebuilt to install r-base in build environment.
+  skip: ${{ r_abi_build_tag == 453 }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-glue/recipe.yaml
+++ b/recipes/recipes_emscripten/r-glue/recipe.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-glue/recipe.yaml
+++ b/recipes/recipes_emscripten/r-glue/recipe.yaml
@@ -14,7 +14,8 @@ source:
   sha256: c86f364ba899b8662f5da3e1a75f43ae081ab04e0d51171d052356e7ee4b72a0
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-haven/recipe.yaml
+++ b/recipes/recipes_emscripten/r-haven/recipe.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-cli
   - r-forcats
   - r-hms

--- a/recipes/recipes_emscripten/r-haven/recipe.yaml
+++ b/recipes/recipes_emscripten/r-haven/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 9482cd9c3760e1838acf687235317fed97fa6bf79219d3216f0ea447d4b1c9a5
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-hexbin/recipe.yaml
+++ b/recipes/recipes_emscripten/r-hexbin/recipe.yaml
@@ -15,6 +15,8 @@ source:
 build:
   number: 4
   string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  # TODO: flang needs to be rebuilt to install r-base in build environment.
+  skip: ${{ r_abi_build_tag == 453 }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-hexbin/recipe.yaml
+++ b/recipes/recipes_emscripten/r-hexbin/recipe.yaml
@@ -20,7 +20,7 @@ requirements:
   build:
   - ${{ compiler('c') }}
   - flang_${{ target_platform }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-lattice
   host:
   - r-lattice

--- a/recipes/recipes_emscripten/r-hexbin/recipe.yaml
+++ b/recipes/recipes_emscripten/r-hexbin/recipe.yaml
@@ -13,10 +13,7 @@ source:
   sha256: 2ed087d6399f247d44e555b69d785b48362445c4c8c77330bbd57d282b49d3e6
 
 build:
-  number: 4
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
-  # TODO: flang needs to be rebuilt to install r-base in build environment.
-  skip: ${{ r_abi_build_tag == 453 }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-hexbin/recipe.yaml
+++ b/recipes/recipes_emscripten/r-hexbin/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 2ed087d6399f247d44e555b69d785b48362445c4c8c77330bbd57d282b49d3e6
 
 build:
-  number: 3
+  number: 4
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-hexbin/recipe.yaml
+++ b/recipes/recipes_emscripten/r-hexbin/recipe.yaml
@@ -13,7 +13,10 @@ source:
   sha256: 2ed087d6399f247d44e555b69d785b48362445c4c8c77330bbd57d282b49d3e6
 
 build:
-  number: 3
+  number: 4
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  # TODO: flang needs to be rebuilt to install r-base in build environment.
+  skip: ${{ r_abi_build_tag == 453 }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-htmltools/recipe.yaml
+++ b/recipes/recipes_emscripten/r-htmltools/recipe.yaml
@@ -21,7 +21,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-base64enc
   - r-digest
   - r-fastmap

--- a/recipes/recipes_emscripten/r-htmltools/recipe.yaml
+++ b/recipes/recipes_emscripten/r-htmltools/recipe.yaml
@@ -14,7 +14,8 @@ source:
   sha256: 19308618da485818f69dcfeeadd2ddc81d43a736a74519df7b3fd98e13128afd
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-isoband/recipe.yaml
+++ b/recipes/recipes_emscripten/r-isoband/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
   - r-cli

--- a/recipes/recipes_emscripten/r-isoband/recipe.yaml
+++ b/recipes/recipes_emscripten/r-isoband/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: fe8d3d58ca75bbee32f389152ac0058818f3f76f09c9867949531de7abc424ac
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
+++ b/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 75eb910c82b350ec33f094779da0f87bff154c232e4ae39c9896a9b89f3ac82d
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
+++ b/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
 

--- a/recipes/recipes_emscripten/r-later/recipe.yaml
+++ b/recipes/recipes_emscripten/r-later/recipe.yaml
@@ -21,7 +21,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
   - r-rcpp

--- a/recipes/recipes_emscripten/r-later/recipe.yaml
+++ b/recipes/recipes_emscripten/r-later/recipe.yaml
@@ -15,7 +15,8 @@ source:
   - patches/0001-Do-not-link-with-atomic-lib.patch
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-lattice/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lattice/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: b72ad4ed2e5269fa7cf668e46f83a9b5d9d5f8fdcbc5b9886531ca19dffca4ba
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-lattice/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lattice/recipe.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - r-rlang
   host:

--- a/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: c65db1997b195a7bb0ab3afbb834345ea277b428b2736eeded4242629e86adcb
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-lubridate/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lubridate/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - r-generics
   - r-timechange

--- a/recipes/recipes_emscripten/r-lubridate/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lubridate/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 0bc5d10e5a34285d4f9e9c572c058c386b9e1515d8faebc1496b2680138280a8
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-magrittr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-magrittr/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 3f5b5b1d4e6d12807a95c50b6c88cb1d8af2c5eb5213f08bfe58f278eca2ed23
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-magrittr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-magrittr/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-mass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mass/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: b07ef1e3c364ce56269b4a8a7759cc9f87c876554f91293437bb578cfe38172f
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mass/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-matrix/recipe.yaml
+++ b/recipes/recipes_emscripten/r-matrix/recipe.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-lattice
   host:
   - r-lattice

--- a/recipes/recipes_emscripten/r-matrix/recipe.yaml
+++ b/recipes/recipes_emscripten/r-matrix/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 308b0edd7bcb023a8bb50cc5cec98e66b3658c94a5badfb1ce6024e595fa8a83
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mgcv/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mgcv/recipe.yaml
@@ -15,6 +15,8 @@ source:
 build:
   number: 4
   string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  # TODO: flang needs to be rebuilt to install r-base in build environment.
+  skip: ${{ r_abi_build_tag == 453 }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mgcv/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mgcv/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: a98159698afb269e06a46cac1f945bf2b3427a2dd587c6f2efd67ede90089372
 
 build:
-  number: 3
+  number: 4
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mgcv/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mgcv/recipe.yaml
@@ -22,7 +22,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-nlme
   - r-matrix
   host:

--- a/recipes/recipes_emscripten/r-mime/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mime/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-mime/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mime/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 7132834cf3c3388eff12bad376d69fbcf8275acc37d36c290e59174fe3c7f3eb
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -20,7 +20,7 @@ requirements:
   build:
   - ${{ compiler('c') }}
   - flang_${{ target_platform }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-lattice
   host:
   - r-lattice

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -13,10 +13,7 @@ source:
   sha256: 51b92f1b543d2eb5915478965dab05a9094e1675a160138d49963eb3a0e7fdb8
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
-  # TODO: flang needs to be rebuilt to install r-base in build environment.
-  skip: ${{ r_abi_build_tag == 453 }}
+  number: 0
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -13,7 +13,10 @@ source:
   sha256: 51b92f1b543d2eb5915478965dab05a9094e1675a160138d49963eb3a0e7fdb8
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  # TODO: flang needs to be rebuilt to install r-base in build environment.
+  skip: ${{ r_abi_build_tag == 453 }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -15,6 +15,8 @@ source:
 build:
   number: 1
   string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  # TODO: flang needs to be rebuilt to install r-base in build environment.
+  skip: ${{ r_abi_build_tag == 453 }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 51b92f1b543d2eb5915478965dab05a9094e1675a160138d49963eb3a0e7fdb8
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-plyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-plyr/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
   - r-rcpp

--- a/recipes/recipes_emscripten/r-plyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-plyr/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 15b5e7f711d53bf41b8687923983b8ef424563aa2f74c5195feb5b1df1aee103
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-purrr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-purrr/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: b3bb91dbc67a1cc34080eae960d330626cc76585f80360524b5fceb08febf363
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-purrr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-purrr/recipe.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-cli >=3.6.3
   - r-lifecycle >=1.0.4
   - r-magrittr

--- a/recipes/recipes_emscripten/r-rcpp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rcpp/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: da0c616a71c82150397259516b2ea7558dbd31a5b4a217423ec9666b3a0fcfb7
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-rcpp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rcpp/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-readr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-readr/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
   - r-cli

--- a/recipes/recipes_emscripten/r-readr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-readr/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 8025d797c183e12ad5ebe4af891dbcb5a8e9bd53aa4765006eb25a07f9a9f473
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-rlang/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rlang/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 8f808ad4f6c1ba37d81b6a4a2cdb4a7d4d30d5bee4ba3e9924352d85a3874357
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-rlang/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rlang/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-sp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sp/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 277a4533bc784a08fdbb710757b6af0c7a492691bfb07d8f0b2aa8ad7c857652
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-sp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sp/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - r-lattice
   host:

--- a/recipes/recipes_emscripten/r-stringi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-stringi/recipe.yaml
@@ -18,7 +18,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
   - pkg-config
 

--- a/recipes/recipes_emscripten/r-stringi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-stringi/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 0526decdcd41b7c42278aca96945394c2cb66ba6fdd47fd917b5d3d38ed5c8c6
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/r-sys/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sys/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-    - cross-r-base_${{ target_platform }}
+    - cross-r-base_${{ target_platform }} ==${{ r_base }}
     - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-sys/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sys/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 051e7332e3074db826efef9059067721864f9d70adc55bbcae3a72e5ae83913a
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tibble/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tibble/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: fb309f8a1939021b237c7e85ff7ad6e8ff5acd57a6230d220a452094b492b28f
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tibble/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tibble/recipe.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-fansi
   - r-lifecycle
   - r-magrittr

--- a/recipes/recipes_emscripten/r-tidyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tidyr/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - r-cli
   - r-dplyr

--- a/recipes/recipes_emscripten/r-tidyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tidyr/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 04c0e6daf0af682af73763a42c027d7171761cdbdbf9ff7a77a0e421343d665a
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-timechange/recipe.yaml
+++ b/recipes/recipes_emscripten/r-timechange/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - r-cpp11
   host:

--- a/recipes/recipes_emscripten/r-timechange/recipe.yaml
+++ b/recipes/recipes_emscripten/r-timechange/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 6dc8ff9d339d3c4cff7ddf3800383f3e94f41c021f6c7bacccf971e187f73feb
 
 build:
-  number: 2
+  number: 3
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tzdb/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tzdb/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 380d5237dbfa722fddb7d1d9ad8520a2b26331dbbb77d51850ded332fcf347db
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tzdb/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tzdb/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
   host:
   - r-cpp11

--- a/recipes/recipes_emscripten/r-utf8/recipe.yaml
+++ b/recipes/recipes_emscripten/r-utf8/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 4589f8b72291329e70b7f3a8c20f2feb4e7764eebad2e6976bc9a3eee7686ce9
 
 build:
-  number: 4
+  number: 5
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-utf8/recipe.yaml
+++ b/recipes/recipes_emscripten/r-utf8/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-vctrs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vctrs/recipe.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-cli >=3.6.3
   - r-glue
   - r-rlang

--- a/recipes/recipes_emscripten/r-vctrs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vctrs/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 46452f7f5f800e10ad09c287c488a4f6d887c28ef14bcff4bae4f56e6ba57fce
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-vroom/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vroom/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
   build:
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-bit64
   - r-cli
   - r-crayon

--- a/recipes/recipes_emscripten/r-vroom/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vroom/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 7d64f6227fdac3ee64c506654bb1d919e407f92fc2d0d5a2398dbb83001e8790
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-xfun/recipe.yaml
+++ b/recipes/recipes_emscripten/r-xfun/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 5a0cded15fe21273c6d83dd9b72a1c798a1b43841c2166b563723c2ee4b7f475
 
 build:
-  number: 0
+  number: 1
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-xfun/recipe.yaml
+++ b/recipes/recipes_emscripten/r-xfun/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/recipes/recipes_emscripten/r-yaml/recipe.yaml
+++ b/recipes/recipes_emscripten/r-yaml/recipe.yaml
@@ -13,7 +13,8 @@ source:
   sha256: 80ccf3dde851133ef3e333b818a817c296c6ccdacfc4709cd466995289cd556c
 
 build:
-  number: 1
+  number: 2
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-yaml/recipe.yaml
+++ b/recipes/recipes_emscripten/r-yaml/recipe.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
 
 tests:

--- a/variant.yaml
+++ b/variant.yaml
@@ -31,7 +31,6 @@ c_compiler_version:
     then:
       - 11
 
-
 cxx_compiler_version:
   - if: emscripten
     then:
@@ -48,11 +47,20 @@ fortran_compiler:
     then:
       - flang
 
+r_base:
+  - 4.5.2
+  - 4.5.3
+r_abi_build_tag:
+  - 452
+  - 453
+
 zip_keys:
   -
     - cxx_compiler_version
     - c_compiler_version
-
+  -
+    - r_base
+    - r_abi_build_tag
 
 cuda_compiler:
   - undefined
@@ -613,8 +621,6 @@ root_base:
 ruby:
   - 2.5
   - 2.6
-r_base:
-  - 4.4.1
 scotch:
   - 6.0.9
 ptscotch:


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## Package Details
- **Package Name**: All R packages except `r-base` and `r-arrow`
- **Version**: 

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

- This enables the building of 2 variants for each R package
  - `r_base` 4.5.2
  - `r_base` 4.5.3
- It adds a variant identifier to the build string (R packages on conda-forge already had this, but we did not).

```
r-askpass-1.2.1-r452_h954bd41_5.tar.bz2
r-askpass-1.2.1-r453_h8055c03_5.tar.bz2
r-base64enc-0.1_6-r452_h954bd41_2.tar.bz2
r-base64enc-0.1_6-r453_h8055c03_2.tar.bz2
r-bit-4.6.0-r452_h954bd41_5.tar.bz2
r-bit-4.6.0-r453_h8055c03_5.tar.bz2
r-bit64-4.6.0_1-r452_h954bd41_5.tar.bz2
r-bit64-4.6.0_1-r453_h8055c03_5.tar.bz2
r-cachem-1.1.0-r452_h954bd41_5.tar.bz2
r-cachem-1.1.0-r453_h8055c03_5.tar.bz2
r-cli-3.6.5-r452_h954bd41_5.tar.bz2
r-cli-3.6.5-r453_h8055c03_5.tar.bz2
r-colorspace-2.1_2-r452_h954bd41_5.tar.bz2
r-colorspace-2.1_2-r453_h8055c03_5.tar.bz2
r-data.table-1.18.0-r452_h500f5c5_3.tar.bz2
r-data.table-1.18.0-r453_h1e77a78_3.tar.bz2
r-digest-0.6.39-r452_h8118b0b_5.tar.bz2
r-digest-0.6.39-r453_hb245525_5.tar.bz2
r-dplyr-1.2.1-r452_h954bd41_1.tar.bz2
r-dplyr-1.2.1-r453_h8055c03_1.tar.bz2
r-fansi-1.0.7-r452_h954bd41_5.tar.bz2
r-fansi-1.0.7-r453_h8055c03_5.tar.bz2
r-farver-2.1.2-r452_h1d4ce1e_5.tar.bz2
r-farver-2.1.2-r453_h09d1a6a_5.tar.bz2
r-fastmap-1.2.0-r452_h8118b0b_5.tar.bz2
r-fastmap-1.2.0-r453_hb245525_5.tar.bz2
r-fs-1.6.6-r452_h954bd41_1.tar.bz2
r-fs-1.6.6-r453_h8055c03_1.tar.bz2
r-ggrepel-0.9.8-r452_h1d4ce1e_1.tar.bz2
r-glue-1.8.0-r452_h954bd41_5.tar.bz2
r-glue-1.8.0-r453_h8055c03_5.tar.bz2
r-haven-2.5.5-r452_h500f5c5_5.tar.bz2
r-haven-2.5.5-r453_h1e77a78_5.tar.bz2
r-hexbin-1.28.5-r452_h954bd41_4.tar.bz2
r-htmltools-0.5.9-r452_h954bd41_2.tar.bz2
r-htmltools-0.5.9-r453_h8055c03_2.tar.bz2
r-isoband-0.3.0-r452_h8118b0b_5.tar.bz2
r-isoband-0.3.0-r453_hb245525_5.tar.bz2
r-jsonlite-2.0.0-r452_h8118b0b_5.tar.bz2
r-jsonlite-2.0.0-r453_hb245525_5.tar.bz2
r-later-1.4.8-r452_h8118b0b_2.tar.bz2
r-later-1.4.8-r453_hb245525_2.tar.bz2
r-lattice-0.22_9-r452_h954bd41_2.tar.bz2
r-lattice-0.22_9-r453_h8055c03_2.tar.bz2
r-lazyeval-0.2.3-r452_h954bd41_1.tar.bz2
r-lazyeval-0.2.3-r453_h8055c03_1.tar.bz2
r-lubridate-1.9.5-r452_h954bd41_2.tar.bz2
r-lubridate-1.9.5-r453_h8055c03_2.tar.bz2
r-magrittr-2.0.5-r452_h954bd41_1.tar.bz2
r-magrittr-2.0.5-r453_h8055c03_1.tar.bz2
r-mass-7.3_65-r452_h954bd41_5.tar.bz2
r-mass-7.3_65-r453_h8055c03_5.tar.bz2
r-matrix-1.7_5-r452_h954bd41_1.tar.bz2
r-matrix-1.7_5-r453_h8055c03_1.tar.bz2
r-mgcv-1.9_4-r452_h954bd41_4.tar.bz2
r-mime-0.13-r452_h954bd41_5.tar.bz2
r-mime-0.13-r453_h8055c03_5.tar.bz2
r-nlme-3.1_169-r452_h954bd41_1.tar.bz2
r-plyr-1.8.9-r452_h8118b0b_5.tar.bz2
r-plyr-1.8.9-r453_hb245525_5.tar.bz2
r-purrr-1.2.1-r452_h954bd41_2.tar.bz2
r-purrr-1.2.1-r453_h8055c03_2.tar.bz2
r-rcpp-1.1.1-r452_h1d4ce1e_2.tar.bz2
r-rcpp-1.1.1-r453_h09d1a6a_2.tar.bz2
r-readr-2.2.0-r452_h8118b0b_2.tar.bz2
r-readr-2.2.0-r453_hb245525_2.tar.bz2
r-rlang-1.2.0-r452_h954bd41_1.tar.bz2
r-rlang-1.2.0-r453_h8055c03_1.tar.bz2
r-sp-2.2_1-r452_h954bd41_2.tar.bz2
r-sp-2.2_1-r453_h8055c03_2.tar.bz2
r-stringi-1.8.7-r452_h1d4ce1e_5.tar.bz2
r-stringi-1.8.7-r453_h09d1a6a_5.tar.bz2
r-sys-3.4.3-r452_h954bd41_5.tar.bz2
r-sys-3.4.3-r453_h8055c03_5.tar.bz2
r-tibble-3.3.1-r452_h954bd41_2.tar.bz2
r-tibble-3.3.1-r453_h8055c03_2.tar.bz2
r-tidyr-1.3.2-r452_h954bd41_2.tar.bz2
r-tidyr-1.3.2-r453_h8055c03_2.tar.bz2
r-timechange-0.4.0-r452_h954bd41_3.tar.bz2
r-timechange-0.4.0-r453_h8055c03_3.tar.bz2
r-tzdb-0.5.0-r452_h1d4ce1e_5.tar.bz2
r-tzdb-0.5.0-r453_h09d1a6a_5.tar.bz2
r-utf8-1.2.6-r452_h954bd41_5.tar.bz2
r-utf8-1.2.6-r453_h8055c03_5.tar.bz2
r-vctrs-0.7.2-r452_h954bd41_1.tar.bz2
r-vctrs-0.7.2-r453_h8055c03_1.tar.bz2
r-vroom-1.7.1-r452_h8118b0b_1.tar.bz2
r-vroom-1.7.1-r453_hb245525_1.tar.bz2
r-xfun-0.57-r452_h954bd41_1.tar.bz2
r-xfun-0.57-r453_h8055c03_1.tar.bz2
r-yaml-2.3.12-r452_h954bd41_2.tar.bz2
r-yaml-2.3.12-r453_h8055c03_2.tar.bz2
```

**noarch**
```
r-ellipsis-0.3.3-r452_hfadc2d2_1.tar.bz2
r-ellipsis-0.3.3-r453_h8708db1_1.tar.bz2
```

---
Example of finalized run dependencies:

```

Finalized run dependencies (r-digest-0.6.39-r452_h8118b0b_5):
╭──────────────────┬──────────────────────────────────────────────────────────╮
│ Name             ┆ Spec                                                     │
╞══════════════════╪══════════════════════════════════════════════════════════╡
│ Run dependencies ┆                                                          │
│ emscripten-abi   ┆ >=4,<5.0a0 (RE of [build: emscripten_emscripten-wasm32]) │
│ r-base-abi       ┆ ==4.5.2 (RE of [build: cross-r-base_emscripten-wasm32])  │
╰──────────────────┴──────────────────────────────────────────────────────────╯
```

```
Finalized run dependencies (r-digest-0.6.39-r453_hb245525_5):
╭──────────────────┬──────────────────────────────────────────────────────────╮
│ Name             ┆ Spec                                                     │
╞══════════════════╪══════════════════════════════════════════════════════════╡
│ Run dependencies ┆                                                          │
│ emscripten-abi   ┆ >=4,<5.0a0 (RE of [build: emscripten_emscripten-wasm32]) │
│ r-base-abi       ┆ ==4.5.3 (RE of [build: cross-r-base_emscripten-wasm32])  │
╰──────────────────┴──────────────────────────────────────────────────────────╯
```
