### PR TITLE
Update rattler-build, linter and bot

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -5,7 +5,7 @@ dependencies:
   - python
   - ruamel.yaml
   - typer
-  - rattler-build >=0.60.0,<0.62.0
+  - rattler-build >=0.67.0,<0.68.0
   - pixi
   - jinja2
   - curl

--- a/emci/bot/bump_recipes_versions.py
+++ b/emci/bot/bump_recipes_versions.py
@@ -101,7 +101,10 @@ def update_recipe_version(recipe_file, new_version, new_sha256, is_rattler):
     context['version'] = new_version
 
     # reset build number
-    recipe['build']['number'] = 0
+    if 'build_number' in context:
+        context['build_number'] = 0
+    else:
+        recipe['build']['number'] = 0
 
     # update sha256 in source
     source = recipe['source']

--- a/emci/rattler_build.py
+++ b/emci/rattler_build.py
@@ -5,9 +5,6 @@ from pathlib import Path
 from .constants import RATTLER_CONDA_BUILD_CONFIG_PATH
 
 
-EXPERIMENTAL_RECIPES = {"arrow", "thrift", "r-base-4.5.3", "r-base"}
-
-
 def build_with_rattler(recipe=None, recipes_dir=None, emscripten_wasm32=False, skip_existing="local"):
 
     cmd = ["rattler-build", "build", "--package-format", "tar-bz2", "--log-style", "simple"]
@@ -19,15 +16,11 @@ def build_with_rattler(recipe=None, recipes_dir=None, emscripten_wasm32=False, s
         raise ValueError("recipe or recipes_dir must be set")
     elif recipe is not None:
         cmd.extend(["--recipe", str(recipe)])
-        if recipe in EXPERIMENTAL_RECIPES:
-            cmd.extend(["--experimental"])
     elif recipes_dir is not None:
         cmd.extend(["--recipe-dir", str(recipes_dir)])
         recipes_path = Path(recipes_dir)
         if recipes_path.is_dir():
             folder_names = {p.name for p in recipes_path.iterdir() if p.is_dir()}
-            if folder_names & EXPERIMENTAL_RECIPES:
-                cmd.extend(["--experimental"])
 
     cmd.extend(["--skip-existing", skip_existing])
 

--- a/emci/schema.py
+++ b/emci/schema.py
@@ -42,14 +42,18 @@ Source = Union[PathSource, UrlSource]
 
 class Build(BaseModel):
     """Build configuration for the recipe"""
-    number: int
+    number: int | str
 
     @field_validator("number")
     @classmethod
-    def validate_build_number(cls, v: int) -> int:
-        if v < 0:
-            raise ValueError("build.number must be >= 0")
-        return v
+    def validate_build_number(cls, v: int | str) -> int | str:
+        if isinstance(v, int):
+            if v < 0:
+                raise ValueError("build.number must be >= 0")
+            return v
+        if v == "${{ build_number }}":
+            return v
+        raise ValueError("build.number must be an integer >= 0 or ${{ build_number }}")
 
 class About(BaseModel):
     license: str
@@ -73,10 +77,18 @@ class Recipe(BaseModel):
         build = values['build']
         if isinstance(build, dict):
             if 'number' not in build:
-                raise AttributeError("build.number is required and must be >= 0")
-            number = build.get('number')
-            if not isinstance(number, int) or number < 0:
-                raise ValueError("build.number must be an integer >= 0")
+                raise AttributeError("build.number is required")
+            number = build['number']
+            if isinstance(number, int):
+                if number < 0:
+                    raise ValueError("build.number must be an integer >= 0")
+            elif number == "${{ build_number }}":
+                context = values.get('context', {})
+                context_build_number = context.get('build_number') if isinstance(context, dict) else None
+                if not isinstance(context_build_number, int) or context_build_number < 0:
+                    raise ValueError("context.build_number must be an integer >= 0")
+            else:
+                raise ValueError("build.number must be an integer >= 0 or ${{ build_number }}")
 
         # Check tests
         if 'tests' not in values or values['tests'] is None:

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,7 +8,7 @@ platforms = ["osx-arm64", "osx-64", "linux-64"]
 
 # default environment
 [dependencies]
-rattler-build = ">=0.60.0, <0.62.0"
+rattler-build = ">=0.67.0, <0.68.0"
 curl = "*"
 
 ############################################
@@ -18,7 +18,7 @@ curl = "*"
 [feature.feature_rattler_build.dependencies]
 git = "*"
 patch = "*"
-rattler-build = ">=0.60.0,<0.62.0"
+rattler-build = ">=0.67.0,<0.68.0"
 python = "3.11.*"
 typer = "*"
 curl = "*"

--- a/recipes/recipes/r-wasm-tester/recipe.yaml
+++ b/recipes/recipes/r-wasm-tester/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   run:

--- a/recipes/recipes/r-wasm-tester/run_r_test.sh
+++ b/recipes/recipes/r-wasm-tester/run_r_test.sh
@@ -10,20 +10,21 @@ Usage: run_r_test [--rpy] [<test.R>]
 Run an R test script in the wasm R environment via Rtester.js.
 
 Arguments:
-  <test.R>    Path to one R test script (e.g. ./test-r-bit.R)
-              If omitted, runs all .R files in the current directory
+  <test.R>    Path to one R test script (e.g. ./test-r-bit.R).
+              If omitted, runs all .R files in the current directory.
 
 Options:
-      --rpy   Use the RPY executable (R linked with libpython) instead of R
-  -h, --help  Show this help message and exit
+      --rpy   Use the RPY executable (R linked with libpython).
+  -h, --help  Show this help message and exit.
 
 Environment:
-  PREFIX      Conda environment prefix with r-base (WebAssembly) installed
+  PREFIX      Conda environment prefix with r-base (WebAssembly) installed.
 EOF
 }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RTESTER_JS="${SCRIPT_DIR}/Rtester.js"
+R_TAG="R-TESTER"
 
 if [ "$#" -eq 1 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ]; }; then
     show_help
@@ -33,6 +34,7 @@ fi
 USE_RPY=""
 if [ "$#" -ge 1 ] && [ "$1" = "--rpy" ]; then
     USE_RPY=1
+    R_TAG="RPY-TESTER"
     shift
 fi
 
@@ -45,33 +47,33 @@ if [ "$#" -eq 0 ]; then
     done < <(find . -maxdepth 1 -type f -name "*.R" | sort)
 
     if [ "$found" -eq 0 ]; then
-        echo "[R-TESTER] Error: no .R files found in current directory" >&2
+        echo "[$R_TAG] Error: no .R files found in current directory" >&2
         exit 1
     fi
     exit 0
 fi
 
 if [ "$#" -ne 1 ]; then
-    echo "[R-TESTER] Error: expected zero or one argument (path to an .R file); try --help" >&2
+    echo "[$R_TAG] Error: expected zero or one argument (path to an .R file); try --help" >&2
     exit 1
 fi
 
 R_SCRIPT="$1"
 
 if [ -z "${PREFIX:-}" ] || [ ! -d "$PREFIX" ]; then
-    echo "[R-TESTER] Error: PREFIX is not set or does not exist: ${PREFIX:-}" >&2
+    echo "[$R_TAG] Error: PREFIX is not set or does not exist: ${PREFIX:-}" >&2
     exit 1
 fi
 
 if [ ! -f "$RTESTER_JS" ]; then
-    echo "[R-TESTER] Error: Rtester.js not found: ${RTESTER_JS}" >&2
+    echo "[$R_TAG] Error: Rtester.js not found: ${RTESTER_JS}" >&2
     exit 1
 fi
 
 if [ ! -f "$R_SCRIPT" ]; then
-    echo "[R-TESTER] Error: R script not found: ${R_SCRIPT}" >&2
+    echo "[$R_TAG] Error: R script not found: ${R_SCRIPT}" >&2
     exit 1
 fi
 
-echo "[R-TESTER] Running test script: ${R_SCRIPT}"
+echo "[$R_TAG] Running test script: ${R_SCRIPT}"
 exec env PREFIX="$PREFIX" ${USE_RPY:+USE_RPY=1} node "$RTESTER_JS" "$R_SCRIPT"

--- a/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
@@ -1,9 +1,10 @@
 context:
   name: r-base
   version: 4.5.3
+  build_number: 7
 
 build:
-  number: 6
+  number: ${{ build_number }}
 
 outputs:
 # Staging output: runs build.sh once; r-base and r-py inherit from here.

--- a/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
@@ -108,9 +108,11 @@ outputs:
       - R/library/grDevices/libs/cairo.so
   - script:
     - node ${PREFIX}/lib/R/bin/Rscript --version
+    - run_r_test test-r.R
     requirements:
       build:
       - nodejs
+      - r-wasm-tester
 
 - package:
     name: r-py

--- a/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
@@ -3,6 +3,27 @@ context:
   version: 4.5.3
   build_number: 7
 
+source:
+  url: https://cran.r-project.org/src/base/R-4/R-${{ version }}.tar.gz
+  sha256: aa5c1ed4293c7271ac513d654670356ac0e8a6ad5e42be014365d11150b5b8f2
+  patches:
+  # https://github.com/IsabelParedes/r-source/tree/R-4.5.0-wasm
+  - patches/0001-Add-emscripten-platform-to-configure-script.patch
+  - patches/0002-Disable-libcurl.patch
+  - patches/0003-Disable-internet-module.patch
+  - patches/0004-Fix-iconv-checks-when-using-internal-lapack-blas.patch
+  - patches/0005-Add-sigsuspend-stub-for-Emscripten-compatibility.patch
+  - patches/0006-Disable-which-for-emscripten.patch
+  - patches/0007-Set-cairo-as-default-bitmap-type.patch
+  - patches/0008-Use-source-files-directly.patch
+  - patches/0009-Install-.wasm-files.patch
+  - patches/0010-Fix-extern-C-error-expected-an-identifier.patch
+  - patches/0011-Remove-png-lib-from-bitmap-libs.patch
+  - patches/0012-Use-linux-executables.patch
+  - patches/0013-Use-source-files-when-installing.patch
+  - patches/0014-Fix-cairo-font-scaling-in-emscripten.patch
+  - patches/0015-Add-RPY-target-linked-with-libpython.patch
+
 build:
   number: ${{ build_number }}
 
@@ -52,30 +73,6 @@ outputs:
     - sqlite
     - openssl
     - zstd
-    ignore_run_exports:
-      from_package:
-      - python
-
-  source:
-    url: https://cran.r-project.org/src/base/R-4/R-${{ version }}.tar.gz
-    sha256: aa5c1ed4293c7271ac513d654670356ac0e8a6ad5e42be014365d11150b5b8f2
-    patches:
-    # https://github.com/IsabelParedes/r-source/tree/R-4.5.0-wasm
-    - patches/0001-Add-emscripten-platform-to-configure-script.patch
-    - patches/0002-Disable-libcurl.patch
-    - patches/0003-Disable-internet-module.patch
-    - patches/0004-Fix-iconv-checks-when-using-internal-lapack-blas.patch
-    - patches/0005-Add-sigsuspend-stub-for-Emscripten-compatibility.patch
-    - patches/0006-Disable-which-for-emscripten.patch
-    - patches/0007-Set-cairo-as-default-bitmap-type.patch
-    - patches/0008-Use-source-files-directly.patch
-    - patches/0009-Install-.wasm-files.patch
-    - patches/0010-Fix-extern-C-error-expected-an-identifier.patch
-    - patches/0011-Remove-png-lib-from-bitmap-libs.patch
-    - patches/0012-Use-linux-executables.patch
-    - patches/0013-Use-source-files-when-installing.patch
-    - patches/0014-Fix-cairo-font-scaling-in-emscripten.patch
-    - patches/0015-Add-RPY-target-linked-with-libpython.patch
 
   build:
     script: build.sh
@@ -98,6 +95,9 @@ outputs:
   requirements:
     run_exports:
     - ${{ pin_subpackage('r-base', upper_bound='x.x') }}
+    ignore_run_exports:
+      from_package:
+      - python
 
   tests:
   - package_contents:

--- a/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
@@ -73,6 +73,9 @@ outputs:
     - sqlite
     - openssl
     - zstd
+    ignore_run_exports:
+      from_package:
+      - python
 
   build:
     script: build.sh
@@ -95,9 +98,6 @@ outputs:
   requirements:
     run_exports:
     - ${{ pin_subpackage('r-base', upper_bound='x.x') }}
-    ignore_run_exports:
-      from_package:
-      - python
 
   tests:
   - package_contents:

--- a/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
@@ -109,6 +109,9 @@ outputs:
   - script:
     - node ${PREFIX}/lib/R/bin/Rscript --version
     - run_r_test test-r.R
+    files:
+      recipe:
+      - test-r.R
     requirements:
       build:
       - nodejs

--- a/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base-4.5.3/recipe.yaml
@@ -27,6 +27,8 @@ source:
 build:
   number: ${{ build_number }}
 
+#-------------------------------------------------------------------------------
+
 outputs:
 # Staging output: runs build.sh once; r-base and r-py inherit from here.
 - staging:
@@ -80,6 +82,8 @@ outputs:
   build:
     script: build.sh
 
+#-------------------------------------------------------------------------------
+
 - package:
     name: r-base
     version: ${{ version }}
@@ -117,6 +121,8 @@ outputs:
       - nodejs
       - r-wasm-tester
 
+#-------------------------------------------------------------------------------
+
 - package:
     name: r-py
     version: ${{ version }}
@@ -145,6 +151,15 @@ outputs:
       files:
       - lib/R/bin/exec/RPY
       - lib/R/bin/exec/RPY.wasm
+  - script: run_r_test --rpy test-r.R
+    files:
+      recipe:
+      - test-r.R
+    requirements:
+      build:
+      - r-wasm-tester
+
+#-------------------------------------------------------------------------------
 
 about:
   homepage: http://www.r-project.org/

--- a/recipes/recipes_emscripten/r-base-4.5.3/test-r.R
+++ b/recipes/recipes_emscripten/r-base-4.5.3/test-r.R
@@ -1,0 +1,18 @@
+print(R.version)
+
+library(grDevices)
+library(graphics)
+library(grid)
+library(methods)
+library(parallel)
+library(splines)
+library(stats)
+library(tools)
+library(utils)
+
+A <- matrix(1:9, nrow = 3)
+B <- matrix(9:1, nrow = 3)
+C <- A %*% B
+
+eigen(C)$values
+eigen(C)$vectors


### PR DESCRIPTION
- Add bot/linter support to handle `build_number` as a context variable
- Updated rattler-build to bypass a bug where the `build_number` would default to 0 in multi-output recipes
- Remove `--experimental` flag which is no longer needed for multi-output recipes