### PR TITLE
fix/fortran name mangling dqrls

### DIFF
--- a/.github/workflows/build_recipes.yaml
+++ b/.github/workflows/build_recipes.yaml
@@ -24,6 +24,7 @@ jobs:
       GITHUB_OWNER: "emscripten-forge"
       EXTRA_CHANNELS: ${{ vars.EXTRA_CHANNELS }}
       PREFIX_UPLOAD_CHANNEL: ${{ vars.PREFIX_UPLOAD_CHANNEL }}
+      FLANG_CHANNEL: ${{ vars.FLANG_CHANNEL }}
     strategy:
       fail-fast: false
 

--- a/.github/workflows/build_recipes.yaml
+++ b/.github/workflows/build_recipes.yaml
@@ -22,6 +22,8 @@ jobs:
       FORCE_COLOR: 1
       TARGET_PLATFORM: emscripten-wasm32
       GITHUB_OWNER: "emscripten-forge"
+      EXTRA_CHANNELS: ${{ vars.EXTRA_CHANNELS }}
+      PREFIX_UPLOAD_CHANNEL: ${{ vars.PREFIX_UPLOAD_CHANNEL }}
     strategy:
       fail-fast: false
 
@@ -97,9 +99,10 @@ jobs:
         continue-on-error: true
 
       - name: Upload packages to prefix channel
-        if: (github.event_name == 'push' && github.repository == 'emscripten-forge/recipes')
+        if: github.event_name == 'push' && (github.repository == 'emscripten-forge/recipes' || env.PREFIX_UPLOAD_CHANNEL != '')
         shell: bash -l {0}
         run: |
+          CHANNEL="${PREFIX_UPLOAD_CHANNEL:-emscripten-forge-4x}"
           overall_success=true
 
           # Loop over {emscripten-wasm32, linux-64, noarch}
@@ -109,10 +112,10 @@ jobs:
               files=$(ls *.tar.bz2 2> /dev/null)
               if [ -n "$files" ]; then
                 for package in $files; do
-                  echo "Uploading ${package} for ${platform}"
+                  echo "Uploading ${package} for ${platform} to ${CHANNEL}"
 
                   rattler-build upload prefix \
-                    --channel emscripten-forge-4x \
+                    --channel "${CHANNEL}" \
                     --generate-attestation \
                     ${package}
 

--- a/emci/rattler_build.py
+++ b/emci/rattler_build.py
@@ -36,6 +36,13 @@ def build_with_rattler(recipe=None, recipes_dir=None, emscripten_wasm32=False, s
 
     cmd.extend(["-m", RATTLER_CONDA_BUILD_CONFIG_PATH])
 
+    # add extra channels (highest priority) if configured via env var
+    extra_channels = os.environ.get("EXTRA_CHANNELS", "")
+    for ch in extra_channels.split(","):
+        ch = ch.strip()
+        if ch:
+            cmd.extend(["-c", ch])
+
     # add conda forge and emscripten-forge channels
     cmd.extend([
         "-c", "https://repo.prefix.dev/emscripten-forge-4x",

--- a/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
@@ -3,7 +3,7 @@ context:
   version: 4.5.3
 
 build:
-  number: 1
+  number: 2
 
 outputs:
 - package:

--- a/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
@@ -3,7 +3,7 @@ context:
   version: 4.5.3
 
 build:
-  number: 0
+  number: 1
 
 outputs:
 - package:

--- a/recipes/recipes/flang_emscripten-wasm32/activate.sh
+++ b/recipes/recipes/flang_emscripten-wasm32/activate.sh
@@ -3,7 +3,7 @@
 # Using flang as a WASM cross-compiler
 # https://github.com/serge-sans-paille/llvm-project/blob/feature/flang-wasm/README.wasm.md
 # https://github.com/conda-forge/flang-feedstock/pull/69
-if [ ! -f "$BUILD_PREFIX/bin/flang-new" ]; then
+if [ ! -f "$BUILD_PREFIX/bin/flang" ]; then
     FLANG_CHANNEL="${FLANG_CHANNEL:-conda-forge/label/emscripten}"
     micromamba install -p $BUILD_PREFIX \
         "${FLANG_CHANNEL}::flang==$PKG_VERSION" \
@@ -16,13 +16,13 @@ if [ ! -f "$BUILD_PREFIX/bin/flang-new" ]; then
     ln -s $BUILD_PREFIX/opt/emsdk/upstream/lib/clang $BUILD_PREFIX/lib/clang
 fi
 
-export FC=flang-new
-export F77=flang-new
-export F90=flang-new
-export F95=flang-new
-export F18=flang-new
-export FLANG=flang-new
+export FC=flang
+export F77=flang
+export F90=flang
+export F95=flang
+export F18=flang
+export FLANG=flang
 
 export FFLAGS="--target=wasm32-unknown-emscripten"
 export FPICFLAGS="-fPIC"
-export FCLIBS="-lFortranRuntime"
+export FCLIBS="-lflang_rt.runtime"

--- a/recipes/recipes/flang_emscripten-wasm32/activate.sh
+++ b/recipes/recipes/flang_emscripten-wasm32/activate.sh
@@ -4,12 +4,14 @@
 # https://github.com/serge-sans-paille/llvm-project/blob/feature/flang-wasm/README.wasm.md
 # https://github.com/conda-forge/flang-feedstock/pull/69
 if [ ! -f "$BUILD_PREFIX/bin/flang-new" ]; then
+    FLANG_CHANNEL="${FLANG_CHANNEL:-conda-forge/label/emscripten}"
     micromamba install -p $BUILD_PREFIX \
-        conda-forge/label/emscripten::flang==$PKG_VERSION \
+        "${FLANG_CHANNEL}::flang==$PKG_VERSION" \
         -y --no-channel-priority
 
-    rm $BUILD_PREFIX/bin/clang-20 || true
-    ln -s $BUILD_PREFIX/opt/emsdk/upstream/bin/clang $BUILD_PREFIX/bin/clang-20
+    CLANG_MAJOR="${PKG_VERSION%%.*}"
+    rm $BUILD_PREFIX/bin/clang-${CLANG_MAJOR} || true
+    ln -s $BUILD_PREFIX/opt/emsdk/upstream/bin/clang $BUILD_PREFIX/bin/clang-${CLANG_MAJOR}
     rm -r $BUILD_PREFIX/lib/clang || true
     ln -s $BUILD_PREFIX/opt/emsdk/upstream/lib/clang $BUILD_PREFIX/lib/clang
 fi

--- a/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
@@ -1,13 +1,13 @@
 context:
   name: flang_emscripten-wasm32
-  version: 20.1.7
+  version: 21.1.0
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 build:
-  number: 4
+  number: 0
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
     - zstd
   run:
     - emscripten_emscripten-wasm32
-    - libllvm20 ==${{ version }}
+    - libllvm21 ==${{ version }}
   run_exports:
     strong:
       - emscripten-abi >=3.1.73,<3.1.74.0a0

--- a/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
@@ -20,6 +20,7 @@ requirements:
   run:
     - emscripten_emscripten-wasm32
     - libllvm21 ==${{ version }}
+    - libflang-rt ==${{ version }}
   run_exports:
     strong:
       - emscripten-abi >=4,<5.0a0

--- a/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/flang_emscripten-wasm32/recipe.yaml
@@ -22,7 +22,7 @@ requirements:
     - libllvm21 ==${{ version }}
   run_exports:
     strong:
-      - emscripten-abi >=3.1.73,<3.1.74.0a0
+      - emscripten-abi >=4,<5.0a0
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/libflang/build.sh
+++ b/recipes/recipes_emscripten/libflang/build.sh
@@ -6,7 +6,12 @@ export CFLAGS="$CFLAGS -fPIC"
 export CXXFLAGS="$CXXFLAGS -fPIC"
 
 # See https://github.com/serge-sans-paille/llvm-project/blob/feature/flang-wasm/README.wasm.md
-emcmake cmake -S flang/runtime -B _fbuild_runtime -GNinja \
+# LLVM 21 moved the runtime from flang/runtime to flang-rt/lib/runtime
+# and requires cmake module path for the new flang-rt build infrastructure
+emcmake cmake -S flang-rt/lib/runtime -B _fbuild_runtime -GNinja \
+                -DCMAKE_MODULE_PATH="$(pwd)/flang-rt/cmake/modules;$(pwd)/flang/cmake/modules" \
+                -DFLANG_RT_SOURCE_DIR="$(pwd)/flang-rt" \
+                -DFLANG_SOURCE_DIR="$(pwd)/flang" \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX
 $(which cmake) --build _fbuild_runtime

--- a/recipes/recipes_emscripten/libflang/build.sh
+++ b/recipes/recipes_emscripten/libflang/build.sh
@@ -37,6 +37,16 @@ set(FLANG_RT_INSTALL_RESOURCE_LIB_PATH "lib")
 # Meta-target that add_flangrt_library adds dependencies to
 add_custom_target(flang-rt)
 
+# Generate config.h (normally done by flang-rt/CMakeLists.txt)
+find_package(Backtrace)
+set(HAVE_BACKTRACE ${Backtrace_FOUND})
+set(BACKTRACE_HEADER ${Backtrace_HEADER})
+# wasm32/linux: strerror_r exists, strerror_s (Windows) does not
+set(HAVE_STRERROR_R 1)
+set(HAVE_DECL_STRERROR_S 0)
+configure_file("${FLANG_RT_SOURCE_DIR}/cmake/config.h.cmake.in" config.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 add_subdirectory("${FLANG_RT_SOURCE_DIR}/lib/runtime" runtime_build)
 CMAKEOF
 
@@ -48,7 +58,25 @@ $(which cmake) --build _fbuild_runtime --target install
 
 
 # Build libFortranDecimal.a
-emcmake cmake -S flang/lib/Decimal -B _fbuild_decimal -GNinja \
+# In LLVM 21, flang/lib/Decimal uses add_flang_library which pulls in the
+# entire LLVM cmake infrastructure. For just 2 source files, build directly.
+mkdir -p _wrapper_decimal
+cat > _wrapper_decimal/CMakeLists.txt << 'CMAKEOF'
+cmake_minimum_required(VERSION 3.20)
+project(flang-decimal C CXX)
+
+set(FLANG_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../flang")
+include_directories("${FLANG_SOURCE_DIR}/include")
+
+add_library(FortranDecimal STATIC
+    "${FLANG_SOURCE_DIR}/lib/Decimal/binary-to-decimal.cpp"
+    "${FLANG_SOURCE_DIR}/lib/Decimal/decimal-to-binary.cpp"
+)
+
+install(TARGETS FortranDecimal ARCHIVE DESTINATION lib)
+CMAKEOF
+
+emcmake cmake -S _wrapper_decimal -B _fbuild_decimal -GNinja \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX
 $(which cmake) --build _fbuild_decimal

--- a/recipes/recipes_emscripten/libflang/build.sh
+++ b/recipes/recipes_emscripten/libflang/build.sh
@@ -6,12 +6,41 @@ export CFLAGS="$CFLAGS -fPIC"
 export CXXFLAGS="$CXXFLAGS -fPIC"
 
 # See https://github.com/serge-sans-paille/llvm-project/blob/feature/flang-wasm/README.wasm.md
-# LLVM 21 moved the runtime from flang/runtime to flang-rt/lib/runtime
-# and requires cmake module path for the new flang-rt build infrastructure
-emcmake cmake -S flang-rt/lib/runtime -B _fbuild_runtime -GNinja \
-                -DCMAKE_MODULE_PATH="$(pwd)/flang-rt/cmake/modules;$(pwd)/flang/cmake/modules" \
-                -DFLANG_RT_SOURCE_DIR="$(pwd)/flang-rt" \
-                -DFLANG_SOURCE_DIR="$(pwd)/flang" \
+# LLVM 21 moved the runtime from flang/runtime to flang-rt/lib/runtime.
+# The subdirectory CMakeLists.txt expects the parent cmake to have set up
+# AddFlangRT, install paths, and a flang-rt meta-target. We use a minimal
+# wrapper to provide these without pulling in the full LLVM runtimes build.
+mkdir -p _wrapper
+cat > _wrapper/CMakeLists.txt << 'CMAKEOF'
+cmake_minimum_required(VERSION 3.20)
+project(flang-rt-runtime C CXX)
+
+set(FLANG_RT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../flang-rt")
+set(FLANG_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../flang")
+
+list(APPEND CMAKE_MODULE_PATH
+    "${FLANG_RT_SOURCE_DIR}/cmake/modules"
+    "${FLANG_SOURCE_DIR}/cmake/modules"
+)
+
+# Provide modules and variables the subdirectory expects from its parent
+include(AddFlangRT)
+include(AddFlangRTOffload)
+
+set(FLANG_RT_ENABLE_STATIC ON)
+set(FLANG_RT_ENABLE_SHARED OFF)
+
+# Install paths — just use lib/ under the prefix
+set(FLANG_RT_OUTPUT_RESOURCE_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/lib")
+set(FLANG_RT_INSTALL_RESOURCE_LIB_PATH "lib")
+
+# Meta-target that add_flangrt_library adds dependencies to
+add_custom_target(flang-rt)
+
+add_subdirectory("${FLANG_RT_SOURCE_DIR}/lib/runtime" runtime_build)
+CMAKEOF
+
+emcmake cmake -S _wrapper -B _fbuild_runtime -GNinja \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX
 $(which cmake) --build _fbuild_runtime

--- a/recipes/recipes_emscripten/libflang/patches/0002-Minimal-WASM-support-for-flang.patch
+++ b/recipes/recipes_emscripten/libflang/patches/0002-Minimal-WASM-support-for-flang.patch
@@ -8,14 +8,13 @@ Original patch from https://gws.phd/posts/fortran_wasm/
  flang/lib/Optimizer/CodeGen/Target.cpp | 41 ++++++++++++++++++++++++++
  1 file changed, 41 insertions(+)
 
-diff --git a/flang/lib/Optimizer/CodeGen/Target.cpp b/flang/lib/Optimizer/CodeGen/Target.cpp
-index 2a1eb0bc3..726ce9dc5 100644
 --- a/flang/lib/Optimizer/CodeGen/Target.cpp
 +++ b/flang/lib/Optimizer/CodeGen/Target.cpp
-@@ -1656,6 +1656,44 @@ struct TargetLoongArch64 : public GenericTarget<TargetLoongArch64> {
+@@ -1874,7 +1874,45 @@
+   }
  };
  } // namespace
- 
++
 +//===----------------------------------------------------------------------===//
 +// WebAssembly (wasm32) target specifics.
 +//===----------------------------------------------------------------------===//
@@ -25,7 +24,7 @@ index 2a1eb0bc3..726ce9dc5 100644
 +  using GenericTarget::GenericTarget;
 +
 +  static constexpr int defaultWidth = 32;
-+
+ 
 +  CodeGenSpecifics::Marshalling
 +  complexArgumentType(mlir::Location, mlir::Type eleTy) const override {
 +    assert(fir::isa_real(eleTy));
@@ -57,7 +56,7 @@ index 2a1eb0bc3..726ce9dc5 100644
  // Instantiate the overloaded target instance based on the triple value.
  // TODO: Add other targets to this file as needed.
  std::unique_ptr<fir::CodeGenSpecifics>
-@@ -1711,6 +1749,9 @@ fir::CodeGenSpecifics::get(mlir::MLIRContext *ctx, llvm::Triple &&trp,
+@@ -1933,6 +1971,9 @@
    case llvm::Triple::ArchType::loongarch64:
      return std::make_unique<TargetLoongArch64>(
          ctx, std::move(trp), std::move(kindMap), targetCPU, targetFeatures, dl);

--- a/recipes/recipes_emscripten/libflang/patches/0003-Specialize-Flang-to-target-WASM.patch
+++ b/recipes/recipes_emscripten/libflang/patches/0003-Specialize-Flang-to-target-WASM.patch
@@ -6,22 +6,19 @@ Subject: [PATCH 3/5] Specialize Flang to target WASM
 ---
  .../Optimizer/Builder/Runtime/RTBuilder.h     | 37 ++++++++++---------
  .../flang/Optimizer/Support/DataLayout.h      | 18 +++++++++
- flang/lib/Optimizer/CodeGen/CodeGen.cpp       |  8 +++-
- 3 files changed, 43 insertions(+), 20 deletions(-)
+ 2 files changed, 36 insertions(+), 19 deletions(-)
 
-diff --git a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
-index eaa1de761..2c776d4ea 100644
 --- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
 +++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
-@@ -22,6 +22,7 @@
+@@ -21,6 +21,7 @@
  #include "flang/Optimizer/Builder/FIRBuilder.h"
  #include "flang/Optimizer/Dialect/FIRDialect.h"
  #include "flang/Optimizer/Dialect/FIRType.h"
 +#include "flang/Optimizer/Support/DataLayout.h"
+ #include "flang/Runtime/io-api.h"
  #include "flang/Runtime/reduce.h"
- #include "mlir/IR/BuiltinTypes.h"
- #include "mlir/IR/MLIRContext.h"
-@@ -85,7 +86,7 @@ using FuncTypeBuilderFunc = mlir::FunctionType (*)(mlir::MLIRContext *);
+ #include "flang/Support/Fortran.h"
+@@ -87,7 +88,7 @@
        auto voidTy = fir::LLVMPointerType::get(                                 \
            context, mlir::IntegerType::get(context, 8));                        \
        auto size_tTy =                                                          \
@@ -30,7 +27,7 @@ index eaa1de761..2c776d4ea 100644
        auto refTy = fir::ReferenceType::get(f(context));                        \
        return mlir::FunctionType::get(                                          \
            context, {refTy, size_tTy, refTy, refTy, size_tTy, size_tTy},        \
-@@ -113,13 +114,13 @@ static constexpr TypeBuilderFunc getModel();
+@@ -115,13 +116,13 @@
  template <>
  constexpr TypeBuilderFunc getModel<unsigned int>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
@@ -46,7 +43,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -136,7 +137,7 @@ constexpr TypeBuilderFunc getModel<const short int *>() {
+@@ -138,7 +139,7 @@
  template <>
  constexpr TypeBuilderFunc getModel<int>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
@@ -55,7 +52,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -182,13 +183,13 @@ constexpr TypeBuilderFunc getModel<const char32_t *>() {
+@@ -184,13 +185,13 @@
  template <>
  constexpr TypeBuilderFunc getModel<char>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
@@ -71,7 +68,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -205,7 +206,7 @@ constexpr TypeBuilderFunc getModel<const signed char *>() {
+@@ -207,7 +208,7 @@
  template <>
  constexpr TypeBuilderFunc getModel<char16_t>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
@@ -80,7 +77,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -218,7 +219,7 @@ constexpr TypeBuilderFunc getModel<char16_t *>() {
+@@ -220,7 +221,7 @@
  template <>
  constexpr TypeBuilderFunc getModel<char32_t>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
@@ -89,7 +86,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -231,7 +232,7 @@ constexpr TypeBuilderFunc getModel<char32_t *>() {
+@@ -233,7 +234,7 @@
  template <>
  constexpr TypeBuilderFunc getModel<unsigned char>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
@@ -98,7 +95,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -259,7 +260,7 @@ constexpr TypeBuilderFunc getModel<void **>() {
+@@ -261,7 +262,7 @@
  template <>
  constexpr TypeBuilderFunc getModel<long>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
@@ -107,7 +104,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -280,7 +281,7 @@ constexpr TypeBuilderFunc getModel<const long *>() {
+@@ -282,7 +283,7 @@
  template <>
  constexpr TypeBuilderFunc getModel<long long>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
@@ -116,7 +113,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -308,13 +309,13 @@ constexpr TypeBuilderFunc getModel<const long long *>() {
+@@ -310,13 +311,13 @@
  template <>
  constexpr TypeBuilderFunc getModel<unsigned long>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
@@ -132,7 +129,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -343,7 +344,7 @@ constexpr TypeBuilderFunc getModel<long double>() {
+@@ -345,7 +346,7 @@
    return [](mlir::MLIRContext *context) -> mlir::Type {
      // See TODO at the top of the file. This is configuring for the host system
      // - it might be incorrect when cross-compiling!
@@ -141,7 +138,7 @@ index eaa1de761..2c776d4ea 100644
      static_assert(size == 16 || size == 10 || size == 8,
                    "unsupported long double size");
      if constexpr (size == 16)
-@@ -404,7 +405,7 @@ template <>
+@@ -413,7 +414,7 @@
  constexpr TypeBuilderFunc getModel<unsigned short>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
      return mlir::IntegerType::get(
@@ -150,7 +147,7 @@ index eaa1de761..2c776d4ea 100644
          mlir::IntegerType::SignednessSemantics::Unsigned);
    };
  }
-@@ -422,7 +423,7 @@ template <>
+@@ -431,7 +432,7 @@
  constexpr TypeBuilderFunc getModel<unsigned short *>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
      return fir::ReferenceType::get(
@@ -159,7 +156,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -441,7 +442,7 @@ template <>
+@@ -450,7 +451,7 @@
  constexpr TypeBuilderFunc getModel<unsigned long *>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
      return fir::ReferenceType::get(
@@ -168,7 +165,7 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-@@ -452,7 +453,7 @@ template <>
+@@ -461,7 +462,7 @@
  constexpr TypeBuilderFunc getModel<unsigned long long *>() {
    return [](mlir::MLIRContext *context) -> mlir::Type {
      return fir::ReferenceType::get(
@@ -177,13 +174,11 @@ index eaa1de761..2c776d4ea 100644
    };
  }
  template <>
-diff --git a/flang/include/flang/Optimizer/Support/DataLayout.h b/flang/include/flang/Optimizer/Support/DataLayout.h
-index 6072425b7..a252dc3af 100644
 --- a/flang/include/flang/Optimizer/Support/DataLayout.h
 +++ b/flang/include/flang/Optimizer/Support/DataLayout.h
-@@ -23,6 +23,24 @@ namespace llvm {
+@@ -27,6 +27,24 @@
  class DataLayout;
- }
+ } // namespace llvm
  
 +constexpr size_t FLANG_TARGET_SIZEOF_UINT = 4;
 +constexpr size_t FLANG_TARGET_SIZEOF_INT = 4;
@@ -206,30 +201,3 @@ index 6072425b7..a252dc3af 100644
  namespace fir::support {
  /// Create an mlir::DataLayoutSpecInterface attribute from an llvm::DataLayout
  /// and set it on the provided mlir::ModuleOp.
-diff --git a/flang/lib/Optimizer/CodeGen/CodeGen.cpp b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
-index 1b078be7b..40f84e3fb 100644
---- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
-+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
-@@ -949,7 +949,8 @@ getMallocInModule(ModuleOp mod, fir::AllocMemOp op,
-     return mlir::SymbolRefAttr::get(userMalloc);
- 
-   mlir::OpBuilder moduleBuilder(mod.getBodyRegion());
--  auto indexType = mlir::IntegerType::get(op.getContext(), 64);
-+  auto indexType =
-+      mlir::IntegerType::get(op.getContext(), 8 * FLANG_TARGET_SIZEOF_SIZE_T);
-   auto mallocDecl = moduleBuilder.create<mlir::LLVM::LLVMFuncOp>(
-       op.getLoc(), mallocName,
-       mlir::LLVM::LLVMFunctionType::get(getLlvmPtrType(op.getContext()),
-@@ -1025,8 +1026,11 @@ struct AllocMemOpConversion : public fir::FIROpConversion<fir::AllocMemOp> {
-       size = rewriter.create<mlir::LLVM::MulOp>(
-           loc, ity, size, integerCast(loc, rewriter, ity, opnd));
-     heap->setAttr("callee", getMalloc(heap, rewriter));
-+    auto szt_ty = mlir::IntegerType::get(rewriter.getContext(),
-+                                         8 * FLANG_TARGET_SIZEOF_SIZE_T);
-+    auto size_szt = integerCast(loc, rewriter, szt_ty, size);
-     rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(
--        heap, ::getLlvmPtrType(heap.getContext()), size,
-+        heap, ::getLlvmPtrType(heap.getContext()), size_szt,
-         addLLVMOpBundleAttrs(rewriter, heap->getAttrs(), 1));
-     return mlir::success();
-   }

--- a/recipes/recipes_emscripten/libflang/patches/0004-Disable-float128-math.patch
+++ b/recipes/recipes_emscripten/libflang/patches/0004-Disable-float128-math.patch
@@ -4,84 +4,63 @@ Date: Tue, 8 Jul 2025 16:57:20 +0200
 Subject: [PATCH 4/5] Disable float128 math
 
 ---
- flang/runtime/CMakeLists.txt | 60 ++++++++++++++++++------------------
- 1 file changed, 30 insertions(+), 30 deletions(-)
+ flang-rt/lib/runtime/CMakeLists.txt | 49 +++++++++++++++++-----------
+ 1 file changed, 30 insertions(+), 24 deletions(-)
 
-diff --git a/flang/runtime/CMakeLists.txt b/flang/runtime/CMakeLists.txt
-index bf27a121e..e0fd195d4 100644
---- a/flang/runtime/CMakeLists.txt
-+++ b/flang/runtime/CMakeLists.txt
-@@ -113,7 +113,7 @@ append(${NO_LTO_FLAGS} CMAKE_CXX_FLAGS)
- add_definitions(-U_GLIBCXX_ASSERTIONS)
- add_definitions(-U_LIBCPP_ENABLE_ASSERTIONS)
+--- a/flang-rt/lib/runtime/CMakeLists.txt
++++ b/flang-rt/lib/runtime/CMakeLists.txt
+@@ -151,29 +151,31 @@
  
--add_subdirectory(Float128Math)
-+# add_subdirectory(Float128Math)
  
- set(sources
-   ISO_Fortran_binding.cpp
-@@ -242,35 +242,35 @@ set(supported_files
- enable_cuda_compilation(FortranRuntime "${supported_files}")
- enable_omp_offload_compilation("${supported_files}")
- 
--if (NOT TARGET FortranFloat128Math)
--  # If FortranFloat128Math is not defined, then we are not building
--  # standalone FortranFloat128Math library. Instead, include
--  # the relevant sources into FortranRuntime itself.
--  # The information is provided via FortranFloat128MathILib
--  # interface library.
--  get_target_property(f128_sources
--    FortranFloat128MathILib INTERFACE_SOURCES
+ # Import changes from flang_rt.quadmath
+-get_target_property(f128_sources
+-  FortranFloat128MathILib INTERFACE_SOURCES
+-  )
+-if (f128_sources)
+-  # The interface may define special macros for Float128Math files,
+-  # so we need to propagate them.
+-  get_target_property(f128_defs
+-    FortranFloat128MathILib INTERFACE_COMPILE_DEFINITIONS
 -    )
--  if (f128_sources)
--    # The interface may define special macros for Float128Math files,
--    # so we need to propagate them.
--    get_target_property(f128_defs
--      FortranFloat128MathILib INTERFACE_COMPILE_DEFINITIONS
--      )
--    set_property(SOURCE ${f128_sources}
--      APPEND PROPERTY COMPILE_DEFINITIONS
--      ${f128_defs}
--      )
--    get_target_property(f128_include_dirs
--      FortranFloat128MathILib INTERFACE_INCLUDE_DIRECTORIES
--      )
--    set_property(SOURCE ${f128_sources}
--      APPEND PROPERTY INCLUDE_DIRECTORIES
--      ${f128_include_dirs}
--      )
--    list(APPEND sources ${f128_sources})
--  endif()
--endif()
-+# if (NOT TARGET FortranFloat128Math)
-+#   # If FortranFloat128Math is not defined, then we are not building
-+#   # standalone FortranFloat128Math library. Instead, include
-+#   # the relevant sources into FortranRuntime itself.
-+#   # The information is provided via FortranFloat128MathILib
-+#   # interface library.
-+#   get_target_property(f128_sources
-+#     FortranFloat128MathILib INTERFACE_SOURCES
+-  set_property(SOURCE ${f128_sources}
+-    APPEND PROPERTY COMPILE_DEFINITIONS
+-    ${f128_defs}
+-    )
+-  get_target_property(f128_include_dirs
+-    FortranFloat128MathILib INTERFACE_INCLUDE_DIRECTORIES
+-    )
+-  set_property(SOURCE ${f128_sources}
+-    APPEND PROPERTY INCLUDE_DIRECTORIES
+-    ${f128_include_dirs}
+-    )
+-else ()
+-  set(f128_sources "")
+-endif ()
++# Disabled for wasm32 — Float128/quadmath is not supported
++# get_target_property(f128_sources
++#   FortranFloat128MathILib INTERFACE_SOURCES
++#   )
++# if (f128_sources)
++#   # The interface may define special macros for Float128Math files,
++#   # so we need to propagate them.
++#   get_target_property(f128_defs
++#     FortranFloat128MathILib INTERFACE_COMPILE_DEFINITIONS
 +#     )
-+#   if (f128_sources)
-+#     # The interface may define special macros for Float128Math files,
-+#     # so we need to propagate them.
-+#     get_target_property(f128_defs
-+#       FortranFloat128MathILib INTERFACE_COMPILE_DEFINITIONS
-+#       )
-+#     set_property(SOURCE ${f128_sources}
-+#       APPEND PROPERTY COMPILE_DEFINITIONS
-+#       ${f128_defs}
-+#       )
-+#     get_target_property(f128_include_dirs
-+#       FortranFloat128MathILib INTERFACE_INCLUDE_DIRECTORIES
-+#       )
-+#     set_property(SOURCE ${f128_sources}
-+#       APPEND PROPERTY INCLUDE_DIRECTORIES
-+#       ${f128_include_dirs}
-+#       )
-+#     list(APPEND sources ${f128_sources})
-+#   endif()
-+# endif()
++#   set_property(SOURCE ${f128_sources}
++#     APPEND PROPERTY COMPILE_DEFINITIONS
++#     ${f128_defs}
++#     )
++#   get_target_property(f128_include_dirs
++#     FortranFloat128MathILib INTERFACE_INCLUDE_DIRECTORIES
++#     )
++#   set_property(SOURCE ${f128_sources}
++#     APPEND PROPERTY INCLUDE_DIRECTORIES
++#     ${f128_include_dirs}
++#     )
++# else ()
++#   set(f128_sources "")
++# endif ()
++set(f128_sources "")
  
- if (NOT DEFINED MSVC)
-   add_flang_library(FortranRuntime
+ if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn|^nvptx")
+   set(sources ${gpu_sources})

--- a/recipes/recipes_emscripten/libflang/patches/0005-Simulate-common-symbols-as-weak.patch
+++ b/recipes/recipes_emscripten/libflang/patches/0005-Simulate-common-symbols-as-weak.patch
@@ -7,11 +7,9 @@ Subject: [PATCH 5/5] Simulate common symbols as weak
  llvm/lib/MC/MCWasmStreamer.cpp | 12 ++++++++++--
  1 file changed, 10 insertions(+), 2 deletions(-)
 
-diff --git a/llvm/lib/MC/MCWasmStreamer.cpp b/llvm/lib/MC/MCWasmStreamer.cpp
-index 8560f0ebe..f8a83e01a 100644
 --- a/llvm/lib/MC/MCWasmStreamer.cpp
 +++ b/llvm/lib/MC/MCWasmStreamer.cpp
-@@ -150,7 +150,11 @@ bool MCWasmStreamer::emitSymbolAttribute(MCSymbol *S, MCSymbolAttr Attribute) {
+@@ -131,7 +131,11 @@
  
  void MCWasmStreamer::emitCommonSymbol(MCSymbol *S, uint64_t Size,
                                        Align ByteAlignment) {
@@ -24,7 +22,7 @@ index 8560f0ebe..f8a83e01a 100644
  }
  
  void MCWasmStreamer::emitELFSize(MCSymbol *Symbol, const MCExpr *Value) {
-@@ -159,7 +163,11 @@ void MCWasmStreamer::emitELFSize(MCSymbol *Symbol, const MCExpr *Value) {
+@@ -140,7 +144,11 @@
  
  void MCWasmStreamer::emitLocalCommonSymbol(MCSymbol *S, uint64_t Size,
                                             Align ByteAlignment) {

--- a/recipes/recipes_emscripten/libflang/patches/0006-Fix-narrowing-conversion-in-descriptor-for-wasm32.patch
+++ b/recipes/recipes_emscripten/libflang/patches/0006-Fix-narrowing-conversion-in-descriptor-for-wasm32.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Adam Blake <adam@coursekata.org>
+Date: Wed, 2 Apr 2026 15:20:00 -0700
+Subject: [PATCH 6/6] Fix narrowing conversion in descriptor for wasm32
+
+On wasm32, size_t is 4 bytes but sizeInBytes() returns uint64_t.
+Brace initialization treats this as a narrowing error. Use
+parenthesized initialization which allows the implicit conversion.
+---
+ flang-rt/lib/runtime/descriptor.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/flang-rt/lib/runtime/descriptor.cpp
++++ b/flang-rt/lib/runtime/descriptor.cpp
+@@ -85,7 +85,7 @@
+ RT_API_ATTRS void Descriptor::Establish(const typeInfo::DerivedType &dt,
+     void *p, int rank, const SubscriptValue *extent,
+     ISO::CFI_attribute_t attribute) {
+-  std::size_t elementBytes{dt.sizeInBytes()};
++  std::size_t elementBytes(dt.sizeInBytes());
+   ISO::EstablishDescriptor(
+       &raw_, p, attribute, CFI_type_struct, elementBytes, rank, extent);
+   if (elementBytes == 0) {

--- a/recipes/recipes_emscripten/libflang/patches/0007-Fix-complex-reduction-ABI-mismatch-for-wasm32.patch
+++ b/recipes/recipes_emscripten/libflang/patches/0007-Fix-complex-reduction-ABI-mismatch-for-wasm32.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Adam Blake <adam@coursekata.org>
+Date: Thu, 10 Apr 2026 00:00:00 -0700
+Subject: [PATCH 7/7] Fix complex reduction ABI mismatch for wasm32
+
+The ADAPT_REDUCTION macro in complex-reduction.c declares the C++
+CppReduce* functions with a struct return type. On native targets,
+the struct return ABI matches C++'s void-with-reference-param ABI.
+On wasm32, struct returns use an sret parameter, creating a signature
+mismatch (11 params vs 9 params) that causes wasm-ld errors.
+
+Fix by declaring the C++ functions as void-returning, matching
+their actual C++ definition in reduce.cpp.
+---
+ flang-rt/lib/runtime/complex-reduction.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/flang-rt/lib/runtime/complex-reduction.c
++++ b/flang-rt/lib/runtime/complex-reduction.c
+@@ -104,7 +104,7 @@
+ 
+ #define CPP_NAME(name) Cpp##name
+ #define ADAPT_REDUCTION(name, cComplex, cpptype, cmplxMacro, ARGS, ARG_NAMES) \
+-  struct cpptype RTNAME(CPP_NAME(name))(struct cpptype *, ARGS); \
++  void RTNAME(CPP_NAME(name))(struct cpptype *, ARGS); \
+   cComplex RTNAME(name)(ARGS) { \
+     struct cpptype result; \
+     RTNAME(CPP_NAME(name))(&result, ARG_NAMES); \

--- a/recipes/recipes_emscripten/libflang/patches/0007-Fix-complex-reduction-ABI-mismatch-for-wasm32.patch
+++ b/recipes/recipes_emscripten/libflang/patches/0007-Fix-complex-reduction-ABI-mismatch-for-wasm32.patch
@@ -3,26 +3,144 @@ From: Adam Blake <adam@coursekata.org>
 Date: Thu, 10 Apr 2026 00:00:00 -0700
 Subject: [PATCH 7/7] Fix complex reduction ABI mismatch for wasm32
 
-The ADAPT_REDUCTION macro in complex-reduction.c declares the C++
-CppReduce* functions with a struct return type. On native targets,
-the struct return ABI matches C++'s void-with-reference-param ABI.
-On wasm32, struct returns use an sret parameter, creating a signature
-mismatch (11 params vs 9 params) that causes wasm-ld errors.
+The ADAPT_REDUCTION macro in complex-reduction.c generates incorrect
+forward declarations and call sequences for the CppReduce* and
+CppDotProduct* functions:
 
-Fix by declaring the C++ functions as void-returning, matching
-their actual C++ definition in reduce.cpp.
+1. It declares them with a struct return type, but the C++ definitions
+   return void. On wasm32, struct returns add an sret parameter.
+
+2. For REDUCE, the macro passes arguments in the wrong order
+   (operation before array) and includes an extra 'y' parameter.
+
+3. For DOT_PRODUCT, the struct return causes a similar sret mismatch.
+
+On native targets these mismatches are silent. On wasm32, strict
+signature checking causes link errors.
+
+Fix by replacing ADAPT_REDUCTION usage for DOT_PRODUCT and REDUCE
+with hand-written adapters that match the C++ signatures exactly.
 ---
- flang-rt/lib/runtime/complex-reduction.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ flang-rt/lib/runtime/complex-reduction.c | 117 +++++++++++++++-------
+ 1 file changed, 82 insertions(+), 35 deletions(-)
 
 --- a/flang-rt/lib/runtime/complex-reduction.c
 +++ b/flang-rt/lib/runtime/complex-reduction.c
-@@ -104,7 +104,7 @@
+@@ -103,8 +103,10 @@
+  */
  
  #define CPP_NAME(name) Cpp##name
++/* Only valid for SUM/PRODUCT where the C++ signature is
++ * void Cpp...(result*, REDUCTION_ARGS). */
  #define ADAPT_REDUCTION(name, cComplex, cpptype, cmplxMacro, ARGS, ARG_NAMES) \
 -  struct cpptype RTNAME(CPP_NAME(name))(struct cpptype *, ARGS); \
 +  void RTNAME(CPP_NAME(name))(struct cpptype *, ARGS); \
    cComplex RTNAME(name)(ARGS) { \
      struct cpptype result; \
      RTNAME(CPP_NAME(name))(&result, ARG_NAMES); \
+@@ -142,53 +144,65 @@
+ #endif
+ 
+ /* DOT_PRODUCT() */
+-ADAPT_REDUCTION(DotProductComplex4, float_Complex_t, CppComplexFloat, CMPLXF,
+-    DOT_PRODUCT_ARGS, DOT_PRODUCT_ARG_NAMES)
+-ADAPT_REDUCTION(DotProductComplex8, double_Complex_t, CppComplexDouble, CMPLX,
+-    DOT_PRODUCT_ARGS, DOT_PRODUCT_ARG_NAMES)
++/* The C++ CppDotProduct* functions have signature:
++ *   void Cpp...(result*, array_x*, array_y*, source, line, dim, mask*)
++ * The ADAPT_REDUCTION macro would generate a struct return (adding sret on
++ * wasm32), so we use hand-written adapters with void return. */
++#define ADAPT_DOT_PRODUCT(name, cComplex, cpptype, cmplxMacro) \
++  void RTNAME(CPP_NAME(name))(struct cpptype *, \
++      const struct CppDescriptor *, const struct CppDescriptor *, \
++      const char *, int, int, const struct CppDescriptor *); \
++  cComplex RTNAME(name)(DOT_PRODUCT_ARGS) { \
++    struct cpptype result; \
++    RTNAME(CPP_NAME(name))(&result, x, y, source, line, dim, mask); \
++    return cmplxMacro(result.r, result.i); \
++  }
++
++ADAPT_DOT_PRODUCT(DotProductComplex4, float_Complex_t, CppComplexFloat, CMPLXF)
++ADAPT_DOT_PRODUCT(DotProductComplex8, double_Complex_t, CppComplexDouble, CMPLX)
+ #if HAS_FLOAT80
+-ADAPT_REDUCTION(DotProductComplex10, long_double_Complex_t,
+-    CppComplexLongDouble, CMPLXL, DOT_PRODUCT_ARGS, DOT_PRODUCT_ARG_NAMES)
++ADAPT_DOT_PRODUCT(DotProductComplex10, long_double_Complex_t,
++    CppComplexLongDouble, CMPLXL)
+ #endif
+ #if HAS_LDBL128 || HAS_FLOAT128
+-ADAPT_REDUCTION(DotProductComplex16, CFloat128ComplexType, CppComplexFloat128,
+-    CMPLXF128, DOT_PRODUCT_ARGS, DOT_PRODUCT_ARG_NAMES)
++ADAPT_DOT_PRODUCT(DotProductComplex16, CFloat128ComplexType,
++    CppComplexFloat128, CMPLXF128)
+ #endif
+ 
+ /* REDUCE() */
+-#define RARGS REDUCE_ARGS(float_Complex_t, float_Complex_t_ref_op)
+-ADAPT_REDUCTION(ReduceComplex4Ref, float_Complex_t, CppComplexFloat, CMPLXF,
+-    RARGS, REDUCE_ARG_NAMES)
+-#undef RARGS
+-#define RARGS REDUCE_ARGS(float_Complex_t, float_Complex_t_value_op)
+-ADAPT_REDUCTION(ReduceComplex4Value, float_Complex_t, CppComplexFloat, CMPLXF,
+-    RARGS, REDUCE_ARG_NAMES)
+-#undef RARGS
+-#define RARGS REDUCE_ARGS(double_Complex_t, double_Complex_t_ref_op)
+-ADAPT_REDUCTION(ReduceComplex8Ref, double_Complex_t, CppComplexDouble, CMPLX,
+-    RARGS, REDUCE_ARG_NAMES)
+-#undef RARGS
+-#define RARGS REDUCE_ARGS(double_Complex_t, double_Complex_t_value_op)
+-ADAPT_REDUCTION(ReduceComplex8Value, double_Complex_t, CppComplexDouble, CMPLX,
+-    RARGS, REDUCE_ARG_NAMES)
+-#undef RARGS
++/* The C++ CppReduce* functions have signature:
++ *   void Cpp...(result*, array*, operation, source, line, dim, mask*,
++ *               identity*, ordered)
++ * The ADAPT_REDUCTION macro passes args in the wrong order and includes an
++ * extra 'y' param from REDUCE_ARGS, so we use hand-written adapters. */
++#define ADAPT_REDUCE(name, cComplex, cpptype, cmplxMacro, T, OP) \
++  void RTNAME(CPP_NAME(name))(struct cpptype *, \
++      const struct CppDescriptor *, OP, const char *, int, int, \
++      const struct CppDescriptor *, const T *, _Bool); \
++  cComplex RTNAME(name)(REDUCE_ARGS(T, OP)) { \
++    struct cpptype result; \
++    RTNAME(CPP_NAME(name))(&result, x, operation, source, line, dim, \
++        mask, identity, ordered); \
++    return cmplxMacro(result.r, result.i); \
++  }
++
++ADAPT_REDUCE(ReduceComplex4Ref, float_Complex_t, CppComplexFloat, CMPLXF,
++    float_Complex_t, float_Complex_t_ref_op)
++ADAPT_REDUCE(ReduceComplex4Value, float_Complex_t, CppComplexFloat, CMPLXF,
++    float_Complex_t, float_Complex_t_value_op)
++ADAPT_REDUCE(ReduceComplex8Ref, double_Complex_t, CppComplexDouble, CMPLX,
++    double_Complex_t, double_Complex_t_ref_op)
++ADAPT_REDUCE(ReduceComplex8Value, double_Complex_t, CppComplexDouble, CMPLX,
++    double_Complex_t, double_Complex_t_value_op)
+ #if HAS_FLOAT80
+-#define RARGS REDUCE_ARGS(long_double_Complex_t, long_double_Complex_t_ref_op)
+-ADAPT_REDUCTION(ReduceComplex10Ref, long_double_Complex_t, CppComplexLongDouble,
+-    CMPLXL, RARGS, REDUCE_ARG_NAMES)
+-#undef RARGS
+-#define RARGS REDUCE_ARGS(long_double_Complex_t, long_double_Complex_t_value_op)
+-ADAPT_REDUCTION(ReduceComplex10Value, long_double_Complex_t,
+-    CppComplexLongDouble, CMPLXL, RARGS, REDUCE_ARG_NAMES)
+-#undef RARGS
++ADAPT_REDUCE(ReduceComplex10Ref, long_double_Complex_t, CppComplexLongDouble,
++    CMPLXL, long_double_Complex_t, long_double_Complex_t_ref_op)
++ADAPT_REDUCE(ReduceComplex10Value, long_double_Complex_t, CppComplexLongDouble,
++    CMPLXL, long_double_Complex_t, long_double_Complex_t_value_op)
+ #endif
+ #if HAS_LDBL128 || HAS_FLOAT128
+-#define RARGS REDUCE_ARGS(CFloat128ComplexType, CFloat128ComplexType_ref_op)
+-ADAPT_REDUCTION(ReduceComplex16Ref, CFloat128ComplexType, CppComplexFloat128,
+-    CMPLXF128, RARGS, REDUCE_ARG_NAMES)
+-#undef RARGS
+-#define RARGS REDUCE_ARGS(CFloat128ComplexType, CFloat128ComplexType_value_op)
+-ADAPT_REDUCTION(ReduceComplex16Value, CFloat128ComplexType, CppComplexFloat128,
+-    CMPLXF128, RARGS, REDUCE_ARG_NAMES)
+-#undef RARGS
++ADAPT_REDUCE(ReduceComplex16Ref, CFloat128ComplexType, CppComplexFloat128,
++    CMPLXF128, CFloat128ComplexType, CFloat128ComplexType_ref_op)
++ADAPT_REDUCE(ReduceComplex16Value, CFloat128ComplexType, CppComplexFloat128,
++    CMPLXF128, CFloat128ComplexType, CFloat128ComplexType_value_op)
+ #endif

--- a/recipes/recipes_emscripten/libflang/recipe.yaml
+++ b/recipes/recipes_emscripten/libflang/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: libflang
-  version: 20.1.8
+  version: 21.1.0
 
 package:
   name: ${{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-${{ version }}.tar.gz
-  sha256: a6cbad9b2243b17e87795817cfff2107d113543a12486586f8a055a2bb044963
+  sha256: fba0618cf8de48ec05880c446edd756a2669157eab9d29949e971c77da10275f
   patches:
   # from https://github.com/serge-sans-paille/llvm-project/tree/feature/flang-wasm
   # - patches/0001-Instructions-for-building-a-functional-Flang-cross-c.patch
@@ -30,7 +30,7 @@ requirements:
 tests:
 - package_contents:
     lib:
-    - libFortranRuntime.a
+    - libflang_rt.runtime.a
     - libFortranDecimal.a
 
 about:

--- a/recipes/recipes_emscripten/libflang/recipe.yaml
+++ b/recipes/recipes_emscripten/libflang/recipe.yaml
@@ -16,6 +16,7 @@ source:
   - patches/0003-Specialize-Flang-to-target-WASM.patch
   - patches/0004-Disable-float128-math.patch
   - patches/0005-Simulate-common-symbols-as-weak.patch
+  - patches/0006-Fix-narrowing-conversion-in-descriptor-for-wasm32.patch
 
 build:
   number: 0

--- a/recipes/recipes_emscripten/libflang/recipe.yaml
+++ b/recipes/recipes_emscripten/libflang/recipe.yaml
@@ -20,7 +20,7 @@ source:
   - patches/0007-Fix-complex-reduction-ABI-mismatch-for-wasm32.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/libflang/recipe.yaml
+++ b/recipes/recipes_emscripten/libflang/recipe.yaml
@@ -17,6 +17,7 @@ source:
   - patches/0004-Disable-float128-math.patch
   - patches/0005-Simulate-common-symbols-as-weak.patch
   - patches/0006-Fix-narrowing-conversion-in-descriptor-for-wasm32.patch
+  - patches/0007-Fix-complex-reduction-ABI-mismatch-for-wasm32.patch
 
 build:
   number: 0

--- a/recipes/recipes_emscripten/libflang/recipe.yaml
+++ b/recipes/recipes_emscripten/libflang/recipe.yaml
@@ -20,7 +20,7 @@ source:
   - patches/0007-Fix-complex-reduction-ABI-mismatch-for-wasm32.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/r-askpass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-askpass/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 6c2106a74c44a748f2cea795d9686e27a0058a90debcfd8558b62b06aec0c7dd
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-askpass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-askpass/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 6c2106a74c44a748f2cea795d9686e27a0058a90debcfd8558b62b06aec0c7dd
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-base/build.sh
+++ b/recipes/recipes_emscripten/r-base/build.sh
@@ -51,7 +51,7 @@ pushd _build_linux
     export PREFIX=$BUILD_PREFIX
     export CC=gcc
     export CXX=g++
-    export FC=flang-new
+    export FC=flang
     export CPPFLAGS="-I$BUILD_PREFIX/include"
     export LDFLAGS="-L$BUILD_PREFIX/lib"
     export FC_LEN_T=size_t
@@ -128,4 +128,4 @@ sed -i '/DOCTYPE/d' "$PREFIX/etc/fonts/fonts.conf"
 sed -i 's|<dir>/usr/share/fonts</dir>|<dir>/fonts</dir>|' "$PREFIX/etc/fonts/fonts.conf"
 sed -i 's|<include ignore_missing="yes">conf.d</include>|<include ignore_missing="yes">/etc/fonts/conf.d</include>\n<include ignore_missing="yes">/etc/fonts/config.d</include>|' "$PREFIX/etc/fonts/fonts.conf"
 
-rm $PREFIX/lib/libFortranRuntime.a
+rm $PREFIX/lib/libflang_rt.runtime.a

--- a/recipes/recipes_emscripten/r-base/build.sh
+++ b/recipes/recipes_emscripten/r-base/build.sh
@@ -109,4 +109,23 @@ pushd _build_wasm
 )
 popd
 
+#-------------------------------------------------------------------------------
+# FONTCONFIG SETUP
+#-------------------------------------------------------------------------------
+# At runtime the WASM filesystem prefix is /, but fontconfig's compiled-in
+# config path points to the build host prefix. Set FONTCONFIG_FILE so
+# fontconfig can find its config, and add /fonts/ (where font-ttf-dejavu
+# installs) as a font directory.
+
+# Wasm expat can't resolve the fontconfig DOCTYPE URN, so strip it from
+# all config files. Also patch fonts.conf to use /fonts/ (where
+# font-ttf-dejavu installs) and add an absolute include for config.d/
+# (where DejaVu's family alias configs live).
+for f in "$PREFIX"/etc/fonts/conf.d/*.conf "$PREFIX"/etc/fonts/config.d/*.conf; do
+  [ -f "$f" ] && sed -i '/DOCTYPE/d' "$f"
+done
+sed -i '/DOCTYPE/d' "$PREFIX/etc/fonts/fonts.conf"
+sed -i 's|<dir>/usr/share/fonts</dir>|<dir>/fonts</dir>|' "$PREFIX/etc/fonts/fonts.conf"
+sed -i 's|<include ignore_missing="yes">conf.d</include>|<include ignore_missing="yes">/etc/fonts/conf.d</include>\n<include ignore_missing="yes">/etc/fonts/config.d</include>|' "$PREFIX/etc/fonts/fonts.conf"
+
 rm $PREFIX/lib/libFortranRuntime.a

--- a/recipes/recipes_emscripten/r-base/config.site
+++ b/recipes/recipes_emscripten/r-base/config.site
@@ -129,6 +129,8 @@ FLIBS="-lflang_rt.runtime"
 ## Skip the dummy main linking test — it can't run wasm binaries to check.
 ## flang doesn't need a dummy main (confirmed by the native Linux build).
 ac_cv_fc_dummy_main=none
+## Fortran name-mangling: flang uses lowercase, no underscores
+ac_cv_fc_mangling="lower case, no underscore, no extra underscore"
 ## Ditto for free-form Fortran.
 ## FCFLAGS=
 ## If just one of these is set, it is used for both.

--- a/recipes/recipes_emscripten/r-base/config.site
+++ b/recipes/recipes_emscripten/r-base/config.site
@@ -126,6 +126,9 @@ FFLAGS="-g --target=wasm32-unknown-emscripten -fPIC -O2"
 ## Fortran runtime library for linking. In LLVM 21, the runtime was renamed
 ## from FortranRuntime to flang_rt.runtime but flang still reports the old name.
 FLIBS="-lflang_rt.runtime"
+## Skip the dummy main linking test — it can't run wasm binaries to check.
+## flang doesn't need a dummy main (confirmed by the native Linux build).
+ac_cv_fc_dummy_main=none
 ## Ditto for free-form Fortran.
 ## FCFLAGS=
 ## If just one of these is set, it is used for both.

--- a/recipes/recipes_emscripten/r-base/config.site
+++ b/recipes/recipes_emscripten/r-base/config.site
@@ -123,6 +123,9 @@ FC=flang
 ## Options for the Fortran compiler.
 ## Use this to specify compilation flags for fixed-form Fortran.
 FFLAGS="-g --target=wasm32-unknown-emscripten -fPIC -O2"
+## Fortran runtime library for linking. In LLVM 21, the runtime was renamed
+## from FortranRuntime to flang_rt.runtime but flang still reports the old name.
+FLIBS="-lflang_rt.runtime"
 ## Ditto for free-form Fortran.
 ## FCFLAGS=
 ## If just one of these is set, it is used for both.

--- a/recipes/recipes_emscripten/r-base/config.site
+++ b/recipes/recipes_emscripten/r-base/config.site
@@ -129,8 +129,12 @@ FLIBS="-lflang_rt.runtime"
 ## Skip the dummy main linking test — it can't run wasm binaries to check.
 ## flang doesn't need a dummy main (confirmed by the native Linux build).
 ac_cv_fc_dummy_main=none
-## Fortran name-mangling: flang uses lowercase, no underscores
-ac_cv_fc_mangling="lower case, no underscore, no extra underscore"
+## Fortran name-mangling: LLVM flang appends a trailing underscore by default,
+## matching gfortran. (An earlier comment here said "no underscores" — that
+## was true for Classic Flang, not LLVM flang / flang-new, and the resulting
+## HAVE_F77_UNDERSCORE=undef caused stats.so to import e.g. `dqrls` while
+## libR.so exported `dqrls_`, crashing lm() with a dynamic-linking error.)
+ac_cv_fc_mangling="lower case, underscore, no extra underscore"
 ## Ditto for free-form Fortran.
 ## FCFLAGS=
 ## If just one of these is set, it is used for both.

--- a/recipes/recipes_emscripten/r-base/config.site
+++ b/recipes/recipes_emscripten/r-base/config.site
@@ -118,7 +118,7 @@ CPPFLAGS="${OPT_FLAG} -fwasm-exceptions -sSUPPORT_LONGJMP=wasm -I$PREFIX/include
 ## The command which runs the Fortran compiler.
 ## Used for both fixed-form and free-form Fortran
 ## If this is a wrapper it should pass on --version to the real compiler.
-FC=flang-new
+FC=flang
 
 ## Options for the Fortran compiler.
 ## Use this to specify compilation flags for fixed-form Fortran.

--- a/recipes/recipes_emscripten/r-base/patches/0014-Fix-cairo-font-scaling-in-emscripten.patch
+++ b/recipes/recipes_emscripten/r-base/patches/0014-Fix-cairo-font-scaling-in-emscripten.patch
@@ -1,0 +1,92 @@
+--- a/src/library/grDevices/src/cairo/cairoFns.c	2026-03-30 15:26:57
++++ b/src/library/grDevices/src/cairo/cairoFns.c	2026-03-31 09:47:14
+@@ -1884,7 +1884,6 @@
+ {
+     pX11Desc xd = (pX11Desc) dd->deviceSpecific;
+     int face = gc->fontface;
+-    double size = gc->cex * gc->ps *fs;
+     cairo_font_face_t *cairo_face = NULL;
+     const char *family;
+ #ifdef Win32
+@@ -1911,9 +1910,10 @@
+ 	Rc_addFont(family, face, cairo_face);
+     }
+     cairo_set_font_face (xd->cc, cairo_face);
+-    /* FIXME: this should really use cairo_set_font_matrix
+-       if pixels are non-square on a screen device. */
+-    cairo_set_font_size (xd->cc, size);
++    /* Font size is applied via CTM scaling in Cairo_Text, Cairo_StrWidth,
++     * and Cairo_MetricInfo because cairo_set_font_size does not work
++     * correctly in emscripten-wasm32 builds. */
++    cairo_set_font_size (xd->cc, 1.0);
+ }
+ 
+ #else
+@@ -1997,11 +1997,20 @@
+ 	str[0] = (char)c; str[1] = 0;
+     }
+ 
++    double size = gc->cex * gc->ps * xd->fontscale;
+     FT_getFont(gc, dd, xd->fontscale);
++    /* cairo_set_font_size is broken on emscripten-wasm32; query the
++     * actual (stuck) font size and compute a CTM scale ratio. */
++    cairo_matrix_t fm;
++    cairo_get_font_matrix(xd->cc, &fm);
++    double scale = (fm.xx > 0) ? size / fm.xx : size;
++    cairo_save(xd->cc);
++    cairo_scale(xd->cc, scale, scale);
+     cairo_text_extents(xd->cc, str, &exts);
+-    *ascent  = -exts.y_bearing;
+-    *descent = exts.height + exts.y_bearing;
+-    *width = exts.x_advance;
++    cairo_restore(xd->cc);
++    *ascent  = -exts.y_bearing * scale;
++    *descent = (exts.height + exts.y_bearing) * scale;
++    *width = exts.x_advance * scale;
+ }
+ 
+ static double Cairo_StrWidth(const char *str, pGEcontext gc, pDevDesc dd)
+@@ -2020,9 +2029,16 @@
+     } else {
+         textstr = str;
+     }
++    double size = gc->cex * gc->ps * xd->fontscale;
+     FT_getFont(gc, dd, xd->fontscale);
++    cairo_matrix_t fm;
++    cairo_get_font_matrix(xd->cc, &fm);
++    double scale = (fm.xx > 0) ? size / fm.xx : size;
++    cairo_save(xd->cc);
++    cairo_scale(xd->cc, scale, scale);
+     cairo_text_extents(xd->cc, textstr, &exts);
+-    return exts.x_advance;
++    cairo_restore(xd->cc);
++    return exts.x_advance * scale;
+ }
+ 
+ static void Cairo_Text(double x, double y,
+@@ -2051,15 +2067,20 @@
+             grouping = cairoBegin(xd);
+         }
+ 
++	double size = gc->cex * gc->ps * xd->fontscale;
+ 	FT_getFont(gc, dd, xd->fontscale);
+-	cairo_move_to(xd->cc, x, y);
+-	if (hadj != 0.0 || rot != 0.0) {
++	cairo_matrix_t fm;
++	cairo_get_font_matrix(xd->cc, &fm);
++	double scale = (fm.xx > 0) ? size / fm.xx : size;
++	cairo_translate(xd->cc, x, y);
++	if (rot != 0.0) cairo_rotate(xd->cc, -rot/180.*M_PI);
++	cairo_scale(xd->cc, scale, scale);
++	if (hadj != 0.0) {
+ 	    cairo_text_extents_t te;
+ 	    cairo_text_extents(xd->cc, textstr, &te);
+-	    if (rot != 0.0) cairo_rotate(xd->cc, -rot/180.*M_PI);
+-	    if (hadj != 0.0)
+-		cairo_rel_move_to(xd->cc, -te.x_advance * hadj, 0);
++	    cairo_translate(xd->cc, -te.x_advance * hadj, 0);
+ 	}
++	cairo_move_to(xd->cc, 0, 0);
+         if (!xd->appending) {
+             CairoColor(gc->col, xd);
+             cairo_show_text(xd->cc, textstr);

--- a/recipes/recipes_emscripten/r-base/patches/0015-Set-fontconfig-path-for-emscripten.patch
+++ b/recipes/recipes_emscripten/r-base/patches/0015-Set-fontconfig-path-for-emscripten.patch
@@ -1,0 +1,13 @@
+--- a/src/library/grDevices/src/cairo/cairoFns.c
++++ b/src/library/grDevices/src/cairo/cairoFns.c
+@@ -1756,6 +1756,10 @@ static cairo_font_face_t *FC_getFont(const char *family, int style)
+
+     /* find candidate fonts via FontConfig */
+     if (!fc_loaded) {
++#ifdef __EMSCRIPTEN__
++	/* Compiled-in config path doesn't survive wasm relocation */
++	setenv("FONTCONFIG_FILE", "/etc/fonts/fonts.conf", 0);
++#endif
+ 	if (!FcInit()) {
+ 	    warning("unable to initialize FontConfig in cairo-ft font selection");
+ 	    return NULL;

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -24,9 +24,10 @@ source:
   - patches/0011-Remove-png-lib-from-bitmap-libs.patch
   - patches/0012-Use-linux-executables.patch
   - patches/0013-Use-source-files-when-installing.patch
+  - patches/0014-Fix-cairo-font-scaling-in-emscripten.patch
 
 build:
-  number: 1
+  number: 2
 
   files:
     exclude:

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -28,7 +28,7 @@ source:
   - patches/0015-Set-fontconfig-path-for-emscripten.patch
 
 build:
-  number: 3
+  number: 4
 
   files:
     exclude:

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -25,9 +25,10 @@ source:
   - patches/0012-Use-linux-executables.patch
   - patches/0013-Use-source-files-when-installing.patch
   - patches/0014-Fix-cairo-font-scaling-in-emscripten.patch
+  - patches/0015-Set-fontconfig-path-for-emscripten.patch
 
 build:
-  number: 2
+  number: 3
 
   files:
     exclude:
@@ -65,6 +66,10 @@ requirements:
   - pixman
   - expat
   - freetype
+  - font-ttf-dejavu >=2.37
+  run:
+  - fontconfig >=2.15
+  - font-ttf-dejavu >=2.37
   run_exports:
   - ${{ pin_subpackage("r-base", exact=True) }}
 

--- a/recipes/recipes_emscripten/r-base64enc/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base64enc/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 3c7e9d22f7409fa2989008fa6e980c3dd8e2693eb20676acf2470ae7addb0816
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-base64enc/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base64enc/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 3c7e9d22f7409fa2989008fa6e980c3dd8e2693eb20676acf2470ae7addb0816
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-bit/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 48fe21c5d04c7b724d695eeb60074395c0c631a7fb234e2075de92471445de08
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-bit/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 48fe21c5d04c7b724d695eeb60074395c0c631a7fb234e2075de92471445de08
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-bit64/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit64/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: fbc0ce142fc22c9a9fdcbac930a814dfb648563d4b6a77dff739c23cc81319b7
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-bit64/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit64/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: fbc0ce142fc22c9a9fdcbac930a814dfb648563d4b6a77dff739c23cc81319b7
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-cachem/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cachem/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 550839fc2ae5d865db475ba2c1714144f07fa0c052c72135b0e4a70287492e21
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-cachem/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cachem/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 550839fc2ae5d865db475ba2c1714144f07fa0c052c72135b0e4a70287492e21
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-cli/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cli/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 3.6.5
+  version: 3.6.6
   name: r-cli
 
 package:
@@ -10,10 +10,10 @@ source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  sha256: 8ebe3146e66a285d8ad6ddcff87e2a9790ea7c9cdfce7fdd8bf13095fa459679
+  sha256: b2b58d6dd82f5798b335e39c00591686a01fd3e94399ef898e146173e36f18f9
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-cli/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cli/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b2b58d6dd82f5798b335e39c00591686a01fd3e94399ef898e146173e36f18f9
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-colorspace/recipe.yaml
+++ b/recipes/recipes_emscripten/r-colorspace/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: ec71499d33ef5d72b7fb3359b8320639e06e413abad61a070201178a254b153e
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-colorspace/recipe.yaml
+++ b/recipes/recipes_emscripten/r-colorspace/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: ec71499d33ef5d72b7fb3359b8320639e06e413abad61a070201178a254b153e
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-data.table/recipe.yaml
+++ b/recipes/recipes_emscripten/r-data.table/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 7663893a84b3e22ff23efb4658bf7809ea4ff5551659cae96f264ae1a2b815a2
 
 build:
-  number: 3
+  number: 4
   script: $R CMD INSTALL $R_ARGS .
 
   files:

--- a/recipes/recipes_emscripten/r-data.table/recipe.yaml
+++ b/recipes/recipes_emscripten/r-data.table/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 1.18.0
+  version: 1.18.2.1
   name: r-data.table
 
 package:
@@ -7,11 +7,13 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/Rdatatable/${{ name[2:] }}/archive/refs/tags/${{ version }}.tar.gz
-  sha256: 40b6bd3ed8664130d257fa0476d7f65f9327552344d532d77ccc4aa1a8bca09a
+  url:
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  sha256: 7663893a84b3e22ff23efb4658bf7809ea4ff5551659cae96f264ae1a2b815a2
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
   files:

--- a/recipes/recipes_emscripten/r-digest/recipe.yaml
+++ b/recipes/recipes_emscripten/r-digest/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 8bf048b49b2d17077138fae758bda56bbd53278d9437f2fdeaedf979c90a13c9
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-digest/recipe.yaml
+++ b/recipes/recipes_emscripten/r-digest/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 8bf048b49b2d17077138fae758bda56bbd53278d9437f2fdeaedf979c90a13c9
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-dplyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-dplyr/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 1.2.0
+  version: 1.2.1
   name: r-dplyr
 
 package:
@@ -10,10 +10,10 @@ source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  sha256: a82c292f2249d439157986b504edd1d99741f467c75bf08969254ca8d441bfa3
+  sha256: 18d66fe2f24cda8b619c177326d39dd015229ab99695fa67d3fa31e4569390e0
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-dplyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-dplyr/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 18d66fe2f24cda8b619c177326d39dd015229ab99695fa67d3fa31e4569390e0
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: r-ellipsis
-  version: 0.3.2
+  version: 0.3.3
 
 package:
   name: ${{ name }}
@@ -10,15 +10,14 @@ source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  sha256: a90266e5eb59c7f419774d5c6d6bd5e09701a26c9218c5933c9bce6765aa1558
+  sha256: da1782bce5c1baf1cf8c69877078db51fabf2693a393b55ff044fd2e32966873
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
-  - ${{ compiler('c') }}
   - cross-r-base_${{ target_platform }}
   - r-rlang
   host:
@@ -28,8 +27,8 @@ requirements:
 
 tests:
 - package_contents:
-    lib:
-    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+    files:
+    - lib/R/library/${{ name[2:] }}/DESCRIPTION
 
 about:
   homepage: https://ellipsis.r-lib.org

--- a/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: da1782bce5c1baf1cf8c69877078db51fabf2693a393b55ff044fd2e32966873
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-fansi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fansi/recipe.yaml
@@ -15,7 +15,7 @@ source:
   - patches/0001-Ignore-custom-limit-checks.patch
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-fansi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fansi/recipe.yaml
@@ -15,7 +15,7 @@ source:
   - patches/0001-Ignore-custom-limit-checks.patch
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-farver/recipe.yaml
+++ b/recipes/recipes_emscripten/r-farver/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 528823b95daab4566137711f1c842027a952bea1b2ae6ff098e2ca512b17fe25
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-farver/recipe.yaml
+++ b/recipes/recipes_emscripten/r-farver/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 528823b95daab4566137711f1c842027a952bea1b2ae6ff098e2ca512b17fe25
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-fastmap/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fastmap/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b1da04a2915d1d057f3c2525e295ef15016a64e6667eac83a14641bbd83b9246
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-fastmap/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fastmap/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b1da04a2915d1d057f3c2525e295ef15016a64e6667eac83a14641bbd83b9246
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-fs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fs/recipe.yaml
@@ -19,7 +19,7 @@ source:
   - patches/0003-Set-UNAME-to-Emscripten.patch
 
 build:
-  number: 0
+  number: 1
   script: |
     $R CMD INSTALL \
     --no-docs \

--- a/recipes/recipes_emscripten/r-fs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fs/recipe.yaml
@@ -19,7 +19,7 @@ source:
   - patches/0003-Set-UNAME-to-Emscripten.patch
 
 build:
-  number: 1
+  number: 2
   script: |
     $R CMD INSTALL \
     --no-docs \

--- a/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 0317dff5e11d9dae7225d5c1794fe16ea1bedc7d535ac98e990925670724c027
 
 build:
-  number: 0
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 0317dff5e11d9dae7225d5c1794fe16ea1bedc7d535ac98e990925670724c027
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-glue/recipe.yaml
+++ b/recipes/recipes_emscripten/r-glue/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: c86f364ba899b8662f5da3e1a75f43ae081ab04e0d51171d052356e7ee4b72a0
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-glue/recipe.yaml
+++ b/recipes/recipes_emscripten/r-glue/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: c86f364ba899b8662f5da3e1a75f43ae081ab04e0d51171d052356e7ee4b72a0
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-haven/recipe.yaml
+++ b/recipes/recipes_emscripten/r-haven/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 9482cd9c3760e1838acf687235317fed97fa6bf79219d3216f0ea447d4b1c9a5
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-haven/recipe.yaml
+++ b/recipes/recipes_emscripten/r-haven/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 9482cd9c3760e1838acf687235317fed97fa6bf79219d3216f0ea447d4b1c9a5
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-hexbin/recipe.yaml
+++ b/recipes/recipes_emscripten/r-hexbin/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 2ed087d6399f247d44e555b69d785b48362445c4c8c77330bbd57d282b49d3e6
 
 build:
-  number: 3
+  number: 4
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-hexbin/recipe.yaml
+++ b/recipes/recipes_emscripten/r-hexbin/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 2ed087d6399f247d44e555b69d785b48362445c4c8c77330bbd57d282b49d3e6
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-htmltools/recipe.yaml
+++ b/recipes/recipes_emscripten/r-htmltools/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 19308618da485818f69dcfeeadd2ddc81d43a736a74519df7b3fd98e13128afd
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-htmltools/recipe.yaml
+++ b/recipes/recipes_emscripten/r-htmltools/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 19308618da485818f69dcfeeadd2ddc81d43a736a74519df7b3fd98e13128afd
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-isoband/recipe.yaml
+++ b/recipes/recipes_emscripten/r-isoband/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: fe8d3d58ca75bbee32f389152ac0058818f3f76f09c9867949531de7abc424ac
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-isoband/recipe.yaml
+++ b/recipes/recipes_emscripten/r-isoband/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: fe8d3d58ca75bbee32f389152ac0058818f3f76f09c9867949531de7abc424ac
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
+++ b/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 75eb910c82b350ec33f094779da0f87bff154c232e4ae39c9896a9b89f3ac82d
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
+++ b/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 75eb910c82b350ec33f094779da0f87bff154c232e4ae39c9896a9b89f3ac82d
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-later/recipe.yaml
+++ b/recipes/recipes_emscripten/r-later/recipe.yaml
@@ -15,7 +15,7 @@ source:
   - patches/0001-Do-not-link-with-atomic-lib.patch
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-later/recipe.yaml
+++ b/recipes/recipes_emscripten/r-later/recipe.yaml
@@ -15,7 +15,7 @@ source:
   - patches/0001-Do-not-link-with-atomic-lib.patch
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-lattice/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lattice/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b72ad4ed2e5269fa7cf668e46f83a9b5d9d5f8fdcbc5b9886531ca19dffca4ba
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-lattice/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lattice/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b72ad4ed2e5269fa7cf668e46f83a9b5d9d5f8fdcbc5b9886531ca19dffca4ba
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: c65db1997b195a7bb0ab3afbb834345ea277b428b2736eeded4242629e86adcb
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.2.2
+  version: 0.2.3
   name: r-lazyeval
 
 package:
@@ -10,16 +10,21 @@ source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  sha256: d6904112a21056222cfcd5eb8175a78aa063afe648a562d9c42c6b960a8820d4
+  sha256: c65db1997b195a7bb0ab3afbb834345ea277b428b2736eeded4242629e86adcb
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }}
   - ${{ compiler('c') }}
+  - r-rlang
+  host:
+  - r-rlang
+  run:
+  - r-rlang
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-lubridate/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lubridate/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 0bc5d10e5a34285d4f9e9c572c058c386b9e1515d8faebc1496b2680138280a8
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-lubridate/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lubridate/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 0bc5d10e5a34285d4f9e9c572c058c386b9e1515d8faebc1496b2680138280a8
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-magrittr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-magrittr/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 3f5b5b1d4e6d12807a95c50b6c88cb1d8af2c5eb5213f08bfe58f278eca2ed23
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-magrittr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-magrittr/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: r-magrittr
-  version: 2.0.4
+  version: 2.0.5
 
 package:
   name: ${{ name }}
@@ -10,10 +10,10 @@ source:
   url:
   - https://cran.r-project.org//src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org//src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  sha256: 6aba790c40de70d8fb4d2db4bebb377418971761b0da7df2141b5d4ad95981f3
+  sha256: 3f5b5b1d4e6d12807a95c50b6c88cb1d8af2c5eb5213f08bfe58f278eca2ed23
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mass/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b07ef1e3c364ce56269b4a8a7759cc9f87c876554f91293437bb578cfe38172f
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mass/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b07ef1e3c364ce56269b4a8a7759cc9f87c876554f91293437bb578cfe38172f
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-matrix/recipe.yaml
+++ b/recipes/recipes_emscripten/r-matrix/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 308b0edd7bcb023a8bb50cc5cec98e66b3658c94a5badfb1ce6024e595fa8a83
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-matrix/recipe.yaml
+++ b/recipes/recipes_emscripten/r-matrix/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 308b0edd7bcb023a8bb50cc5cec98e66b3658c94a5badfb1ce6024e595fa8a83
 
 build:
-  number: 0
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mgcv/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mgcv/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: a98159698afb269e06a46cac1f945bf2b3427a2dd587c6f2efd67ede90089372
 
 build:
-  number: 3
+  number: 4
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mgcv/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mgcv/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: a98159698afb269e06a46cac1f945bf2b3427a2dd587c6f2efd67ede90089372
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mime/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mime/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 7132834cf3c3388eff12bad376d69fbcf8275acc37d36c290e59174fe3c7f3eb
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mime/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mime/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 7132834cf3c3388eff12bad376d69fbcf8275acc37d36c290e59174fe3c7f3eb
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 51b92f1b543d2eb5915478965dab05a9094e1675a160138d49963eb3a0e7fdb8
 
 build:
-  number: 0
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 51b92f1b543d2eb5915478965dab05a9094e1675a160138d49963eb3a0e7fdb8
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-plyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-plyr/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 15b5e7f711d53bf41b8687923983b8ef424563aa2f74c5195feb5b1df1aee103
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-plyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-plyr/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 15b5e7f711d53bf41b8687923983b8ef424563aa2f74c5195feb5b1df1aee103
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-purrr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-purrr/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: ac3bc0fc0e789510042522e6c4294336c71447be8f6921b5ef78b9a9fb86617d
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-purrr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-purrr/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: r-purrr
-  version: 1.2.1
+  version: 1.2.2
 
 package:
   name: ${{ name }}
@@ -10,10 +10,10 @@ source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  sha256: b3bb91dbc67a1cc34080eae960d330626cc76585f80360524b5fceb08febf363
+  sha256: ac3bc0fc0e789510042522e6c4294336c71447be8f6921b5ef78b9a9fb86617d
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-rcpp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rcpp/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: da0c616a71c82150397259516b2ea7558dbd31a5b4a217423ec9666b3a0fcfb7
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-rcpp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rcpp/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: da0c616a71c82150397259516b2ea7558dbd31a5b4a217423ec9666b3a0fcfb7
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-readr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-readr/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 8025d797c183e12ad5ebe4af891dbcb5a8e9bd53aa4765006eb25a07f9a9f473
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-readr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-readr/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 8025d797c183e12ad5ebe4af891dbcb5a8e9bd53aa4765006eb25a07f9a9f473
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-rlang/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rlang/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 8f808ad4f6c1ba37d81b6a4a2cdb4a7d4d30d5bee4ba3e9924352d85a3874357
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-rlang/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rlang/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 1.1.7
+  version: 1.2.0
   name: r-rlang
 
 package:
@@ -10,10 +10,10 @@ source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  sha256: 123c91e7eaacd3514a368a31c30617d36a874def37f6cafdacc0c7d1409be373
+  sha256: 8f808ad4f6c1ba37d81b6a4a2cdb4a7d4d30d5bee4ba3e9924352d85a3874357
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-sp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sp/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 277a4533bc784a08fdbb710757b6af0c7a492691bfb07d8f0b2aa8ad7c857652
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-sp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sp/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 277a4533bc784a08fdbb710757b6af0c7a492691bfb07d8f0b2aa8ad7c857652
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-stringi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-stringi/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 0526decdcd41b7c42278aca96945394c2cb66ba6fdd47fd917b5d3d38ed5c8c6
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/r-stringi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-stringi/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 0526decdcd41b7c42278aca96945394c2cb66ba6fdd47fd917b5d3d38ed5c8c6
 
 build:
-  number: 5
+  number: 6
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/r-sys/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sys/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 051e7332e3074db826efef9059067721864f9d70adc55bbcae3a72e5ae83913a
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-sys/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sys/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 051e7332e3074db826efef9059067721864f9d70adc55bbcae3a72e5ae83913a
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tibble/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tibble/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: fb309f8a1939021b237c7e85ff7ad6e8ff5acd57a6230d220a452094b492b28f
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tibble/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tibble/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: fb309f8a1939021b237c7e85ff7ad6e8ff5acd57a6230d220a452094b492b28f
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tidyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tidyr/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 04c0e6daf0af682af73763a42c027d7171761cdbdbf9ff7a77a0e421343d665a
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tidyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tidyr/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 04c0e6daf0af682af73763a42c027d7171761cdbdbf9ff7a77a0e421343d665a
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-timechange/recipe.yaml
+++ b/recipes/recipes_emscripten/r-timechange/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 6dc8ff9d339d3c4cff7ddf3800383f3e94f41c021f6c7bacccf971e187f73feb
 
 build:
-  number: 3
+  number: 4
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-timechange/recipe.yaml
+++ b/recipes/recipes_emscripten/r-timechange/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 6dc8ff9d339d3c4cff7ddf3800383f3e94f41c021f6c7bacccf971e187f73feb
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tzdb/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tzdb/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 380d5237dbfa722fddb7d1d9ad8520a2b26331dbbb77d51850ded332fcf347db
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-tzdb/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tzdb/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 380d5237dbfa722fddb7d1d9ad8520a2b26331dbbb77d51850ded332fcf347db
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-utf8/recipe.yaml
+++ b/recipes/recipes_emscripten/r-utf8/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 4589f8b72291329e70b7f3a8c20f2feb4e7764eebad2e6976bc9a3eee7686ce9
 
 build:
-  number: 4
+  number: 5
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-utf8/recipe.yaml
+++ b/recipes/recipes_emscripten/r-utf8/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 4589f8b72291329e70b7f3a8c20f2feb4e7764eebad2e6976bc9a3eee7686ce9
 
 build:
-  number: 5
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-vctrs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vctrs/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b45078413e06ac624dddb7221a3a43908b405c8abec09822cb86638d30b0435b
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-vctrs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vctrs/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: r-vctrs
-  version: 0.7.2
+  version: 0.7.3
 
 package:
   name: ${{ name }}
@@ -10,10 +10,10 @@ source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  sha256: 46452f7f5f800e10ad09c287c488a4f6d887c28ef14bcff4bae4f56e6ba57fce
+  sha256: b45078413e06ac624dddb7221a3a43908b405c8abec09822cb86638d30b0435b
 
 build:
-  number: 0
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-vroom/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vroom/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 7d64f6227fdac3ee64c506654bb1d919e407f92fc2d0d5a2398dbb83001e8790
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-vroom/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vroom/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 7d64f6227fdac3ee64c506654bb1d919e407f92fc2d0d5a2398dbb83001e8790
 
 build:
-  number: 0
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-xfun/recipe.yaml
+++ b/recipes/recipes_emscripten/r-xfun/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 5a0cded15fe21273c6d83dd9b72a1c798a1b43841c2166b563723c2ee4b7f475
 
 build:
-  number: 0
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-xfun/recipe.yaml
+++ b/recipes/recipes_emscripten/r-xfun/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 5a0cded15fe21273c6d83dd9b72a1c798a1b43841c2166b563723c2ee4b7f475
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-yaml/recipe.yaml
+++ b/recipes/recipes_emscripten/r-yaml/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 80ccf3dde851133ef3e333b818a817c296c6ccdacfc4709cd466995289cd556c
 
 build:
-  number: 1
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-yaml/recipe.yaml
+++ b/recipes/recipes_emscripten/r-yaml/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 80ccf3dde851133ef3e333b818a817c296c6ccdacfc4709cd466995289cd556c
 
 build:
-  number: 2
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/xeus-r/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-r/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.10.0
+  version: 0.10.1
   name: xeus-r
 
 package:
@@ -7,11 +7,11 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/coursekata/xeus-r/archive/d1b0e0dcf3411d3a409de456ed76a51ff48df377.tar.gz
-  sha256: 6ebc6f6725f32ee58e43f7c6617ef5a6814b3c1c30a6488e72ebe9a2b4ef61dd
+  url: https://github.com/coursekata/xeus-r/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 15057479706ff3ca8fab3cc65fde655642610f1116c5660df6eff6241f3575fa
 
 build:
-  number: 3
+  number: 0
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/xeus-r/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-r/recipe.yaml
@@ -7,14 +7,11 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/jupyter-xeus/xeus-r/archive/refs/tags/${{ version }}.tar.gz
-  sha256: 2c13cab2c362e84e56aa70ed46b4700c6a6346b4ef2366fd4789f6ebe82617bc
-  patches:
-  - patches/0001-Update-linkage.patch
-  - patches/0002-Add-shared-libs.patch
+  url: https://github.com/coursekata/xeus-r/archive/d1b0e0dcf3411d3a409de456ed76a51ff48df377.tar.gz
+  sha256: 6ebc6f6725f32ee58e43f7c6617ef5a6814b3c1c30a6488e72ebe9a2b4ef61dd
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
- **feat(ci): support configurable channels for fork builds**
- **feat(libflang): update libflang to 21.1.0 and port WASM patches**
- **fix(libflang): use cmake wrapper for flang-rt build infrastructure**
- **fix(libflang): patch narrowing conversion in descriptor.cpp for wasm32**
- **fix(libflang): update emscripten-abi pin to 4.x in flang compiler recipe**
- **fix(libflang): patch complex reduction ABI mismatch for wasm32**
- **fix(libflang): bump build number for ABI fix republish**
- **fix(libflang): correct complex reduction ABI adapters for wasm32**
- **fix(r-base): patch Cairo font scaling for emscripten-wasm32**
- **fix(r-base): bundle DejaVu fonts and configure fontconfig for wasm**
- **fix(flang): make activate.sh channel-configurable and version-aware**
- **fix(flang): update toolchain for LLVM 21 runtime rename**
- **fix(r-base): override FLIBS for LLVM 21 runtime rename**
- **fix(r-base): skip dummy main linking test for wasm cross-build**
- **fix(r-base): add Fortran name-mangling override for wasm cross-build**
- **fix: rebuild all R packages against r-base 4.5.3**
- **fix: bump build numbers again to resolve upload conflicts**
- **feat(xeus-r): use coursekata/xeus-r with shared R library and plot defaults**
- **fix(xeus-r): use tagged version URL to satisfy linter**
- **fix(r-base): correct Fortran name-mangling override for LLVM flang**
