### PR TITLE
add fricas

### DIFF
--- a/recipes/recipes_emscripten/fricas/build.sh
+++ b/recipes/recipes_emscripten/fricas/build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# FIX THE NATIVE COMPILER MISSING ISSUE
+mkdir -p ${BUILD_PREFIX}/bin
+ln -s $(which gcc) ${BUILD_PREFIX}/bin/x86_64-conda-linux-gnu-cc
+
+BUILD_ARCH="${BUILD:-$(gcc -dumpmachine 2>/dev/null | sed 's/-gnux32$/-gnu/' || echo x86_64-pc-linux-gnu)}"
+
+# NATIVE HOST BUILD
+mkdir -p bld-native
+pushd bld-native
+
+env -u CFLAGS -u CXXFLAGS -u LDFLAGS -u CPPFLAGS \
+../configure \
+    --build="${BUILD_ARCH}" \
+    --prefix="${PREFIX}" \
+    --with-lisp=ecl
+
+# Generate the required build directories first
+make stamp-rootdirs
+
+# Build the native C dependencies and Lisp compiler
+env -u CFLAGS -u CXXFLAGS -u LDFLAGS -u CPPFLAGS make CC=gcc AR=ar RANLIB=ranlib -C src/lib
+env -u CFLAGS -u CXXFLAGS -u LDFLAGS -u CPPFLAGS make CC=gcc AR=ar RANLIB=ranlib -C src/lisp
+
+popd
+
+# WEBASSEMBLY TARGET BUILD
+export CPPFLAGS="-I${PREFIX}/include"
+export LDFLAGS="-L${PREFIX}/lib -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB"
+export CXXFLAGS="-std=c++17"
+
+mkdir -p bld-wasm
+pushd bld-wasm
+
+emconfigure ../configure \
+    --build="${BUILD_ARCH}" \
+    --host=wasm32-unknown-emscripten \
+    --prefix="${PREFIX}" \
+    --with-lisp=ecl 
+
+# Generate root directories
+make stamp-rootdirs
+
+# Copy the native lisp tool into the Wasm build tree.
+cp ../bld-native/build/${BUILD_ARCH}/bin/lisp build/${BUILD_ARCH}/bin/lisp
+
+# This dynamically rewrites the generated Lisp script so it executes 
+# `(progn "$@" nil)` instead of `(make-program "$@" nil)`. 
+sed -i 's/make-program/progn/g' src/lisp/Makefile
+
+emmake make -j8
+emmake make install
+
+popd

--- a/recipes/recipes_emscripten/fricas/recipe.yaml
+++ b/recipes/recipes_emscripten/fricas/recipe.yaml
@@ -1,0 +1,45 @@
+context:
+  name: fricas
+  version: 1.3.13
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/fricas/fricas/releases/download/${{ version }}/fricas-${{ version }}-full.tar.bz2
+  sha256: dd4d5e06db0ba4a43a5bfb64e94f6c8d4b10e68ac65a77556891a6b24af148a2
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - pkg-config
+  - autoconf-archive
+  - ${{ compiler('c') }}     
+  - ${{ compiler('cxx') }}
+  - ecl                     
+  - nodejs
+  host:
+  - ecl
+  - libffi
+
+tests:
+- package_contents:
+    files:
+    - bin/fricas
+
+about:
+  homepage: https://fricas.github.io/
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: FriCAS is a general purpose computer algebra system (CAS).
+
+extra:
+  recipe-maintainers:
+  - wangyenshu


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: fricas
- **Version**: 1.3.13

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->
This is an attempt to compile fricas using classic ./configure then make and make install method. 

Current issue is the executable is a bash script. And there is no main .wasm executable, although many small auxiliary program is compiled to wasm, like session.wasm, spadclient.wasm, spadbuf.wasm. They are not yet included in the output tar.zst file.

Another method is to compile ecl to wasm then load the [pure lisp version of fricas](https://github.com/oldk1331/fricas0). I am evaluating which method is better.
