### PR TITLE
Fix plotmath rendering in r-base on the cairo FreeType path

### DIFF
--- a/recipes/recipes_emscripten/r-base/build.sh
+++ b/recipes/recipes_emscripten/r-base/build.sh
@@ -91,6 +91,13 @@ pushd _build_wasm
     export LINUX_BUILD_DIR=$(realpath ..)/_build_linux
     export WASM_BUILD_DIR=$(pwd)
 
+    # cairo's probe can't link-run under wasm; force it onto the FreeType path.
+    export r_cv_cairo_works=yes
+    export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+    export CAIRO_CFLAGS="-I$PREFIX/include/cairo -I$PREFIX/include"
+    export CAIRO_LIBS="-L$PREFIX/lib -lcairo -lfreetype -lfontconfig"
+    export CPPFLAGS="${CPPFLAGS:-} -I$PREFIX/include -I$PREFIX/include/cairo"
+
     # RPY_LIBS are appended to $(R_bin_LDADD) when linking the RPY target
     # (see patch 0015). This statically links libpython and its transitive deps
     # into RPY only; the standard R executable is unaffected.
@@ -118,3 +125,11 @@ pushd _build_wasm
 
 )
 popd
+
+#-------------------------------------------------------------------------------
+# FONTS
+#-------------------------------------------------------------------------------
+install -Dm644 "$RECIPE_DIR/fonts.conf" "$PREFIX/lib/R/etc/fonts.conf"
+
+# ${R_HOME} must be in direct position: R's Renviron won't expand it in a default.
+echo 'FONTCONFIG_FILE=${R_HOME}/etc/fonts.conf' >> "$PREFIX/lib/R/etc/Renviron"

--- a/recipes/recipes_emscripten/r-base/fonts.conf
+++ b/recipes/recipes_emscripten/r-base/fonts.conf
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!-- No DOCTYPE: wasm expat cannot resolve the fontconfig URN. -->
+<fontconfig>
+  <dir>/fonts</dir>
+  <cachedir>/tmp/fontconfig</cachedir>
+
+  <!-- DejaVu covers Latin, Greek and math across all four faces; use it for
+       every R family. plotmath routes symbols to the "sans" family with
+       usePUA=FALSE; R remaps sans/serif/mono base faces to Helvetica/times/Courier. -->
+  <alias><family>sans-serif</family><prefer><family>DejaVu Sans</family></prefer></alias>
+  <alias><family>serif</family><prefer><family>DejaVu Serif</family></prefer></alias>
+  <alias><family>monospace</family><prefer><family>DejaVu Sans Mono</family></prefer></alias>
+  <alias><family>Helvetica</family><prefer><family>DejaVu Sans</family></prefer></alias>
+  <alias><family>Times</family><prefer><family>DejaVu Serif</family></prefer></alias>
+  <alias><family>Courier</family><prefer><family>DejaVu Sans Mono</family></prefer></alias>
+  <alias><family>sans</family><accept><family>sans-serif</family></accept></alias>
+  <alias><family>mono</family><accept><family>monospace</family></accept></alias>
+
+  <!-- R requests faces by style name (":style=Italic", ":style=Bold Italic"),
+       but DejaVu names its slanted faces "Oblique". Decompose the style name
+       into fontconfig's strong slant/weight properties so the Bold, Oblique and
+       Bold Oblique faces resolve regardless of the name mismatch. -->
+  <match target="pattern">
+    <test name="style" compare="contains"><string>Bold</string></test>
+    <edit name="weight" mode="assign"><const>bold</const></edit>
+  </match>
+  <match target="pattern">
+    <test name="style" compare="contains"><string>Italic</string></test>
+    <edit name="slant" mode="assign"><const>italic</const></edit>
+  </match>
+</fontconfig>

--- a/recipes/recipes_emscripten/r-base/patches/0013-Fix-cairo-font-scaling-in-emscripten.patch
+++ b/recipes/recipes_emscripten/r-base/patches/0013-Fix-cairo-font-scaling-in-emscripten.patch
@@ -3,21 +3,16 @@ From: Adam Blake <adam@ablake.dev>
 Date: Thu, 19 Jun 2026 00:00:00 +0000
 Subject: [PATCH] Fix cairo font scaling under emscripten
 
-Under emscripten-wasm32, cairo_set_font_size() has no effect: the cairo
-font matrix stays at a fixed scale regardless of the requested size, so
-every string renders at the same size and cex / pointsize changes (for
-example a larger plot title) are silently ignored.
-
-Pin cairo_set_font_size() to 1.0 in FT_getFont and apply the requested
-size as a CTM scale instead. A shared FT_getFontScale() helper selects
-the font, reads back the (stuck) font matrix, and returns size / fm.xx.
-Cairo_MetricInfo and Cairo_StrWidth multiply the returned text metrics by
-that scale so measurement matches rendering; Cairo_Text folds the scale
-into its existing transform stack (translate to the origin, rotate, then
-scale) and draws at (0,0).
+Under emscripten-wasm32 cairo_set_font_size() has no effect: the font matrix
+stays at a fixed scale, so cex / pointsize changes are ignored. Pin the font
+size to 1.0 and apply the requested size as a CTM scale (FT_getFontScale).
+Cairo_Text folds that scale into its transform stack; Cairo_MetricInfo and
+Cairo_StrWidth scale the drawing context around cairo_text_extents and scale
+the returned metrics, so plotmath layout (sub/superscripts, sum and integral
+limits) is measured in the same frame it is drawn in.
 ---
 diff --git a/src/library/grDevices/src/cairo/cairoFns.c b/src/library/grDevices/src/cairo/cairoFns.c
-index 50ff723..906f26e 100644
+index 50ff723..c10f4da 100644
 --- a/src/library/grDevices/src/cairo/cairoFns.c
 +++ b/src/library/grDevices/src/cairo/cairoFns.c
 @@ -1884,7 +1884,6 @@ static void FT_getFont(pGEcontext gc, pDevDesc dd, double fs)
@@ -62,35 +57,41 @@ index 50ff723..906f26e 100644
  static void Cairo_MetricInfo(int c, pGEcontext gc,
  			     double* ascent, double* descent,
  			     double* width, pDevDesc dd)
-@@ -1997,11 +2010,11 @@ static void Cairo_MetricInfo(int c, pGEcontext gc,
+@@ -1997,11 +2010,14 @@ static void Cairo_MetricInfo(int c, pGEcontext gc,
  	str[0] = (char)c; str[1] = 0;
      }
  
 -    FT_getFont(gc, dd, xd->fontscale);
 +    double scale = FT_getFontScale(gc, dd);
++    cairo_save(xd->cc);
++    cairo_scale(xd->cc, scale, scale);
      cairo_text_extents(xd->cc, str, &exts);
 -    *ascent  = -exts.y_bearing;
 -    *descent = exts.height + exts.y_bearing;
 -    *width = exts.x_advance;
++    cairo_restore(xd->cc);
 +    *ascent  = -exts.y_bearing * scale;
 +    *descent = (exts.height + exts.y_bearing) * scale;
 +    *width = exts.x_advance * scale;
  }
  
  static double Cairo_StrWidth(const char *str, pGEcontext gc, pDevDesc dd)
-@@ -2020,9 +2033,9 @@ static double Cairo_StrWidth(const char *str, pGEcontext gc, pDevDesc dd)
+@@ -2020,9 +2036,12 @@ static double Cairo_StrWidth(const char *str, pGEcontext gc, pDevDesc dd)
      } else {
          textstr = str;
      }
 -    FT_getFont(gc, dd, xd->fontscale);
 +    double scale = FT_getFontScale(gc, dd);
++    cairo_save(xd->cc);
++    cairo_scale(xd->cc, scale, scale);
      cairo_text_extents(xd->cc, textstr, &exts);
 -    return exts.x_advance;
++    cairo_restore(xd->cc);
 +    return exts.x_advance * scale;
  }
  
  static void Cairo_Text(double x, double y,
-@@ -2051,15 +2064,16 @@ static void Cairo_Text(double x, double y,
+@@ -2051,15 +2070,16 @@ static void Cairo_Text(double x, double y,
              grouping = cairoBegin(xd);
          }
  

--- a/recipes/recipes_emscripten/r-base/patches/0016-Route-plotmath-symbols-through-Unicode-font.patch
+++ b/recipes/recipes_emscripten/r-base/patches/0016-Route-plotmath-symbols-through-Unicode-font.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Adam Blake <adam@ablake.dev>
+Date: Thu, 19 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Route plotmath symbols through Unicode under emscripten
+
+The cairo device's Type-1 symbol path assumes the Adobe Symbol font. Under
+emscripten there is no pango, and the cairo FreeType path cannot render the
+Adobe Symbol encoding, so plotmath Greek and math symbols render as tofu.
+Route them through Unicode instead, as pango-enabled builds already do.
+---
+--- a/src/library/grDevices/R/cairo.R
++++ b/src/library/grDevices/R/cairo.R
+@@ -96,6 +96,9 @@
+ }
+ 
+ symbolType1support <- function() {
++    ## wasm cairo uses the FreeType path, which cannot render the Adobe
++    ## Symbol Type-1 encoding; use Unicode symbols instead.
++    if (grepl("emscripten", R.version$os)) return(FALSE)
+     pangoVersion <- grSoftVersion()["pango"]
+     pangoVersion == "" ||
+         comparePangoVersion(pangoVersion, "1.44") < 0

--- a/recipes/recipes_emscripten/r-base/recipe.yaml
+++ b/recipes/recipes_emscripten/r-base/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: r-base
   version: 4.6.1
-  build_number: 0
+  build_number: 1
 
 source:
   url: https://cran.r-project.org/src/base/R-4/R-${{ version }}.tar.gz
@@ -21,6 +21,7 @@ source:
   - patches/0012-Remove-png-lib-from-bitmap-libs.patch
   - patches/0013-Fix-cairo-font-scaling-in-emscripten.patch
   - patches/0015-Add-RPY-target-linked-with-libpython.patch
+  - patches/0016-Route-plotmath-symbols-through-Unicode-font.patch
 
 build:
   number: ${{ build_number }}
@@ -100,6 +101,12 @@ outputs:
       - share/man/man1/**
 
   requirements:
+    run:
+    # DejaVu provides /fonts at runtime: one family covering Latin/Greek/math
+    # across all four faces (the cairo FreeType path does no per-glyph fallback).
+    # The shipped fonts.conf aliases R's families to it.
+    - font-ttf-dejavu >=2.37
+    - font-ttf-dejavu-sans-mono >=2.37
     run_exports:
     - ${{ pin_subpackage('r-base', upper_bound='x.x') }}
 


### PR DESCRIPTION
On `emscripten-wasm32`, R's cairo device runs on the FreeType/fontconfig text path (there is no pango in the wasm build), and plotmath renders wrong there in two ways: Greek and math symbols come out as tofu, and composite expressions (subscripts, superscripts, and the limits on sums and integrals) are mis-positioned relative to their base.

The fix has four parts:
- Ship an r-base-owned `fonts.conf` and select it with a `FONTCONFIG_FILE` line appended to `etc/Renviron`. fontconfig's wasm-compiled default config path points at the build prefix, which does not exist at runtime; `Renviron` is read unconditionally at startup, before `FcInit` and regardless of `--vanilla`, so this reliably points fontconfig at a config that exists.
- Add `font-ttf-dejavu` run-deps. DejaVu is one family covering Latin, Greek, and math across all four faces, which the FreeType path needs because it does no per-glyph fallback; `fonts.conf` aliases R's families (Helvetica/Times/Courier plus the sans/serif/mono generics) to DejaVu.
- Patch 0016 (`cairo.R`) routes plotmath symbols through Unicode under emscripten instead of the legacy Adobe Symbol Type-1 font, which the FreeType path cannot render.
- Patch 0013 (`cairoFns.c`) gains a six-line addition: `Cairo_MetricInfo` and `Cairo_StrWidth` scale the drawing context around `cairo_text_extents` so text is measured in the same frame it is drawn in. Without it the existing font-scaling patch measures composite plotmath in a different frame than it draws, mis-positioning it.

Verified by building r-base 4.6.1 for `emscripten-wasm32` and rendering a plotmath test image covering all four font faces of Latin and Greek plus sum, integral, subscript, and superscript composites; all render correctly. An A/B against the unmodified 0013 patch confirms the composite fix is necessary and that the six-line form reproduces it exactly.

## Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [ ] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: r-base
- **Version**: 4.6.1 (build 1)

## Build Notes
Version unchanged at 4.6.1; build number bumped `0 → 1`. Adds one new patch (`0016`, routes plotmath symbols through Unicode under emscripten) and a six-line addition to the existing `0013` cairo font-scaling patch (measures composite text in the frame it is drawn in). Ships a `fonts.conf` installed into `lib/R/etc` and selected via `FONTCONFIG_FILE` in `Renviron`, plus `font-ttf-dejavu` / `font-ttf-dejavu-sans-mono` (>=2.37, conda-forge) run-deps to supply the four DejaVu faces at runtime.
