### PR TITLE
Coreutils: improved patch for uniq command

### DIFF
--- a/recipes/recipes_emscripten/coreutils/patches/0001-sethostname-not-static.patch
+++ b/recipes/recipes_emscripten/coreutils/patches/0001-sethostname-not-static.patch
@@ -1,4 +1,4 @@
-From 3be6c9919b55f181cfd1140fd1d21a0b08f76832 Mon Sep 17 00:00:00 2001
+From 4bf31f3390514402df802edf29a8821951257026 Mon Sep 17 00:00:00 2001
 From: Ian Thomas <ianthomas23@gmail.com>
 Date: Mon, 30 Mar 2026 12:54:02 +0100
 Subject: [PATCH 1/4] sethostname not static

--- a/recipes/recipes_emscripten/coreutils/patches/0002-Don-t-build-tests-or-man-pages.patch
+++ b/recipes/recipes_emscripten/coreutils/patches/0002-Don-t-build-tests-or-man-pages.patch
@@ -1,4 +1,4 @@
-From 12d3754d9ee4fca12408e01d7d3e0aff9b16b2e6 Mon Sep 17 00:00:00 2001
+From e1db156025682ae478d5b30b7ed5c2b64f751ba5 Mon Sep 17 00:00:00 2001
 From: Ian Thomas <ianthomas23@gmail.com>
 Date: Mon, 30 Mar 2026 12:55:33 +0100
 Subject: [PATCH 2/4] Don't build tests or man pages

--- a/recipes/recipes_emscripten/coreutils/patches/0003-Avoid-use-of-freopen-in-uniq.patch
+++ b/recipes/recipes_emscripten/coreutils/patches/0003-Avoid-use-of-freopen-in-uniq.patch
@@ -1,4 +1,4 @@
-From e614de13b330a70915852bfe160927a5acfe28d4 Mon Sep 17 00:00:00 2001
+From 4d0f268f8c18201c87335ba532d7f5ffcd012568 Mon Sep 17 00:00:00 2001
 From: Ian Thomas <ianthomas23@gmail.com>
 Date: Wed, 1 Apr 2026 13:54:05 +0100
 Subject: [PATCH 3/4] Avoid use of freopen in uniq
@@ -6,8 +6,8 @@ Subject: [PATCH 3/4] Avoid use of freopen in uniq
 ---
  lib/closeout.c |  8 +++++++-
  lib/closeout.h |  3 +++
- src/uniq.c     | 50 +++++++++++++++++++++++++++++++-------------------
- 3 files changed, 41 insertions(+), 20 deletions(-)
+ src/uniq.c     | 52 +++++++++++++++++++++++++++++++-------------------
+ 3 files changed, 42 insertions(+), 21 deletions(-)
 
 diff --git a/lib/closeout.c b/lib/closeout.c
 index a41758e..9655cec 100644
@@ -50,7 +50,7 @@ index 689f06c..5a1cda7 100644
  # ifdef __cplusplus
  }
 diff --git a/src/uniq.c b/src/uniq.c
-index eebff4b..346c16d 100644
+index eebff4b..d764dc6 100644
 --- a/src/uniq.c
 +++ b/src/uniq.c
 @@ -71,6 +71,8 @@ static bool output_later_repeated = false;
@@ -71,9 +71,12 @@ index eebff4b..346c16d 100644
  {
    if (! (linecount == 0 ? output_unique
           : !match ? output_first_repeated
-@@ -326,7 +328,7 @@ writeline (struct linebuffer const *line,
+@@ -324,9 +326,9 @@ writeline (struct linebuffer const *line,
+     return;
+ 
    if (count_occurrences)
-     printf ("%7jd ", linecount + 1);
+-    printf ("%7jd ", linecount + 1);
++    fprintf (out, "%7jd ", linecount + 1);
  
 -  if (fwrite (line->buffer, sizeof (char), line->length, stdout)
 +  if (fwrite (line->buffer, sizeof (char), line->length, out)

--- a/recipes/recipes_emscripten/coreutils/patches/0004-Avoid-use-of-fd_reopen-in-touch.patch
+++ b/recipes/recipes_emscripten/coreutils/patches/0004-Avoid-use-of-fd_reopen-in-touch.patch
@@ -1,4 +1,4 @@
-From 541081b4132f94fc3e81fb65c49a031ca27eebcc Mon Sep 17 00:00:00 2001
+From d9bb13ec7eb969c6330359085815582865c59715 Mon Sep 17 00:00:00 2001
 From: Ian Thomas <ianthomas23@gmail.com>
 Date: Wed, 1 Apr 2026 13:55:25 +0100
 Subject: [PATCH 4/4] Avoid use of fd_reopen in touch

--- a/recipes/recipes_emscripten/coreutils/recipe.yaml
+++ b/recipes/recipes_emscripten/coreutils/recipe.yaml
@@ -16,7 +16,7 @@ source:
   - patches/0004-Avoid-use-of-fd_reopen-in-touch.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [ ] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: coreutils
- **Version**: 9.10

## Build Notes

Follow up to #5277 to improve patch for `uniq` command so that count numbers obtained via `uniq -c` are output to the correct stream.
