### PR TITLE
Add xerces-c recipe for emscripten-wasm32

### DIFF
--- a/recipes/recipes_emscripten/xerces-c/build.sh
+++ b/recipes/recipes_emscripten/xerces-c/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -exuo pipefail
+
+mkdir -p build
+cd build
+
+emcmake cmake -GNinja \
+    ${CMAKE_ARGS} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+    -DCMAKE_CXX_EXTENSIONS=OFF \
+    -DCMAKE_PREFIX_PATH="${PREFIX}" \
+    -DCMAKE_FIND_ROOT_PATH="${PREFIX}" \
+    -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
+    -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH \
+    -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+    -DICU_ROOT="${PREFIX}" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -Dnetwork=OFF \
+    -Dthreads=OFF \
+    -Dsse2=OFF \
+    -Dtranscoder=icu \
+    -Dmessage-loader=inmemory \
+    -DXERCES_BUILD_DOCS=OFF \
+    -DXERCES_BUILD_SAMPLES=OFF \
+    -DXERCES_BUILD_TESTS=OFF \
+    ..
+
+ninja install

--- a/recipes/recipes_emscripten/xerces-c/patches/allow-cxx-standard-override.patch
+++ b/recipes/recipes_emscripten/xerces-c/patches/allow-cxx-standard-override.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ebf2a9f..1b25dc3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,8 +20,10 @@
+ cmake_minimum_required(VERSION 3.12.0)
+ 
+ # Try C++14, then fall back to C++11 and C++98.  Used for feature tests
+ # for optional features.
+-set(CMAKE_CXX_STANDARD 14)
++if(NOT DEFINED CMAKE_CXX_STANDARD)
++  set(CMAKE_CXX_STANDARD 14)
++endif()
+ 
+ # Use folders (for IDE project grouping)
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/recipes/recipes_emscripten/xerces-c/patches/disable-unneeded-targets.patch
+++ b/recipes/recipes_emscripten/xerces-c/patches/disable-unneeded-targets.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 47a3b1d..c87eb55 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -154,10 +154,16 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/xerces-c.pc.in
+   DESTINATION "${PKGCONFIGDIR}"
+   COMPONENT "development")
+ 
++option(XERCES_BUILD_DOCS "Build Xerces documentation targets" ON)
++option(XERCES_BUILD_SAMPLES "Build Xerces sample programs" ON)
++option(XERCES_BUILD_TESTS "Build Xerces test programs" ON)
++
+ # Process subdirectories
+-add_subdirectory(doc)
+-add_subdirectory(src)
+-add_subdirectory(tests)
+-add_subdirectory(samples)
++if(XERCES_BUILD_DOCS)
++  add_subdirectory(doc)
++endif()
++add_subdirectory(src)
++if(XERCES_BUILD_TESTS)
++  add_subdirectory(tests)
++endif()
++if(XERCES_BUILD_SAMPLES)
++  add_subdirectory(samples)
++endif()
+ 
+ # Display configuration summary

--- a/recipes/recipes_emscripten/xerces-c/recipe.yaml
+++ b/recipes/recipes_emscripten/xerces-c/recipe.yaml
@@ -1,0 +1,51 @@
+context:
+  version: 3.3.0
+
+package:
+  name: xerces-c
+  version: ${{ version }}
+
+source:
+  url: https://downloads.apache.org/xerces/c/3/sources/xerces-c-${{ version }}.tar.gz
+  sha256: 9555f1d06f82987fbb4658862705515740414fd34b4db6ad2ed76a2dc08d3bde
+  patches:
+  - patches/allow-cxx-standard-override.patch
+  - patches/disable-unneeded-targets.patch
+
+build:
+  number: 0
+  script: build.sh
+
+requirements:
+  build:
+  - ${{ compiler('c') }}
+  - ${{ compiler('cxx') }}
+  - cmake
+  - ninja
+  host:
+  - icu 77.*
+
+tests:
+- package_contents:
+    lib:
+    - libxerces-c.a
+    include:
+    - xercesc/util/XercesVersion.hpp
+    files:
+    - lib/cmake/XercesC/XercesCConfig.cmake
+    - lib/cmake/XercesC/XercesCConfigVersion.cmake
+
+about:
+  homepage: https://xerces.apache.org/xerces-c/
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: Apache Xerces-C++ XML parser library
+  description: |
+    Apache Xerces-C++ is a validating XML parser written in a portable subset
+    of C++. This Emscripten recipe builds a static library for wasm32 use.
+  repository: https://github.com/apache/xerces-c
+
+extra:
+  recipe-maintainers:
+  - tritao


### PR DESCRIPTION
## Summary
- add a new `xerces-c` recipe for `emscripten-wasm32`
- build a static library with ICU transcoding and disable docs, samples, and tests in the cross build
- add a small upstream patch so an externally provided `CMAKE_CXX_STANDARD` can override Xerces' default `C++14` setting

## Validation
- built locally with `pixi run build-emscripten-wasm32-pkg recipes/recipes_emscripten/xerces-c`
- package tests passed and produced `lib/libxerces-c.a`, headers, and CMake package files

## Context
This was needed to unblock a downstream FreeCAD wasm configure, which was previously failing at `find_package(XercesC)` because `xerces-c` was missing from the target channel.