### PR TITLE
Add pyzmq

### DIFF
--- a/recipes/recipes_emscripten/pyzmq/recipe.yaml
+++ b/recipes/recipes_emscripten/pyzmq/recipe.yaml
@@ -1,0 +1,119 @@
+context:
+  version: 27.1.0
+  build_number: '0'
+
+package:
+  name: pyzmq
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/p/pyzmq/pyzmq-${{ version }}.tar.gz
+  sha256: ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540
+
+build:
+  number: ${{ build_number }}
+  script: ${{ PYTHON }} -m pip install .
+
+requirements:
+  host:
+  - python >=3.8
+  - cffi; implementation_name == 'pypy'
+  - cython>=3.0.0; implementation_name != 'pypy'
+  - packaging
+  - scikit-build-core>=0.10
+  - pip
+  run:
+  - python >=3.8
+  # - cffi  # implementation_name == "pypy"
+
+tests:
+- python:
+    imports:
+    - pyzmq
+    pip_check: true
+
+about:
+  summary: Python bindings for 0MQ
+  description: |
+    # PyZMQ: Python bindings for ØMQ
+
+    This package contains Python bindings for [ZeroMQ](https://zeromq.org).
+    ØMQ is a lightweight and fast messaging implementation.
+
+    PyZMQ should work with any reasonable version of Python (≥ 3.8), as well as PyPy.
+    PyZMQ supports libzmq ≥ 3.2.2 (including 4.x).
+
+    For a summary of changes to pyzmq, see our
+    [changelog](https://pyzmq.readthedocs.io/en/latest/changelog.html).
+
+    ### ØMQ 3.x, 4.x
+
+    PyZMQ fully supports the stable (not DRAFT) 3.x and 4.x APIs of libzmq,
+    developed at [zeromq/libzmq](https://github.com/zeromq/libzmq).
+    No code to change, no flags to pass,
+    just build pyzmq against the latest and it should work.
+
+    ## Documentation
+
+    See PyZMQ's Sphinx-generated
+    documentation [on Read the Docs](https://pyzmq.readthedocs.io) for API
+    details, and some notes on Python and Cython development. If you want to
+    learn about using ØMQ in general, the excellent [ØMQ
+    Guide](http://zguide.zeromq.org/py:all) is the place to start, which has a
+    Python version of every example. We also have some information on our
+    [wiki](https://github.com/zeromq/pyzmq/wiki).
+
+    ## Downloading
+
+    Unless you specifically want to develop PyZMQ, we recommend downloading
+    the PyZMQ source code or wheels from
+    [PyPI](https://pypi.io/project/pyzmq/),
+    or install with conda.
+
+    You can also get the latest source code from our GitHub repository, but
+    building from the repository will require that you install recent Cython.
+
+    ## Building and installation
+
+    For more detail on building pyzmq, see [our docs](https://pyzmq.readthedocs.io/en/latest/howto/build.html).
+
+    We build wheels for macOS, Windows, and Linux, so you can get a binary on those platforms with:
+
+    ```
+    pip install pyzmq
+    ```
+
+    but compiling from source with `pip install pyzmq` should work in most environments.
+    Make sure you are using the latest pip, or it may not find the right wheels.
+
+    If the wheel doesn't work for some reason, or you want to force pyzmq to be compiled
+    (this is often preferable if you already have libzmq installed and configured the way you want it),
+    you can force installation from source with:
+
+    ```
+    pip install --no-binary=pyzmq pyzmq
+    ```
+
+    ## Old versions
+
+    pyzmq 16 drops support Python 2.6 and 3.2.
+    If you need to use one of those Python versions, you can pin your pyzmq version to before 16:
+
+    ```
+    pip install 'pyzmq<16'
+    ```
+
+    For libzmq 2.0.x, use 'pyzmq\<2.1'
+
+    pyzmq-2.1.11 was the last version of pyzmq to support Python 2.5,
+    and pyzmq ≥ 2.2.0 requires Python ≥ 2.6.
+    pyzmq-13.0.0 introduces PyPy support via CFFI, which only supports libzmq-3.2.2 and newer.
+
+    PyZMQ releases ≤ 2.2.0 matched libzmq versioning, but this is no longer the case,
+    starting with PyZMQ 13.0.0 (it was the thirteenth release, so why not?).
+    PyZMQ ≥ 13.0 follows semantic versioning conventions accounting only for PyZMQ itself.
+  # WARNING: The following PyPI classifier(s) are ambiguous (per PEP 639)
+  # and may not map to the correct SPDX license. Please verify:
+  #   - BSD License
+  license: BSD-3-Clause
+  documentation: https://pyzmq.readthedocs.org

--- a/recipes/recipes_emscripten/pyzmq/recipe.yaml
+++ b/recipes/recipes_emscripten/pyzmq/recipe.yaml
@@ -1,36 +1,57 @@
 context:
+  name: pyzmq
   version: 27.1.0
-  build_number: '0'
 
 package:
-  name: pyzmq
+  name: ${{ name }}
   version: ${{ version }}
 
 source:
-- url: https://pypi.org/packages/source/p/pyzmq/pyzmq-${{ version }}.tar.gz
+- url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540
 
 build:
-  number: ${{ build_number }}
+  number: 0
   script: ${{ PYTHON }} -m pip install .
 
 requirements:
-  host:
-  - python >=3.8
-  - cffi; implementation_name == 'pypy'
-  - cython>=3.0.0; implementation_name != 'pypy'
+  build:
+  - ${{ compiler('c') }}
+  - ${{ compiler('cxx') }}
+  - cross-python_${{ target_platform }}
+  - python
+  - pip
+  - cffi>=1.0.1
+  - cython>=3.0.0
   - packaging
   - scikit-build-core>=0.10
+  - zeromq
+  host:
+  - python
   - pip
+  - cffi>=1.0.1
+  - cython>=3.0.0
+  - packaging
+  - scikit-build-core>=0.10
+  - zeromq
   run:
-  - python >=3.8
-  # - cffi  # implementation_name == "pypy"
+  - python
+  - pip
+  - cffi>=1.0.1
+  - cython>=3.0.0
+  - packaging
+  - scikit-build-core>=0.10
 
 tests:
-- python:
-    imports:
-    - pyzmq
-    pip_check: true
+- script: pytester
+  files:
+    recipe:
+    - test_import_pyzmq.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
 
 about:
   summary: Python bindings for 0MQ
@@ -116,4 +137,10 @@ about:
   # and may not map to the correct SPDX license. Please verify:
   #   - BSD License
   license: BSD-3-Clause
+  license_file:
+  - LICENSE.md
   documentation: https://pyzmq.readthedocs.org
+
+extra:
+  recipe-maintainers:
+  - bmorris3

--- a/recipes/recipes_emscripten/pyzmq/test_import_pyzmq.py
+++ b/recipes/recipes_emscripten/pyzmq/test_import_pyzmq.py
@@ -1,0 +1,3 @@
+def test_import_pyzmq():
+    import pyzmq
+    assert hasattr(pyzmq, '__version__')


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [X] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [X] `context` section with `version` (and optionally `name`)
- [X] `package` section with name and version using Jinja2 templates
- [X] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [X] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [X] `requirements` section (build, host, run as needed)
- [X] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [X] `about` section with license, homepage, summary

---

## Package Details
- **Package Name**: pyzmq
- **Version**: 27.1.0
