### PR TITLE
add readline, libgc, libatomic_ops, xz

### DIFF
--- a/recipes/recipes_emscripten/libatomic_ops/build.sh
+++ b/recipes/recipes_emscripten/libatomic_ops/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+CPPFLAGS="-I${PREFIX}/include" \
+LDFLAGS="-L${PREFIX}/lib" \
+CXXFLAGS="-std=c++11" \
+
+emconfigure ./configure \
+    --build=i686-pc-linux-gnu \
+    --host=wasm32-unknown-emscripten \
+    --disable-shared \
+    --enable-static \
+    --disable-docs \
+    CFLAGS="${CFLAGS:-} -DAO_SINGLE_THREADED" \
+    --prefix="${PREFIX}"
+
+emmake make -j8
+emmake make install

--- a/recipes/recipes_emscripten/libatomic_ops/recipe.yaml
+++ b/recipes/recipes_emscripten/libatomic_ops/recipe.yaml
@@ -1,0 +1,38 @@
+context:
+  name: libatomic_ops
+  version: 7.10.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/bdwgc/libatomic_ops/releases/download/v${{ version }}/libatomic_ops-${{ version }}.tar.gz
+  sha256: 0db3ebff755db170f65e74a64ec4511812e9ee3185c232eeffeacd274190dfb0
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - ${{ compiler('cxx') }}
+
+tests:
+- package_contents:
+    files:
+    - lib/libatomic_ops.a
+    - include/atomic_ops.h
+
+about:
+  homepage: https://github.com/bdwgc/libatomic_ops/wiki
+  license: MIT AND GPL-2.0-only
+  license_file: LICENSE
+  summary: This package provides semi-portable access to hardware-provided atomic memory update operations on a number of architectures.
+
+extra:
+  recipe-maintainers:
+  - wangyenshu

--- a/recipes/recipes_emscripten/libgc/build.sh
+++ b/recipes/recipes_emscripten/libgc/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+CPPFLAGS="-I${PREFIX}/include" \
+LDFLAGS="-L${PREFIX}/lib" \
+CXXFLAGS="-std=c++11" \
+
+emconfigure ./configure \
+    --build=i686-pc-linux-gnu \
+    --host=wasm32-unknown-emscripten \
+    --disable-shared \
+    --enable-static \
+    --disable-threads \
+    --enable-cplusplus \
+    --prefix="${PREFIX}"
+
+emmake make -j8
+emmake make install

--- a/recipes/recipes_emscripten/libgc/recipe.yaml
+++ b/recipes/recipes_emscripten/libgc/recipe.yaml
@@ -1,0 +1,38 @@
+context:
+  name: libgc
+  version: 8.2.12
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/bdwgc/bdwgc/releases/download/v${{ version }}/gc-${{ version }}.tar.gz
+  sha256: 42e5194ad06ab6ffb806c83eb99c03462b495d979cda782f3c72c08af833cd4e
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - ${{ compiler('cxx') }}
+
+tests:
+- package_contents:
+    files:
+    - lib/libgc.a
+    - include/gc.h
+
+about:
+  homepage: https://www.hboehm.info/gc/
+  license: LicenseRef-MIT-style
+  license_file: README.md
+  summary: The Boehm-Demers-Weiser conservative C/C++ Garbage Collector
+
+extra:
+  recipe-maintainers:
+  - wangyenshu

--- a/recipes/recipes_emscripten/readline/build.sh
+++ b/recipes/recipes_emscripten/readline/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+CPPFLAGS="-I${PREFIX}/include" \
+LDFLAGS="-L${PREFIX}/lib" \
+CXXFLAGS="-std=c89" \
+
+emconfigure ./configure \
+    --build=i686-pc-linux-gnu \
+    --host=wasm32-unknown-emscripten \
+    --disable-shared \
+    --enable-static \
+    --with-curses \
+    CFLAGS="${CFLAGS:-} -DHAVE_POSIX_SIGNALS" \
+    --prefix="${PREFIX}"
+
+emmake make -j8
+emmake make install

--- a/recipes/recipes_emscripten/readline/recipe.yaml
+++ b/recipes/recipes_emscripten/readline/recipe.yaml
@@ -1,0 +1,38 @@
+context:
+  name: readline
+  version: 8.3
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://ftp.gnu.org/gnu/readline/readline-${{ version }}.tar.gz
+  sha256: fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - ${{ compiler('cxx') }}
+
+tests:
+- package_contents:
+    files:
+    - lib/libreadline.a
+    - include/readline/readline.h
+
+about:
+  homepage: https://tiswww.cwru.edu/php/chet/readline/rltop.html
+  license: GPL-3.0-only
+  license_file: COPYING
+  summary: The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in.
+
+extra:
+  recipe-maintainers:
+  - wangyenshu

--- a/recipes/recipes_emscripten/xz/build.sh
+++ b/recipes/recipes_emscripten/xz/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+CPPFLAGS="-I${PREFIX}/include" \
+LDFLAGS="-L${PREFIX}/lib" \
+CXXFLAGS="-std=c++11" \
+
+emconfigure ./configure \
+    --build=i686-pc-linux-gnu \
+    --host=wasm32-unknown-emscripten \
+    --disable-shared \
+    --enable-static \
+    --prefix="${PREFIX}"
+
+emmake make -j8
+emmake make install
+
+cp src/xz/xz.wasm "${PREFIX}/bin/"

--- a/recipes/recipes_emscripten/xz/recipe.yaml
+++ b/recipes/recipes_emscripten/xz/recipe.yaml
@@ -1,0 +1,40 @@
+context:
+  name: xz
+  version: 5.8.3
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/tukaani-project/xz/releases/download/v${{ version }}/xz-${{ version }}.tar.gz
+  sha256: 3d3a1b973af218114f4f889bbaa2f4c037deaae0c8e815eec381c3d546b974a0
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - ${{ compiler('cxx') }}
+
+tests:
+- package_contents:
+    files:
+    - lib/liblzma.a
+    - include/lzma.h
+    - bin/xz
+    - bin/xz.wasm
+
+about:
+  homepage: https://tukaani.org/xz/
+  license: 0BSD
+  license_file: COPYING
+  summary: XZ Utils 
+
+extra:
+  recipe-maintainers:
+  - wangyenshu


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: readline, libgc, libatomic_ops, xz
- **Version**: various, see their recipe.yaml

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

