### PR TITLE
Disable updates for emscripten-3x branch

### DIFF
--- a/.github/workflows/new_versions.yaml
+++ b/.github/workflows/new_versions.yaml
@@ -11,7 +11,7 @@ jobs:
   update_versions:
     strategy:
       matrix:
-        branch: [main, emscripten-3x]
+        branch: [main]
 
     if: (github.event_name == 'schedule' && github.repository == 'emscripten-forge/recipes') || (github.event_name != 'schedule')
     runs-on: [ubuntu-latest]

--- a/emci/bot/bump_recipes_versions.py
+++ b/emci/bot/bump_recipes_versions.py
@@ -307,7 +307,7 @@ def bump_recipe_versions(recipe_dir, pr_target_branch, use_bot=True, pr_limit=20
         prs_packages = [pr['title'].split()[1] for pr in all_prs]
 
         # Merge PRs if possible
-        if pr_target_branch in ["main", "emscripten-3x"]:
+        if pr_target_branch in ["main"]:
             for pr,pr_pkg in zip(prs_id, prs_packages):
                 # get the recipe dir
                 recipe_dir = recipe_name_to_recipe_dir.get(pr_pkg)

--- a/emci/git_utils.py
+++ b/emci/git_utils.py
@@ -116,9 +116,5 @@ def make_pr_for_recipe(recipe_dir, pr_title, target_branch_name, branch_name, au
             '--label', 'Automerge' if automerge else 'Needs Tests'
     ]
 
-    # this is not necessary, it can be removed later
-    if target_branch_name == "main":
-        args.extend(['--label', '4.X'])
-
     # call gh to create a PR
     subprocess.check_call(args, cwd=os.getcwd())


### PR DESCRIPTION
The main branch uses Emscripten v4.x. The v3.x packages are no longer maintained.