### PR TITLE
Add Xeus-haskell

### DIFF
--- a/recipes/recipes_emscripten/xeus-haskell/build.sh
+++ b/recipes/recipes_emscripten/xeus-haskell/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+emcmake cmake \
+  -S $PWD \
+  -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DCMAKE_PREFIX_PATH="$PREFIX" \
+  -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON \
+  -DCMAKE_C_FLAGS="" \
+  -DCMAKE_CXX_FLAGS="" \
+  -DCMAKE_EXE_LINKER_FLAGS="" \
+  -DCMAKE_SHARED_LINKER_FLAGS="" \
+  -DCMAKE_SYSTEM_NAME=Emscripten
+emmake make -C build install

--- a/recipes/recipes_emscripten/xeus-haskell/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-haskell/recipe.yaml
@@ -1,0 +1,41 @@
+context:
+  version: 0.3.0
+
+package:
+  name: xeus-haskell
+  version: ${{ version }}
+
+source:
+  url: https://github.com/jupyter-xeus/xeus-haskell/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: a2ec33edb675d04ea9e206a923aabf39e1e7e58d3b35f4471752ff320e64457f
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - ${{ compiler("cxx") }}
+  - ${{ compiler("c") }}
+  - cmake
+  - make
+  host:
+  - nlohmann_json
+  - nlohmann_json-abi
+  - xeus
+  - xeus-lite
+
+tests:
+- package_contents:
+    files:
+    - bin/xhaskell.wasm
+    - bin/xhaskell.js
+
+about:
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Haskell kernel for Jupyter based on xeus
+  homepage: https://github.com/jupyter-xeus/xeus-haskell
+
+extra:
+  recipe-maintainers:
+  - tani


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: Xeus-Haskell
- **Version**: 0.3.0

## Note

refs: #4278 

<!-- Any special build considerations, patches applied, or issues encountered -->

