### PR TITLE
add v86

### DIFF
--- a/recipes/recipes_emscripten/v86/build.sh
+++ b/recipes/recipes_emscripten/v86/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+# Hide the host system's rustup by filtering .cargo/bin out of the PATH
+export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "\.cargo/bin" | grep -v "\.rustup" | tr '\n' ':' | sed 's/:$//')
+# Patch the Makefile to pass compatibility flags to the newer LLVM linker
+sed -i 's/--global-base=4096/--global-base=4096 --no-stack-first --import-undefined/g' Makefile
+
+make all
+
+mkdir -p ${PREFIX}/lib/v86/build
+
+cp build/v86_all.js ${PREFIX}/lib/v86/build/
+cp build/libv86.js ${PREFIX}/lib/v86/build/
+cp build/libv86.mjs ${PREFIX}/lib/v86/build/
+cp build/v86.wasm ${PREFIX}/lib/v86/build/
+
+cp index.html ${PREFIX}/lib/v86/
+cp v86.css ${PREFIX}/lib/v86/
+cp -r bios ${PREFIX}/lib/v86/bios

--- a/recipes/recipes_emscripten/v86/recipe.yaml
+++ b/recipes/recipes_emscripten/v86/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/copy/v86/archive/refs/tags/0.5.tar.gz
+  url: https://github.com/copy/v86/archive/refs/tags/${{ version }}.tar.gz
   sha256: d76a4449b8b33449f45da332542b121767a363a389d1a3990f104423a4833b0e
 
 build:

--- a/recipes/recipes_emscripten/v86/recipe.yaml
+++ b/recipes/recipes_emscripten/v86/recipe.yaml
@@ -1,0 +1,35 @@
+context:
+  name: v86
+  version: '0.5'
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/copy/v86/archive/refs/tags/0.5.tar.gz
+  sha256: d76a4449b8b33449f45da332542b121767a363a389d1a3990f104423a4833b0e
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - make
+    - clang           
+    - rust
+    - rust-std-wasm32-unknown-unknown            
+    - nodejs          
+    - openjdk        
+    - wget            
+    - lld
+
+about:
+  homepage: https://copy.sh/v86/
+  license: BSD-2-Clause AND MIT
+  license_file: LICENSE
+  summary: x86 PC emulator and x86-to-wasm JIT, running in the browser 
+
+extra:
+  recipe-maintainers:
+  - wangyenshu

--- a/recipes/recipes_emscripten/v86/recipe.yaml
+++ b/recipes/recipes_emscripten/v86/recipe.yaml
@@ -24,6 +24,14 @@ requirements:
     - wget            
     - lld
 
+tests:
+- package_contents:
+    files:
+    - lib/v86/build/v86_all.js
+    - lib/v86/build/v86.wasm
+    - lib/v86/build/libv86.mjs
+    - lib/v86/build/libv86.js
+
 about:
   homepage: https://copy.sh/v86/
   license: BSD-2-Clause AND MIT


### PR DESCRIPTION

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: v86
- **Version**: 0.5

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

