### PR TITLE
Add r-readxl

### DIFF
--- a/recipes/recipes_emscripten/r-readxl/recipe.yaml
+++ b/recipes/recipes_emscripten/r-readxl/recipe.yaml
@@ -1,0 +1,56 @@
+context:
+  version: 1.5.0
+  name: r-readxl
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url:
+    - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+    - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  sha256: 908347d27f455ba6f42dc0b0619656166cfd916b3e2cffee4eff867ce5014ce7
+
+build:
+  number: 0
+  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  script: $R CMD INSTALL $R_ARGS .
+
+requirements:
+  build:
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
+  - ${{ compiler('c') }}
+  - r-cellranger
+  - r-tibble
+  - r-cpp11
+  - r-progress
+  host:
+  - r-cellranger
+  - r-tibble
+  - r-cpp11
+  - r-progress
+  run:
+  - r-cellranger
+  - r-tibble
+  - r-cpp11
+  - r-progress
+
+tests:
+- package_contents:
+    lib:
+    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
+
+about:
+  homepage: https://readxl.tidyverse.org/
+  repository: https://github.com/tidyverse/readxl
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Read excel files (.xls and .xlsx) into R
+  description: |
+    Import excel files into R. Supports '.xls' via the embedded 'libxls' C library <https://github.com/libxls/libxls> and '.xlsx' via the embedded 'RapidXML' C++ library <https://rapidxml.sourceforge.net/>. Works on Windows, Mac and Linux without external dependencies.
+
+extra:
+  recipe-maintainers:
+    - IsabelParedes


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## Package Details
- **Package Name**: r-readxl
- **Version**: 1.5.0

- [x] Tested
<img width="508" height="404" alt="image" src="https://github.com/user-attachments/assets/b00ef53a-c42c-4f48-aba3-7ef8958c28a3" />
