### PR TITLE
add gf2x

### DIFF
--- a/recipes/recipes_emscripten/gf2x/build.sh
+++ b/recipes/recipes_emscripten/gf2x/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+autoreconf -vfi
+
+export CFLAGS_FOR_BUILD="-O2"
+export CXXFLAGS_FOR_BUILD="-O2"
+export CPPFLAGS_FOR_BUILD=""
+export LDFLAGS_FOR_BUILD=""
+
+export HOST_CFLAGS="-O2"
+export HOST_CXXFLAGS="-O2"
+export HOST_LDFLAGS=""
+
+BUILD_ARCH=$("${CC_FOR_BUILD:-cc}" -dumpmachine || echo "x86_64-pc-linux-gnu")
+
+emconfigure ./configure \
+    --build="${BUILD_ARCH}" \
+    --host=wasm32-unknown-emscripten \
+    --disable-shared \
+    --prefix="${PREFIX}" \
+    CC_FOR_BUILD="${CC_FOR_BUILD:-cc}" \
+    CPP_FOR_BUILD="${CC_FOR_BUILD:-cc} -E" \
+    HOST_CC="${CC_FOR_BUILD:-cc}" \
+    ABI=32
+
+emmake make -j${CPU_COUNT:-4} 
+emmake make install

--- a/recipes/recipes_emscripten/gf2x/recipe.yaml
+++ b/recipes/recipes_emscripten/gf2x/recipe.yaml
@@ -1,0 +1,39 @@
+context:
+  name: gf2x
+  version: 1.3.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://gitlab.inria.fr/gf2x/gf2x/-/archive/gf2x-${{ version }}/gf2x-gf2x-${{ version }}.tar.gz
+  sha256: 11bcf98b620c60c2ee3b4460b02b7be741f14cfdc26b542f22c92950926575e0
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - ${{ compiler('c') }}
+  - ${{ compiler('cxx') }}
+
+tests:
+- package_contents:
+    files:
+    - lib/libgf2x.a
+    - include/gf2x.h
+
+about:
+  homepage: https://gitlab.inria.fr/gf2x/gf2x
+  license: GPL-3.0-only
+  license_file: COPYING
+  summary: gf2x is a C/C++ software package containing routines for fast arithmetic in GF(2)[x] (multiplication, squaring, GCD) and searching for irreducible/primitive trinomials.
+
+extra:
+  recipe-maintainers:
+  - wangyenshu


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: gf2x
- **Version**: 1.3.0

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

