### PR TITLE
add fplll

### DIFF
--- a/recipes/recipes_emscripten/fplll/build.sh
+++ b/recipes/recipes_emscripten/fplll/build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+autoreconf -vfi
+
+SAFE_CFLAGS="${CFLAGS:-}"
+SAFE_CXXFLAGS="${CXXFLAGS:-}"
+SAFE_LDFLAGS="${LDFLAGS:-}"
+
+LOCAL_CFLAGS="${SAFE_CFLAGS//-pthread/}"
+LOCAL_CXXFLAGS="${SAFE_CXXFLAGS//-pthread/}"
+LOCAL_LDFLAGS="${SAFE_LDFLAGS//-pthread/} -L${PREFIX}/lib -sSHARED_MEMORY=0"
+
+emconfigure ./configure \
+    --build=i686-pc-linux-gnu \
+    --host=wasm32-unknown-emscripten \
+    --enable-static \
+    --disable-shared \
+    --with-gmp="${PREFIX}" \
+    --with-mpfr="${PREFIX}" \
+    --prefix="${PREFIX}" \
+    CFLAGS="${LOCAL_CFLAGS}" \
+    CXXFLAGS="${LOCAL_CXXFLAGS}" \
+    LDFLAGS="${LOCAL_LDFLAGS}"
+
+find . -type f -name "Makefile" -exec sed -i 's/-pthread//g' {} +
+find . -type f -name "Makefile" -exec sed -i 's/-lpthread//g' {} +
+
+emmake make -j8 
+emmake make install

--- a/recipes/recipes_emscripten/fplll/recipe.yaml
+++ b/recipes/recipes_emscripten/fplll/recipe.yaml
@@ -1,0 +1,43 @@
+context:
+  name: fplll
+  version: 5.5.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/fplll/fplll/releases/download/${{ version }}/fplll-${{ version }}.tar.gz
+  sha256: f0af6bdd0ebd5871e87ff3ef7737cb5360b1e38181a4e5a8c1236f3476fec3b2
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - pkg-config
+  - autoconf-archive
+  - ${{ compiler('cxx') }}
+  host:
+  - gmp
+  - mpfr
+
+tests:
+- package_contents:
+    files:
+    - lib/libfplll.a
+    - include/fplll.h
+
+about:
+  homepage: https://github.com/fplll/fplll
+  license: LGPL-2.1-only
+  license_file: COPYING
+  summary: Lattice algorithms using floating-point arithmetic
+
+extra:
+  recipe-maintainers:
+  - wangyenshu


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: fplll
- **Version**: 5.5.0

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

