### PR TITLE
add libcadabra2

### DIFF
--- a/recipes/recipes_emscripten/libcadabra2/build.sh
+++ b/recipes/recipes_emscripten/libcadabra2/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+mkdir -p build-lib
+cd build-lib
+
+PY_VER=$(ls "${PREFIX}/include" | grep -E '^python3\.[0-9]+$' | head -n 1)
+PY_LIB=$(find "${PREFIX}/lib" -name "lib${PY_VER}.*" -print -quit)
+
+CPPFLAGS="-I${PREFIX}/include" \
+LDFLAGS="-L${PREFIX}/lib" \
+CXXFLAGS="-std=c++11" \
+
+emcmake cmake .. \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DBUILD_AS_CPP_LIBRARY=ON \
+    -DCMAKE_FIND_ROOT_PATH="${PREFIX}" \
+    -DPython_EXECUTABLE="${BUILD_PREFIX}/bin/python" \
+    -DPython_INCLUDE_DIR="${PREFIX}/include/${PY_VER}" \
+    -DPython_LIBRARY="${PY_LIB}" \
+    -DGMP_LIB="${PREFIX}/lib/libgmp.a" \
+    -DGMP_INCLUDE_DIR="${PREFIX}/include"
+
+emmake make -j8 
+emmake make install

--- a/recipes/recipes_emscripten/libcadabra2/recipe.yaml
+++ b/recipes/recipes_emscripten/libcadabra2/recipe.yaml
@@ -1,0 +1,54 @@
+context:
+  name: libcadabra2
+  version: 2.5.14
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/kpeeters/cadabra2/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 9e85977f49dae20230f4865a4f879d819cbfaaf3797d22adef1407990eab66ff
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - ${{ compiler("c") }}
+  - ${{ compiler('cxx') }}
+  - pkg-config
+  - python
+  - cross-python_${{ target_platform }}
+  host:
+  - libpython
+  - python
+  - gmp
+  - boost-cpp
+  - openssl
+  - sqlite
+  - matplotlib
+  - sympy
+  - gmpy2
+
+tests:
+- package_contents:
+    files:
+    - lib/libcadabra2++.a
+    - lib/libcadabra2++_static.a
+    - include/cadabra2++/include/cadabra2++.hh
+
+
+about:
+  homepage: https://cadabra.science/
+  license: GPL-3.0-only
+  license_file: LICENSE
+  summary: A field-theory motivated approach to computer algebra. 
+
+extra:
+  recipe-maintainers:
+  - wangyenshu


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: libcadabra2
- **Version**: 2.5.14

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

