### PR TITLE
Add pytensor

### DIFF
--- a/recipes/recipes_emscripten/pytensor/build.sh
+++ b/recipes/recipes_emscripten/pytensor/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+# Build with PYODIDE=1 to skip the cython extension (scan_perform) and
+# produce a pure-python wheel, as pytensor's C compilation is unavailable
+# under emscripten. This corresponds to pytensor's "Python mode".
+# See https://www.pymc-labs.com/blog-posts/pymc-in-browser
+PYODIDE=1 ${PYTHON} -m pip install . ${PIP_ARGS} --no-build-isolation

--- a/recipes/recipes_emscripten/pytensor/patches/0001-skip-c-code-loading-on-emscripten.patch
+++ b/recipes/recipes_emscripten/pytensor/patches/0001-skip-c-code-loading-on-emscripten.patch
@@ -1,0 +1,27 @@
+diff --git a/pytensor/link/c/op.py b/pytensor/link/c/op.py
+--- a/pytensor/link/c/op.py
++++ b/pytensor/link/c/op.py
+@@ -1,5 +1,6 @@
+ import inspect
+ import re
++import sys
+ import warnings
+ from collections.abc import Callable, Collection, Iterable
+ from pathlib import Path
+@@ -318,10 +319,13 @@
+         self.func_name = func_name
+         self.code_sections: dict[str, str] = dict()
+ 
+-        self.load_c_code(self.func_files)
++        # On emscripten C compilation is unavailable and the C source files
++        # are not present in the virtual filesystem, so skip loading them.
++        if sys.platform != "emscripten":
++            self.load_c_code(self.func_files)
+ 
+-        if len(self.code_sections) == 0:
+-            raise ValueError("No sections where defined in the C files")
++            if len(self.code_sections) == 0:
++                raise ValueError("No sections where defined in the C files")
+ 
+         if self.func_name is not None:
+             if "op_code" in self.code_sections:

--- a/recipes/recipes_emscripten/pytensor/patches/0002-use-vm-linker-on-emscripten.patch
+++ b/recipes/recipes_emscripten/pytensor/patches/0002-use-vm-linker-on-emscripten.patch
@@ -1,0 +1,29 @@
+diff --git a/pytensor/compile/mode.py b/pytensor/compile/mode.py
+--- a/pytensor/compile/mode.py
++++ b/pytensor/compile/mode.py
+@@ -4,6 +4,7 @@
+ """
+ 
+ import logging
++import sys
+ import warnings
+ from typing import Any
+ 
+@@ -311,7 +312,7 @@
+         if linker is None:
+             linker = config.linker
+         if isinstance(linker, str) and linker == "auto":
+-            linker = "numba"
++            linker = "vm" if sys.platform == "emscripten" else "numba"
+         if isinstance(optimizer, str) and optimizer == "default":
+             optimizer = config.optimizer
+ 
+@@ -518,7 +519,7 @@
+     if upper_string == "FAST_RUN":
+         linker = config.linker
+         if linker == "auto":
+-            return NUMBA
++            return Mode("vm", "fast_run") if sys.platform == "emscripten" else NUMBA
+         return fast_run_linkers_to_mode[linker]
+ 
+     global _CACHED_RUNTIME_MODES

--- a/recipes/recipes_emscripten/pytensor/patches/0003-avoid-setuptools-import-on-emscripten.patch
+++ b/recipes/recipes_emscripten/pytensor/patches/0003-avoid-setuptools-import-on-emscripten.patch
@@ -1,0 +1,15 @@
+diff --git a/pytensor/link/c/exceptions.py b/pytensor/link/c/exceptions.py
+--- a/pytensor/link/c/exceptions.py
++++ b/pytensor/link/c/exceptions.py
+@@ -1,4 +1,10 @@
+-from setuptools.errors import CompileError as BaseCompileError
++import sys
++
++if sys.platform != "emscripten":
++    from setuptools.errors import CompileError as BaseCompileError
++else:
++    class BaseCompileError(Exception):
++        """Fallback for emscripten where setuptools is unavailable."""
+ 
+ 
+ class MissingGXX(Exception):

--- a/recipes/recipes_emscripten/pytensor/recipe.yaml
+++ b/recipes/recipes_emscripten/pytensor/recipe.yaml
@@ -70,4 +70,4 @@ about:
 
 extra:
   recipe-maintainers:
-  - IsabelParedes
+  - mmesch

--- a/recipes/recipes_emscripten/pytensor/recipe.yaml
+++ b/recipes/recipes_emscripten/pytensor/recipe.yaml
@@ -1,0 +1,73 @@
+context:
+  name: pytensor
+  version: 3.0.7
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 858df82fa44e5401c9e913e5acaa5e0044f1515db0290755a139e58e28f22b9e
+  patches:
+  - patches/0001-skip-c-code-loading-on-emscripten.patch
+  - patches/0002-use-vm-linker-on-emscripten.patch
+  - patches/0003-avoid-setuptools-import-on-emscripten.patch
+
+build:
+  number: 0
+
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/tests/**'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
+
+requirements:
+  build:
+  - cross-python_${{ target_platform }}
+  - python
+  - pip
+  - setuptools
+  - numpy
+  - versioneer
+  host:
+  - python
+  - numpy
+  - scipy
+  run:
+  - python
+  - numpy
+  - scipy
+  - filelock
+  - etuples
+  - logical-unification
+  - minikanren
+  - cons
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_import_pytensor.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+
+about:
+  homepage: https://github.com/pymc-devs/pytensor
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: Optimizing compiler for evaluating mathematical expressions on CPUs and GPUs
+  documentation: https://pytensor.readthedocs.io/en/latest/
+
+extra:
+  recipe-maintainers:
+  - IsabelParedes

--- a/recipes/recipes_emscripten/pytensor/test_import_pytensor.py
+++ b/recipes/recipes_emscripten/pytensor/test_import_pytensor.py
@@ -1,0 +1,14 @@
+
+def test_import_pytensor():
+    import pytensor
+
+
+def test_pytensor_function():
+    import pytensor
+    import pytensor.tensor as pt
+
+    x = pt.vector("x")
+    y = x * 2
+    fn = pytensor.function([x], y)
+    result = fn([1.0, 2.0, 3.0])
+    assert list(result) == [2.0, 4.0, 6.0]


### PR DESCRIPTION
## Package Details
- **Package Name**: pytensor
- **Version**: 3.0.7

## Build Notes
Builds from sdist with `PYODIDE=1` to skip the cython extension (pure-python mode, as described in https://www.pymc-labs.com/blog-posts/pymc-in-browser).

Three patches adapt pytensor for emscripten:
- `0001`: skip loading C source files in `CLinkerOp.__init__` (the `.c` files are stripped from the browser virtual filesystem by the pytester empack config)
- `0002`: use the pure-python `vm` linker instead of `numba` (numba is unavailable on emscripten)
- `0003`: avoid importing `setuptools` in `link/c/exceptions.py` (setuptools is also stripped from the browser filesystem)

I am unsure whether all of these patches are needed or whether there is a more elegant solution for some of them. I have only tested via the test suite, not yet in a real browser. This is a requirement for running pymc in the browser.

A functional test builds and evaluates `x * 2` via `pytensor.function`.