### PR TITLE
Add r-sourcetools

### DIFF
--- a/recipes/recipes_emscripten/r-sourcetools/recipe.yaml
+++ b/recipes/recipes_emscripten/r-sourcetools/recipe.yaml
@@ -1,0 +1,51 @@
+context:
+  name: sourcetools
+  version: 0.1.7-2
+
+package:
+  name: r-${{ name }}
+  version: ${{ version | replace('-', '_') }}
+
+source:
+  url:
+  - https://cran.r-project.org/src/contrib/${{ name }}_${{ version }}.tar.gz
+  - https://cloud.r-project.org/src/contrib/${{ name }}_${{ version }}.tar.gz
+  sha256: 07e584b780d7fcdfa5b527214361fface49350ab49cf901bd3d5c15950e4f1a7
+
+build:
+  number: 0
+  script: $R CMD INSTALL $R_ARGS .
+
+requirements:
+  build:
+  - cross-r-base_${{ target_platform }} ==${{ r_base }}
+  - ${{ compiler('c') }}
+  host:
+  - r-base ==${{ r_base }}
+
+tests:
+- package_contents:
+    lib:
+    - R/library/${{ name }}/libs/${{ name }}.so
+- script: run_r_test test-r-sourcetools.R
+  files:
+    recipe:
+    - test-r-sourcetools.R
+  requirements:
+    build:
+    - r-wasm-tester
+
+about:
+  homepage: https://cran.r-project.org/package=${{ name }}
+  repository: https://github.com/kevinushey/sourcetools/
+  license: MIT
+  license_file: LICENSE
+  summary: Tools for Reading, Tokenizing and Parsing R Code
+  description: |
+    Tools for the reading and tokenization of R code. The 'sourcetools' package
+    provides both an R and C++ interface for the tokenization of R code, and
+    helpers for interacting with the tokenized representation of R code.
+
+extra:
+  recipe-maintainers:
+    - IsabelParedes

--- a/recipes/recipes_emscripten/r-sourcetools/test-r-sourcetools.R
+++ b/recipes/recipes_emscripten/r-sourcetools/test-r-sourcetools.R
@@ -1,0 +1,25 @@
+library(sourcetools)
+
+cat("Hello, sourcetools!", file = "output.txt", sep = "\n")
+list.files("./")
+path <- "./output.txt"
+
+x <- read(path)
+print(x)
+
+x <- read_lines(path)
+print(x)
+
+x <- read_bytes(path)
+print(x)
+
+x <- read_lines_bytes(path)
+print(x)
+
+y <- tokenize_file(path)
+print(y)
+
+z <- tokenize_string("hello")
+print(z)
+
+tokenize(file = "output.txt", text = NULL)


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## Package Details
- **Package Name**: r-sourcetools
- **Version**: 0.1.7-2

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

