### PR TITLE
Fix cairo font scaling in r-base

### DIFF
--- a/recipes/recipes_emscripten/r-base/patches/0013-Fix-cairo-font-scaling-in-emscripten.patch
+++ b/recipes/recipes_emscripten/r-base/patches/0013-Fix-cairo-font-scaling-in-emscripten.patch
@@ -1,0 +1,115 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Adam Blake <adam@ablake.dev>
+Date: Thu, 19 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Fix cairo font scaling under emscripten
+
+Under emscripten-wasm32, cairo_set_font_size() has no effect: the cairo
+font matrix stays at a fixed scale regardless of the requested size, so
+every string renders at the same size and cex / pointsize changes (for
+example a larger plot title) are silently ignored.
+
+Pin cairo_set_font_size() to 1.0 in FT_getFont and apply the requested
+size as a CTM scale instead. A shared FT_getFontScale() helper selects
+the font, reads back the (stuck) font matrix, and returns size / fm.xx.
+Cairo_MetricInfo and Cairo_StrWidth multiply the returned text metrics by
+that scale so measurement matches rendering; Cairo_Text folds the scale
+into its existing transform stack (translate to the origin, rotate, then
+scale) and draws at (0,0).
+---
+diff --git a/src/library/grDevices/src/cairo/cairoFns.c b/src/library/grDevices/src/cairo/cairoFns.c
+index 50ff723..906f26e 100644
+--- a/src/library/grDevices/src/cairo/cairoFns.c
++++ b/src/library/grDevices/src/cairo/cairoFns.c
+@@ -1884,7 +1884,6 @@ static void FT_getFont(pGEcontext gc, pDevDesc dd, double fs)
+ {
+     pX11Desc xd = (pX11Desc) dd->deviceSpecific;
+     int face = gc->fontface;
+-    double size = gc->cex * gc->ps *fs;
+     cairo_font_face_t *cairo_face = NULL;
+     const char *family;
+ #ifdef Win32
+@@ -1911,9 +1910,9 @@ static void FT_getFont(pGEcontext gc, pDevDesc dd, double fs)
+ 	Rc_addFont(family, face, cairo_face);
+     }
+     cairo_set_font_face (xd->cc, cairo_face);
+-    /* FIXME: this should really use cairo_set_font_matrix
+-       if pixels are non-square on a screen device. */
+-    cairo_set_font_size (xd->cc, size);
++    /* On emscripten-wasm32 cairo_set_font_size() is a no-op; pin it to 1.0
++       and apply the real size as a CTM scale (see FT_getFontScale). */
++    cairo_set_font_size (xd->cc, 1.0);
+ }
+ 
+ #else
+@@ -1965,6 +1964,20 @@ static void FT_getFont(pGEcontext gc, pDevDesc dd, double fs)
+ }
+ #endif
+ 
++/* On emscripten-wasm32 cairo_set_font_size() is a no-op, so FT_getFont pins
++   it to 1.0 and the requested size is applied as a CTM scale. Select the
++   font, read back the (stuck) font matrix, and return that scale. fm.xx
++   should be 1.0 here; fall back to the raw size if the matrix is degenerate. */
++static double FT_getFontScale(pGEcontext gc, pDevDesc dd)
++{
++    pX11Desc xd = (pX11Desc) dd->deviceSpecific;
++    double size = gc->cex * gc->ps * xd->fontscale;
++    FT_getFont(gc, dd, xd->fontscale);
++    cairo_matrix_t fm;
++    cairo_get_font_matrix(xd->cc, &fm);
++    return (fm.xx > 0) ? size / fm.xx : size;
++}
++
+ static void Cairo_MetricInfo(int c, pGEcontext gc,
+ 			     double* ascent, double* descent,
+ 			     double* width, pDevDesc dd)
+@@ -1997,11 +2010,11 @@ static void Cairo_MetricInfo(int c, pGEcontext gc,
+ 	str[0] = (char)c; str[1] = 0;
+     }
+ 
+-    FT_getFont(gc, dd, xd->fontscale);
++    double scale = FT_getFontScale(gc, dd);
+     cairo_text_extents(xd->cc, str, &exts);
+-    *ascent  = -exts.y_bearing;
+-    *descent = exts.height + exts.y_bearing;
+-    *width = exts.x_advance;
++    *ascent  = -exts.y_bearing * scale;
++    *descent = (exts.height + exts.y_bearing) * scale;
++    *width = exts.x_advance * scale;
+ }
+ 
+ static double Cairo_StrWidth(const char *str, pGEcontext gc, pDevDesc dd)
+@@ -2020,9 +2033,9 @@ static double Cairo_StrWidth(const char *str, pGEcontext gc, pDevDesc dd)
+     } else {
+         textstr = str;
+     }
+-    FT_getFont(gc, dd, xd->fontscale);
++    double scale = FT_getFontScale(gc, dd);
+     cairo_text_extents(xd->cc, textstr, &exts);
+-    return exts.x_advance;
++    return exts.x_advance * scale;
+ }
+ 
+ static void Cairo_Text(double x, double y,
+@@ -2051,15 +2064,16 @@ static void Cairo_Text(double x, double y,
+             grouping = cairoBegin(xd);
+         }
+ 
+-	FT_getFont(gc, dd, xd->fontscale);
+-	cairo_move_to(xd->cc, x, y);
+-	if (hadj != 0.0 || rot != 0.0) {
++	double scale = FT_getFontScale(gc, dd);
++	cairo_translate(xd->cc, x, y);
++	if (rot != 0.0) cairo_rotate(xd->cc, -rot/180.*M_PI);
++	cairo_scale(xd->cc, scale, scale);
++	if (hadj != 0.0) {
+ 	    cairo_text_extents_t te;
+ 	    cairo_text_extents(xd->cc, textstr, &te);
+-	    if (rot != 0.0) cairo_rotate(xd->cc, -rot/180.*M_PI);
+-	    if (hadj != 0.0)
+-		cairo_rel_move_to(xd->cc, -te.x_advance * hadj, 0);
++	    cairo_translate(xd->cc, -te.x_advance * hadj, 0);
+ 	}
++	cairo_move_to(xd->cc, 0, 0);
+         if (!xd->appending) {
+             CairoColor(gc->col, xd);
+             cairo_show_text(xd->cc, textstr);

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -22,9 +22,10 @@ source:
   - patches/0010-Fix-iconv-checks-when-using-internal-lapack-blas.patch
   - patches/0011-Guard-Rlog1p-C-linkage-and-avoid-local-symbol-clash.patch
   - patches/0012-Remove-png-lib-from-bitmap-libs.patch
+  - patches/0013-Fix-cairo-font-scaling-in-emscripten.patch
 
 build:
-  number: 0
+  number: 1
 
   files:
     exclude:


### PR DESCRIPTION
`cairo_set_font_size()` is a no-op on `emscripten-wasm32`, so all plot text renders at one size and `cex`/`pointsize` changes (e.g. larger titles) are ignored. Pin it to 1.0 and apply the requested size as a CTM scale via a shared `FT_getFontScale()` helper: the measure functions multiply returned metrics by the scale and `Cairo_Text` folds it into its existing transform stack.

Verified end-to-end on r-base 4.5.3; identical patch/source on 4.6.0.

## Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [ ] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: r-base
- **Version**: 4.6.0 (build 1)

## Build Notes
Adds one patch to r-base's `grDevices` cairo backend to fix font scaling on emscripten. No new dependencies; version unchanged, build number bumped `0 → 1`. The affected source (`grDevices/src/cairo/cairoFns.c`) is identical on 4.5.3 and 4.6.0, so the patch is version-portable.