### PR TITLE
Remove r-base-abi

### DIFF
--- a/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
@@ -2,37 +2,23 @@ context:
   name: cross-r-base_emscripten-wasm32
   version: 4.5.3
 
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
 build:
-  number: 0
+  number: 1
 
-outputs:
-- package:
-    name: ${{ name }}
-    version: ${{ version }}
-  requirements:
-    run:
-      - r-base-abi ==${{ version }}
-      - emscripten_emscripten-wasm32
-    run_exports:
-      strong:
-      - r-base-abi ==${{ version }}
-  tests:
-  - package_contents:
-      files:
-      - etc/conda/activate.d/activate_z-${{ name }}.sh
-      - etc/conda/deactivate.d/deactivate_z-${{ name }}.sh
+requirements:
+  run:
+  - r-base ==${{ version }}
+  - emscripten_emscripten-wasm32
 
-- package:
-    name: r-base-abi
-    version: ${{ version }}
-  build:
-    noarch: generic
-    script: echo "r-base-abi is built"
-  requirements:
-    run:
-    - r-base ==${{ version }}
-  tests:
-  - script: echo "r-base-abi is an empty package."
+tests:
+- package_contents:
+    files:
+    - etc/conda/activate.d/activate_z-${{ name }}.sh
+    - etc/conda/deactivate.d/deactivate_z-${{ name }}.sh
 
 about:
   summary: Package to cross-compile R packages to WebAssembly using Emscripten.
@@ -41,4 +27,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - IsabelParedes
+  - IsabelParedes


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: cross-r-base
- **Version**: 4.5.3

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

- `r-base-abi` is no longer needed, relaxing the `r-base` run constraints