### PR TITLE
Rebuild R packages for R v4.5.3

### DIFF
--- a/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
@@ -1,13 +1,13 @@
 context:
   name: cross-r-base_emscripten-wasm32
-  version: 4.6.0
+  version: 4.5.3
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:

--- a/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
@@ -1,13 +1,13 @@
 context:
   name: cross-r-base_emscripten-wasm32
-  version: 4.5.3
+  version: 4.6.0
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   run:

--- a/recipes/recipes_emscripten/bioconductor-s4vectors/recipe.yaml
+++ b/recipes/recipes_emscripten/bioconductor-s4vectors/recipe.yaml
@@ -1,19 +1,17 @@
 context:
+  name : S4Vectors
   version: 0.50.1
-  name: bioconductor-s4vectors
-  ccame : S4Vectors
+
 package:
-  name: ${{ name }}
-  version: ${{ version | replace('-', '_') }}
+  name: bioconductor-${{ name | lower }}
+  version: ${{ version }}
 
 source:
-  url:
-  - https://www.bioconductor.org/packages/release/bioc/src/contrib/${{ ccame }}_${{ version }}.tar.gz
+  url: https://www.bioconductor.org/packages/release/bioc/src/contrib/${{ name }}_${{ version }}.tar.gz
   sha256: a85dac9e625424bc06501a47ab57abb0d2b4c53aeb4714bd88397cc3cd9c690e
 
 build:
-  number: 0
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -22,6 +20,7 @@ requirements:
   - ${{ compiler('c') }}
   - bioconductor-biocgenerics
   host:
+  - r-base ==${{ r_base }}
   - bioconductor-biocgenerics
   run:
   - bioconductor-biocgenerics
@@ -29,7 +28,7 @@ requirements:
 tests:
 - package_contents:
     lib:
-    - R/library/${{ ccame }}/libs/${{ ccame }}.so
+    - R/library/${{ name }}/libs/${{ name }}.so
 
 about:
   repository: https://github.com/Bioconductor/S4Vectors

--- a/recipes/recipes_emscripten/bioconductor-s4vectors/recipe.yaml
+++ b/recipes/recipes_emscripten/bioconductor-s4vectors/recipe.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   build:
-  - cross-r-base_${{ target_platform }} ==${{ r_base }}
+  - cross-r-base_${{ target_platform }} == 4.5.3
   - ${{ compiler('c') }}
-  - bioconductor-biocgenerics
+  - bioconductor-biocgenerics # Not yet available for R 4.6.0
   host:
-  - r-base ==${{ r_base }}
+  - r-base == 4.5.3
   - bioconductor-biocgenerics
   run:
   - bioconductor-biocgenerics

--- a/recipes/recipes_emscripten/r-askpass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-askpass/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 6c2106a74c44a748f2cea795d9686e27a0058a90debcfd8558b62b06aec0c7dd
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -23,6 +22,7 @@ requirements:
   - ${{ compiler('c') }}
   - r-sys
   host:
+  - r-base ==${{ r_base }}
   - r-sys
   run:
   - r-sys

--- a/recipes/recipes_emscripten/r-base64enc/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base64enc/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 3c7e9d22f7409fa2989008fa6e980c3dd8e2693eb20676acf2470ae7addb0816
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-bit/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 48fe21c5d04c7b724d695eeb60074395c0c631a7fb234e2075de92471445de08
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-bit64/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit64/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: fbc0ce142fc22c9a9fdcbac930a814dfb648563d4b6a77dff739c23cc81319b7
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -23,6 +22,7 @@ requirements:
   - ${{ compiler('c') }}
   - r-bit
   host:
+  - r-base ==${{ r_base }}
   - r-bit
   run:
   - r-bit

--- a/recipes/recipes_emscripten/r-bit64/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit64/recipe.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/r-lib/${{ name[2:] }}/archive/refs/tags/${{ version }}.tar.gz
-  sha256: fbc0ce142fc22c9a9fdcbac930a814dfb648563d4b6a77dff739c23cc81319b7
+  sha256: b9282f50dadd726896242af5d0788eed6f2df826c40c6f4842fa81dbd31d4e79
 
 build:
   number: 6

--- a/recipes/recipes_emscripten/r-bit64/recipe.yaml
+++ b/recipes/recipes_emscripten/r-bit64/recipe.yaml
@@ -1,15 +1,13 @@
 context:
-  version: 4.6.0-1
   name: r-bit64
+  version: 4.8.2
 
 package:
   name: ${{ name }}
-  version: ${{ version | replace('-', '_') }}
+  version: ${{ version }}
 
 source:
-  url:
-    - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-    - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  url: https://github.com/r-lib/${{ name[2:] }}/archive/refs/tags/${{ version }}.tar.gz
   sha256: fbc0ce142fc22c9a9fdcbac930a814dfb648563d4b6a77dff739c23cc81319b7
 
 build:

--- a/recipes/recipes_emscripten/r-cachem/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cachem/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 550839fc2ae5d865db475ba2c1714144f07fa0c052c72135b0e4a70287492e21
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -24,6 +23,7 @@ requirements:
   - r-rlang
   - r-fastmap
   host:
+  - r-base ==${{ r_base }}
   - r-rlang
   - r-fastmap
   run:

--- a/recipes/recipes_emscripten/r-cli/recipe.yaml
+++ b/recipes/recipes_emscripten/r-cli/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: b2b58d6dd82f5798b335e39c00591686a01fd3e94399ef898e146173e36f18f9
 
 build:
-  number: 0
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-colorspace/recipe.yaml
+++ b/recipes/recipes_emscripten/r-colorspace/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: ec71499d33ef5d72b7fb3359b8320639e06e413abad61a070201178a254b153e
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-data.table/recipe.yaml
+++ b/recipes/recipes_emscripten/r-data.table/recipe.yaml
@@ -11,8 +11,7 @@ source:
   sha256: 40b6bd3ed8664130d257fa0476d7f65f9327552344d532d77ccc4aa1a8bca09a
 
 build:
-  number: 3
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 4
   script: $R CMD INSTALL $R_ARGS .
 
   files:
@@ -23,6 +22,7 @@ requirements:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   host:
+  - r-base ==${{ r_base }}
   - zlib
   run:
   - zlib

--- a/recipes/recipes_emscripten/r-digest/recipe.yaml
+++ b/recipes/recipes_emscripten/r-digest/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 8bf048b49b2d17077138fae758bda56bbd53278d9437f2fdeaedf979c90a13c9
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -22,6 +21,8 @@ requirements:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-dplyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-dplyr/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 18d66fe2f24cda8b619c177326d39dd015229ab99695fa67d3fa31e4569390e0
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -33,6 +32,7 @@ requirements:
   - r-tidyselect
   - r-vctrs
   host:
+  - r-base ==${{ r_base }}
   - r-cli
   - r-generics
   - r-glue

--- a/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ellipsis/recipe.yaml
@@ -15,8 +15,7 @@ source:
 # TODO: remove from emscripten-forge once the noarch version is available on
 # conda-forge
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   noarch: generic
   script: $R CMD INSTALL $R_ARGS .
 
@@ -25,6 +24,7 @@ requirements:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-rlang
   host:
+  - r-base ==${{ r_base }}
   - r-rlang
   run:
   - r-rlang

--- a/recipes/recipes_emscripten/r-fansi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fansi/recipe.yaml
@@ -15,14 +15,15 @@ source:
   - patches/0001-Ignore-custom-limit-checks.patch
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-farver/recipe.yaml
+++ b/recipes/recipes_emscripten/r-farver/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 528823b95daab4566137711f1c842027a952bea1b2ae6ff098e2ca512b17fe25
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-fastmap/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fastmap/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: b1da04a2915d1d057f3c2525e295ef15016a64e6667eac83a14641bbd83b9246
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -22,6 +21,8 @@ requirements:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-fs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-fs/recipe.yaml
@@ -19,8 +19,7 @@ source:
   - patches/0003-Set-UNAME-to-Emscripten.patch
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: |
     $R CMD INSTALL \
     --no-docs \
@@ -35,6 +34,8 @@ requirements:
   - ${{ compiler('c') }}
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - pkg-config
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
+++ b/recipes/recipes_emscripten/r-ggrepel/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 0317dff5e11d9dae7225d5c1794fe16ea1bedc7d535ac98e990925670724c027
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-glue/recipe.yaml
+++ b/recipes/recipes_emscripten/r-glue/recipe.yaml
@@ -14,14 +14,15 @@ source:
   sha256: 1c55905d3efc3d5c199ceb0bd12218e97f0d4c64df6038ff41ecef415478a122
 
 build:
-  number: 0
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-gtools/recipe.yaml
+++ b/recipes/recipes_emscripten/r-gtools/recipe.yaml
@@ -4,26 +4,27 @@ context:
 
 package:
   name: ${{ name }}
-  version: ${{ version | replace('-', '_') }}
+  version: ${{ version }}
 
 source:
   url: https://cran.r-project.org/src/contrib/${{ name[2:]}}_${{ version }}.tar.gz
   sha256: dee9b6c1152db1a5dc427d074b32bbbb738708683f17a95e0e95e4d79fdf174b
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:
     lib:
-    - R/library/${{ name[2:]  }}/libs/${{ name[2:]  }}.so
+    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://cran.r-project.org/package=gtools
@@ -31,7 +32,6 @@ about:
   license: GPL-2.0-only
   license_family: GPL2
   license_file: GPL-2
-
 
 extra:
   recipe-maintainers:

--- a/recipes/recipes_emscripten/r-haven/recipe.yaml
+++ b/recipes/recipes_emscripten/r-haven/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 9482cd9c3760e1838acf687235317fed97fa6bf79219d3216f0ea447d4b1c9a5
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -32,6 +31,7 @@ requirements:
   - r-vctrs
   - r-cpp11
   host:
+  - r-base ==${{ r_base }}
   - r-cli
   - r-forcats
   - r-hms

--- a/recipes/recipes_emscripten/r-hexbin/recipe.yaml
+++ b/recipes/recipes_emscripten/r-hexbin/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 2ed087d6399f247d44e555b69d785b48362445c4c8c77330bbd57d282b49d3e6
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-htmltools/recipe.yaml
+++ b/recipes/recipes_emscripten/r-htmltools/recipe.yaml
@@ -14,8 +14,7 @@ source:
   sha256: 19308618da485818f69dcfeeadd2ddc81d43a736a74519df7b3fd98e13128afd
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -27,6 +26,7 @@ requirements:
   - r-fastmap
   - r-rlang
   host:
+  - r-base ==${{ r_base }}
   - r-base64enc
   - r-digest
   - r-fastmap

--- a/recipes/recipes_emscripten/r-isoband/recipe.yaml
+++ b/recipes/recipes_emscripten/r-isoband/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: fe8d3d58ca75bbee32f389152ac0058818f3f76f09c9867949531de7abc424ac
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -26,6 +25,7 @@ requirements:
   - r-rlang
   - r-cpp11
   host:
+  - r-base ==${{ r_base }}
   - r-cli
   - r-rlang
   - r-cpp11

--- a/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
+++ b/recipes/recipes_emscripten/r-jsonlite/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 75eb910c82b350ec33f094779da0f87bff154c232e4ae39c9896a9b89f3ac82d
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -22,6 +21,8 @@ requirements:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-later/recipe.yaml
+++ b/recipes/recipes_emscripten/r-later/recipe.yaml
@@ -15,8 +15,7 @@ source:
   - patches/0001-Do-not-link-with-atomic-lib.patch
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -27,6 +26,7 @@ requirements:
   - r-rcpp
   - r-rlang
   host:
+  - r-base ==${{ r_base }}
   - r-rcpp
   - r-rlang
   run:
@@ -44,7 +44,7 @@ about:
   license: MIT
   license_file: LICENSE
   summary: |
-    Schedule an R function or formula to run after a specified period of time.
+    Utilities for Scheduling Functions to Execute Later with Event Loops
   description: |
     Executes arbitrary R or C functions some time after the current time, after
     the R execution stack has emptied. The functions are scheduled in an event loop.

--- a/recipes/recipes_emscripten/r-lattice/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lattice/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: b72ad4ed2e5269fa7cf668e46f83a9b5d9d5f8fdcbc5b9886531ca19dffca4ba
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - ${{ compiler('c') }}
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lazyeval/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: c65db1997b195a7bb0ab3afbb834345ea277b428b2736eeded4242629e86adcb
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -23,6 +22,7 @@ requirements:
   - ${{ compiler('c') }}
   - r-rlang
   host:
+  - r-base ==${{ r_base }}
   - r-rlang
   run:
   - r-rlang

--- a/recipes/recipes_emscripten/r-lubridate/recipe.yaml
+++ b/recipes/recipes_emscripten/r-lubridate/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 0bc5d10e5a34285d4f9e9c572c058c386b9e1515d8faebc1496b2680138280a8
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -24,6 +23,7 @@ requirements:
   - r-generics
   - r-timechange
   host:
+  - r-base ==${{ r_base }}
   - r-generics
   - r-timechange
   run:

--- a/recipes/recipes_emscripten/r-magrittr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-magrittr/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 3f5b5b1d4e6d12807a95c50b6c88cb1d8af2c5eb5213f08bfe58f278eca2ed23
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-mass/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mass/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: b07ef1e3c364ce56269b4a8a7759cc9f87c876554f91293437bb578cfe38172f
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-matrix/recipe.yaml
+++ b/recipes/recipes_emscripten/r-matrix/recipe.yaml
@@ -1,20 +1,19 @@
 context:
-  name: r-matrix
+  name: r-Matrix
   version: 1.7-5
 
 package:
-  name: ${{ name }}
-  version: ${{ version|replace('-', '_') }}
+  name: ${{ name | lower }}
+  version: ${{ version | replace('-', '_') }}
 
 source:
   url:
-  - https://cran.r-project.org/src/contrib/Matrix_${{ version }}.tar.gz
-  - https://cloud.r-project.org/src/contrib/Matrix_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 308b0edd7bcb023a8bb50cc5cec98e66b3658c94a5badfb1ce6024e595fa8a83
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -23,17 +22,18 @@ requirements:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - r-lattice
   host:
+  - r-base ==${{ r_base }}
   - r-lattice
-  - libblas>=3.12
-  - liblapack>=3.12
-  - libflang                  # for FortranRuntime
+  - libblas
+  - liblapack
+  - libflang
   run:
   - r-lattice
 
 tests:
 - package_contents:
     lib:
-    - R/library/Matrix/libs/Matrix.so
+    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: http://Matrix.R-forge.R-project.org/

--- a/recipes/recipes_emscripten/r-matrixstats/recipe.yaml
+++ b/recipes/recipes_emscripten/r-matrixstats/recipe.yaml
@@ -1,7 +1,6 @@
 context:
+  name: r-matrixStats
   version: 1.5.0
-  name: r-matrixstats
-  ccname: matrixStats
 
 package:
   name: ${{ name | lower }}
@@ -9,24 +8,25 @@ package:
 
 source:
   url:
-  - https://cran.r-project.org/src/contrib/${{ ccname }}_${{ version }}.tar.gz
-  - https://cloud.r-project.org/src/contrib/${{ ccname }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 12996c5f3e6fc202a43e1087f16a71b7fa93d7e908f512542c7ee89cf95dcc15
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:
     lib:
-    - R/library/${{ ccname }}/libs/${{ ccname }}.so
+    - R/library/${{ name[2:] }}/libs/${{ name[2:] }}.so
 
 about:
   homepage: https://cran.r-project.org/package=matrixStats
@@ -36,10 +36,11 @@ about:
   license_file: LICENSE
   summary: High-performing functions operating on rows and columns of matrices
   description: |
-    High-performing functions operating on rows and columns of matrices, e.g. col / rowMedians(), col / rowRanks(), and col / rowSds().
-    Functions optimized per data type and for subsetted calculations such that both memory usage and processing time is minimized.
-    There are also optimized vector-based methods, e.g.
-    binMeans(), madDiff() and weightedMedian().
+    High-performing functions operating on rows and columns of matrices, e.g.
+    col / rowMedians(), col / rowRanks(), and col / rowSds(). Functions
+    optimized per data type and for subsetted calculations such that both memory
+    usage and processing time is minimized. There are also optimized vector-
+    based methods, e.g. binMeans(), madDiff() and weightedMedian().
 
 extra:
   recipe-maintainers:

--- a/recipes/recipes_emscripten/r-mgcv/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mgcv/recipe.yaml
@@ -4,7 +4,7 @@ context:
 
 package:
   name: ${{ name }}
-  version: ${{ version|replace('-', '_') }}
+  version: ${{ version | replace('-', '_') }}
 
 source:
   url:
@@ -13,8 +13,7 @@ source:
   sha256: a98159698afb269e06a46cac1f945bf2b3427a2dd587c6f2efd67ede90089372
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-mime/recipe.yaml
+++ b/recipes/recipes_emscripten/r-mime/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 7132834cf3c3388eff12bad376d69fbcf8275acc37d36c290e59174fe3c7f3eb
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-nlme/recipe.yaml
+++ b/recipes/recipes_emscripten/r-nlme/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 51b92f1b543d2eb5915478965dab05a9094e1675a160138d49963eb3a0e7fdb8
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-plyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-plyr/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 15b5e7f711d53bf41b8687923983b8ef424563aa2f74c5195feb5b1df1aee103
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -24,6 +23,7 @@ requirements:
   - ${{ compiler('cxx') }}
   - r-rcpp
   host:
+  - r-base ==${{ r_base }}
   - r-rcpp
   run:
   - r-rcpp

--- a/recipes/recipes_emscripten/r-purrr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-purrr/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: ac3bc0fc0e789510042522e6c4294336c71447be8f6921b5ef78b9a9fb86617d
 
 build:
-  number: 0
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -27,6 +26,7 @@ requirements:
   - r-rlang
   - r-vctrs
   host:
+  - r-base ==${{ r_base }}
   - r-cli >=3.6.3
   - r-lifecycle >=1.0.4
   - r-magrittr

--- a/recipes/recipes_emscripten/r-randomforest/recipe.yaml
+++ b/recipes/recipes_emscripten/r-randomforest/recipe.yaml
@@ -8,23 +8,22 @@ package:
 
 source:
   url:
-    - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-    - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: aad33227b648bad50412849d7e0fed00fd07f1d1d4a14fa015b4b9f939b04a11
 
 build:
-  number: 0
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
-    - cross-r-base_${{ target_platform }} ==${{ r_base }}
-    - ${{ compiler('c') }}
-    - ${{ compiler('fortran') }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
+  - ${{ compiler('c') }}
+  - ${{ compiler('fortran') }}
   host:
-    - r-base ==${{ r_base }}
-    - libflang
+  - r-base ==${{ r_base }}
+  - libflang
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-rcpp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rcpp/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: da0c616a71c82150397259516b2ea7558dbd31a5b4a217423ec9666b3a0fcfb7
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:
@@ -34,8 +35,10 @@ about:
   license_file: GPL-2
   summary: Seamless R and C++ Integration
   description: |
-    Executes arbitrary R or C functions some time after the current time, after
-    the R execution stack has emptied. The functions are scheduled in an event loop.
+    The 'Rcpp' package provides R functions as well as C++ classes which offer a
+    seamless integration of R and C++. Many R data types and objects can be
+    mapped back and forth to C++ equivalents which facilitates both writing of
+    new code as well as easier integration of third-party libraries.
 
 extra:
   recipe-maintainers:

--- a/recipes/recipes_emscripten/r-rcpp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rcpp/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 1.1.1
+  version: 1.1.1-1.1
   name: r-Rcpp
 
 package:
@@ -10,10 +10,10 @@ source:
   url:
   - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-  sha256: da0c616a71c82150397259516b2ea7558dbd31a5b4a217423ec9666b3a0fcfb7
+  sha256: 32e5d5fee4080c8ca315f31b74c3eaa6367a1900e92e860e00390c9565f5fbe1
 
 build:
-  number: 3
+  number: 0
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:

--- a/recipes/recipes_emscripten/r-readr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-readr/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 8025d797c183e12ad5ebe4af891dbcb5a8e9bd53aa4765006eb25a07f9a9f473
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -34,6 +33,7 @@ requirements:
   - r-cpp11
   - r-tzdb
   host:
+  - r-base ==${{ r_base }}
   - r-cli
   - r-clipr
   - r-crayon

--- a/recipes/recipes_emscripten/r-readxl/recipe.yaml
+++ b/recipes/recipes_emscripten/r-readxl/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 908347d27f455ba6f42dc0b0619656166cfd916b3e2cffee4eff867ce5014ce7
 
 build:
-  number: 0
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -26,6 +25,7 @@ requirements:
   - r-cpp11
   - r-progress
   host:
+  - r-base ==${{ r_base }}
   - r-cellranger
   - r-tibble
   - r-cpp11
@@ -49,7 +49,10 @@ about:
   license_file: LICENSE
   summary: Read excel files (.xls and .xlsx) into R
   description: |
-    Import excel files into R. Supports '.xls' via the embedded 'libxls' C library <https://github.com/libxls/libxls> and '.xlsx' via the embedded 'RapidXML' C++ library <https://rapidxml.sourceforge.net/>. Works on Windows, Mac and Linux without external dependencies.
+    Import excel files into R. Supports '.xls' via the embedded 'libxls' C
+    library <https://github.com/libxls/libxls> and '.xlsx' via the embedded
+    'RapidXML' C++ library <https://rapidxml.sourceforge.net/>. Works on
+    Windows, Mac and Linux without external dependencies.
 
 extra:
   recipe-maintainers:

--- a/recipes/recipes_emscripten/r-reshape2/recipe.yaml
+++ b/recipes/recipes_emscripten/r-reshape2/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: r-reshape2
-  version: '1.4.5'
+  version: 1.4.5
 
 package:
   name: ${{ name }}
@@ -13,8 +13,7 @@ source:
   sha256: 0ead5acd0153e5073b3c24e8e782982a4eab3aaa768ba17700d796fb13b68cef
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -25,14 +24,14 @@ requirements:
   - r-stringr
   - r-plyr
   host:
+  - r-base ==${{ r_base }}
   - r-rcpp
   - r-stringr
   - r-plyr
   run:
   - r-rcpp
-  - r-stringr 
+  - r-stringr
   - r-plyr
-
 
 tests:
 - package_contents:
@@ -44,7 +43,9 @@ about:
   repository: https://github.com/hadley/reshape
   license: MIT
   license_file: LICENSE
-  summary: Flexibly restructure and aggregate data using just two functions, melt and 'dcast' (or 'acast').
+  summary: |
+    Flexibly restructure and aggregate data using just two functions, melt and
+    'dcast' (or 'acast').
 
 extra:
   recipe-maintainers:

--- a/recipes/recipes_emscripten/r-rlang/recipe.yaml
+++ b/recipes/recipes_emscripten/r-rlang/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 8f808ad4f6c1ba37d81b6a4a2cdb4a7d4d30d5bee4ba3e9924352d85a3874357
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-s7/recipe.yaml
+++ b/recipes/recipes_emscripten/r-s7/recipe.yaml
@@ -8,21 +8,20 @@ package:
 
 source:
   url:
-    - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-    - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 6f33245dde05b74265b1c4d379e034bc3a8923d41e7b52e6e75a75ce97d42af7
 
 build:
-  number: 0
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
-    - cross-r-base_${{ target_platform }} ==${{ r_base }}
-    - ${{ compiler('c') }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
+  - ${{ compiler('c') }}
   host:
-    - r-base ==${{ r_base }}
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-sp/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sp/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 277a4533bc784a08fdbb710757b6af0c7a492691bfb07d8f0b2aa8ad7c857652
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -23,6 +22,7 @@ requirements:
   - ${{ compiler('c') }}
   - r-lattice
   host:
+  - r-base ==${{ r_base }}
   - r-lattice
   run:
   - r-lattice

--- a/recipes/recipes_emscripten/r-statmod/recipe.yaml
+++ b/recipes/recipes_emscripten/r-statmod/recipe.yaml
@@ -8,23 +8,22 @@ package:
 
 source:
   url:
-    - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-    - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 5f83d82043c5e26f1048fc0139580da1b7e40becf95fb4cb26ed3afcd46a581d
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
-    - cross-r-base_${{ target_platform }} ==${{ r_base }}
-    - ${{ compiler('c') }}
-    - ${{ compiler('fortran') }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
+  - ${{ compiler('c') }}
+  - ${{ compiler('fortran') }}
   host:
-    - r-base ==${{ r_base }}
-    - libflang
+  - r-base ==${{ r_base }}
+  - libflang
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-stringi/recipe.yaml
+++ b/recipes/recipes_emscripten/r-stringi/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 0526decdcd41b7c42278aca96945394c2cb66ba6fdd47fd917b5d3d38ed5c8c6
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
   - pkg-config
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-sys/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sys/recipe.yaml
@@ -8,19 +8,20 @@ package:
 
 source:
   url:
-    - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
-    - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cran.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name[2:] }}_${{ version }}.tar.gz
   sha256: 051e7332e3074db826efef9059067721864f9d70adc55bbcae3a72e5ae83913a
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
-    - cross-r-base_${{ target_platform }} ==${{ r_base }}
-    - ${{ compiler('c') }}
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
+  - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:
@@ -35,11 +36,11 @@ about:
   license_file: LICENSE
   summary: Powerful and Reliable Tools for Running System Commands in R
   description: |
-   Drop-in replacements for the base system2() function with fine control and
-   consistent behavior across platforms. Supports clean interruption, timeout,
-   background tasks, and streaming STDIN / STDOUT / STDERR over binary or text
-   connections. Arguments on Windows automatically get encoded and quoted to
-   work on different locales.
+    Drop-in replacements for the base system2() function with fine control and
+    consistent behavior across platforms. Supports clean interruption, timeout,
+    background tasks, and streaming STDIN / STDOUT / STDERR over binary or text
+    connections. Arguments on Windows automatically get encoded and quoted to
+    work on different locales.
 
 extra:
   recipe-maintainers:

--- a/recipes/recipes_emscripten/r-tibble/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tibble/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: fb309f8a1939021b237c7e85ff7ad6e8ff5acd57a6230d220a452094b492b28f
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -29,6 +28,7 @@ requirements:
   - r-rlang
   - r-vctrs
   host:
+  - r-base ==${{ r_base }}
   - r-fansi
   - r-lifecycle
   - r-magrittr

--- a/recipes/recipes_emscripten/r-tidyr/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tidyr/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 04c0e6daf0af682af73763a42c027d7171761cdbdbf9ff7a77a0e421343d665a
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -34,6 +33,7 @@ requirements:
   - r-vctrs
   - r-cpp11
   host:
+  - r-base ==${{ r_base }}
   - r-cli
   - r-dplyr
   - r-glue

--- a/recipes/recipes_emscripten/r-timechange/recipe.yaml
+++ b/recipes/recipes_emscripten/r-timechange/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 6dc8ff9d339d3c4cff7ddf3800383f3e94f41c021f6c7bacccf971e187f73feb
 
 build:
-  number: 3
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 4
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -23,6 +22,7 @@ requirements:
   - ${{ compiler('c') }}
   - r-cpp11
   host:
+  - r-base ==${{ r_base }}
   - r-cpp11
   run:
   - r-cpp11

--- a/recipes/recipes_emscripten/r-tzdb/recipe.yaml
+++ b/recipes/recipes_emscripten/r-tzdb/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 380d5237dbfa722fddb7d1d9ad8520a2b26331dbbb77d51850ded332fcf347db
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -22,6 +21,7 @@ requirements:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('cxx') }}
   host:
+  - r-base ==${{ r_base }}
   - r-cpp11
   run:
   - r-cpp11

--- a/recipes/recipes_emscripten/r-utf8/recipe.yaml
+++ b/recipes/recipes_emscripten/r-utf8/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 4589f8b72291329e70b7f3a8c20f2feb4e7764eebad2e6976bc9a3eee7686ce9
 
 build:
-  number: 5
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 6
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-vctrs/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vctrs/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: b45078413e06ac624dddb7221a3a43908b405c8abec09822cb86638d30b0435b
 
 build:
-  number: 0
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -26,6 +25,7 @@ requirements:
   - r-rlang
   - r-lifecycle >=1.0.4
   host:
+  - r-base ==${{ r_base }}
   - r-cli >=3.6.3
   - r-glue
   - r-rlang

--- a/recipes/recipes_emscripten/r-vroom/recipe.yaml
+++ b/recipes/recipes_emscripten/r-vroom/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: 7d64f6227fdac3ee64c506654bb1d919e407f92fc2d0d5a2398dbb83001e8790
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -37,6 +36,7 @@ requirements:
   - r-cpp11
   - r-progress
   host:
+  - r-base ==${{ r_base }}
   - r-bit64
   - r-cli
   - r-crayon

--- a/recipes/recipes_emscripten/r-writexl/recipe.yaml
+++ b/recipes/recipes_emscripten/r-writexl/recipe.yaml
@@ -13,8 +13,7 @@ source:
   sha256: d0574a29ea22bd78785f50c7cd23c6e10036f65321e26d55a694e931467660d3
 
 build:
-  number: 0
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 1
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -22,6 +21,7 @@ requirements:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
   host:
+  - r-base ==${{ r_base }}
   - zlib
 
 tests:

--- a/recipes/recipes_emscripten/r-xfun/recipe.yaml
+++ b/recipes/recipes_emscripten/r-xfun/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 5a0cded15fe21273c6d83dd9b72a1c798a1b43841c2166b563723c2ee4b7f475
 
 build:
-  number: 1
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 2
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/recipes/recipes_emscripten/r-yaml/recipe.yaml
+++ b/recipes/recipes_emscripten/r-yaml/recipe.yaml
@@ -13,14 +13,15 @@ source:
   sha256: 80ccf3dde851133ef3e333b818a817c296c6ccdacfc4709cd466995289cd556c
 
 build:
-  number: 2
-  string: r${{ r_abi_build_tag }}_h${{ hash }}_${{ build_number }}
+  number: 3
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
   build:
   - cross-r-base_${{ target_platform }} ==${{ r_base }}
   - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
 
 tests:
 - package_contents:

--- a/variant.yaml
+++ b/variant.yaml
@@ -49,12 +49,16 @@ fortran_compiler:
 
 r_base:
   - 4.5.3
-  - 4.6.0
+r_abi_build_tag:
+  - 453
 
 zip_keys:
   -
     - cxx_compiler_version
     - c_compiler_version
+  -
+    - r_base
+    - r_abi_build_tag
 
 cuda_compiler:
   - undefined

--- a/variant.yaml
+++ b/variant.yaml
@@ -49,16 +49,12 @@ fortran_compiler:
 
 r_base:
   - 4.5.3
-r_abi_build_tag:
-  - 453
+  - 4.6.0
 
 zip_keys:
   -
     - cxx_compiler_version
     - c_compiler_version
-  -
-    - r_base
-    - r_abi_build_tag
 
 cuda_compiler:
   - undefined


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [x] Or reset build number to 0 if updating the package to a newer version

---

## Package Details
- **Package Name**: All R packages except `r-arrow`
- **Version**: R v4.6.0

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

- Run dependencies must be updated after the removal of `r-base-abi`

