### PR TITLE
Add pyscipopt

### DIFF
--- a/recipes/recipes_emscripten/pyscipopt/build.sh
+++ b/recipes/recipes_emscripten/pyscipopt/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -x
+
+# Build the Cython extension as an Emscripten side module.
+FLAGS="-fPIC -sWASM_BIGINT -sSIDE_MODULE=1"
+export CFLAGS="${CFLAGS:-} ${FLAGS}"
+export CXXFLAGS="${CXXFLAGS:-} ${FLAGS}"
+
+# PySCIPOpt's setup.py only links against `-lscip`, but on Emscripten SCIP and
+# its dependencies are static archives. A lazy `-l` placed before the Cython
+# objects would not pull anything in, so force-load libscip.a with
+# --whole-archive and list its (lazy) transitive dependencies afterwards so
+# their referenced members get linked in the right order.
+export LDFLAGS="${LDFLAGS:-} -sSIDE_MODULE=1 -sWASM_BIGINT -L${PREFIX}/lib \
+  -Wl,--whole-archive ${PREFIX}/lib/libscip.a -Wl,--no-whole-archive \
+  ${PREFIX}/lib/libsoplex.a \
+  ${PREFIX}/lib/libgmpxx.a \
+  ${PREFIX}/lib/libgmp.a \
+  ${PREFIX}/lib/libmpfr.a \
+  ${PREFIX}/lib/libz.a"
+
+# Tell setup.py where to find SCIP's headers and libraries.
+export SCIPOPTDIR="${PREFIX}"
+
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vvv

--- a/recipes/recipes_emscripten/pyscipopt/recipe.yaml
+++ b/recipes/recipes_emscripten/pyscipopt/recipe.yaml
@@ -55,6 +55,7 @@ tests:
         - pytester
       run:
         - pytester-run
+        - pyjs < 4.0.4
     files:
       recipe:
         - test_pyscipopt.py

--- a/recipes/recipes_emscripten/pyscipopt/recipe.yaml
+++ b/recipes/recipes_emscripten/pyscipopt/recipe.yaml
@@ -1,0 +1,68 @@
+schema_version: 1
+
+context:
+  version: "6.2.1"
+
+package:
+  name: pyscipopt
+  version: ${{ version }}
+
+source:
+  url: https://github.com/scipopt/PySCIPOpt/archive/v${{ version }}.tar.gz
+  sha256: 9c511bd3dc6767f08c430c3be18af9e900d5bc939d9d1b44379dd0f760da167e
+
+build:
+  number: 0
+  files:
+    exclude:
+    - '**/*.pyx'
+    - '**/*.pxd'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - python
+    - cross-python_${{ target_platform }}
+    - cython >=3
+    - numpy
+  host:
+    - python
+    - pip
+    - setuptools
+    - cython >=3
+    - numpy
+    # scip is statically linked into the extension, so all of its static
+    # dependencies must be present in the host prefix at link time.
+    - scip
+    - soplex
+    - gmp
+    - mpfr
+    - zlib
+  run:
+    - python
+    - numpy >=1.16.0
+
+tests:
+  - script: pytester
+    requirements:
+      build:
+        - pytester
+      run:
+        - pytester-run
+    files:
+      recipe:
+        - test_pyscipopt.py
+
+about:
+  license: MIT
+  license_file: LICENSE
+  summary: Interface from Python to the SCIP Optimization Suite
+  homepage: https://github.com/scipopt/PySCIPOpt
+  documentation: https://scipopt.github.io/PySCIPOpt/docs/html/
+  repository: https://github.com/scipopt/PySCIPOpt

--- a/recipes/recipes_emscripten/pyscipopt/test_pyscipopt.py
+++ b/recipes/recipes_emscripten/pyscipopt/test_pyscipopt.py
@@ -1,0 +1,18 @@
+def test_import():
+    import pyscipopt
+    import pyscipopt.scip  # noqa: F401
+
+
+def test_solve_lp():
+    from pyscipopt import Model
+
+    model = Model()
+    x = model.addVar("x")
+    y = model.addVar("y")
+    model.setObjective(x + y, sense="maximize")
+    model.addCons(2 * x + y <= 10)
+    model.addCons(x + 3 * y <= 15)
+    model.optimize()
+
+    assert model.getStatus() == "optimal"
+    assert abs(model.getObjVal() - 7.0) < 1e-6


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary
