### PR TITLE
add planarity

### DIFF
--- a/recipes/recipes_emscripten/planarity/build.sh
+++ b/recipes/recipes_emscripten/planarity/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+emconfigure ./configure \
+    --build=i686-pc-linux-gnu \
+    --host=wasm32-unknown-emscripten \
+    --disable-shared \
+    --enable-static \
+    --prefix="${PREFIX}" \
+    CFLAGS="${CFLAGS:-}" \
+    CXXFLAGS="${CXXFLAGS:-}" \
+    LDFLAGS="${LDFLAGS:-}"
+
+emmake make -j8
+emmake make install

--- a/recipes/recipes_emscripten/planarity/recipe.yaml
+++ b/recipes/recipes_emscripten/planarity/recipe.yaml
@@ -1,0 +1,40 @@
+context:
+  name: planarity
+  version: 5.0.0.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/graph-algorithms/edge-addition-planarity-suite/releases/download/Version_${{ version }}/planarity-${{ version }}.tar.gz
+  sha256: 8aa3958f92e3fbbc63815e5b6b454abe40889af5aa35da8306659c58ec16a2d0
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - pkg-config
+  - autoconf-archive
+  - ${{ compiler('cxx') }}
+
+tests:
+- package_contents:
+    files:
+    - lib/libplanarity.a
+    - include/planarity/graphLib.h
+
+about:
+  homepage: https://github.com/graph-algorithms/edge-addition-planarity-suite
+  license: LicenseRef-planarity
+  license_file: LICENSE.TXT
+  summary: implementations of the edge addition planar graph embedding algorithm and related algorithms
+
+extra:
+  recipe-maintainers:
+  - wangyenshu


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: planarity
- **Version**: 5.0.0.0

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

