### PR TITLE
Add passagemath-cddlib

### DIFF
--- a/recipes/recipes_emscripten/passagemath-cddlib/recipe.yaml
+++ b/recipes/recipes_emscripten/passagemath-cddlib/recipe.yaml
@@ -1,0 +1,67 @@
+context:
+  version: 10.8.5
+
+package:
+  name: passagemath-cddlib
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/p/passagemath-cddlib/passagemath_cddlib-${{ version }}.tar.gz
+  sha256: cc821f27be40330a9b9143a2b7eb92cb2454f5002c2e1f24c0eaeedec80fe0e0
+
+build:
+  script: ${{ PYTHON }} -m pip install .
+  number: 0
+
+requirements:
+  build:
+  - python
+  - crossenv >=1.2
+  - cross-python_emscripten-wasm32
+  - ${{ compiler("c") }}
+  - ${{ compiler("cxx") }}
+  - pip
+  - passagemath-setup
+  - passagemath-environment
+  - cython
+  - cysignals
+  - pkgconfig
+  - passagemath-abi == ${{ version }}
+  host:
+  - python
+  - cddlib
+  - gmp
+  run:
+  - python
+  - cysignals
+  - passagemath-environment
+  - passagemath-polyhedra
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_passagemath_cddlib.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+    - passagemath-repl
+
+about:
+  license: GPL-2.0-or-later
+  license_file: README.rst
+  summary: 'passagemath: Polyhedral computation with cddlib'
+  description: |
+    Distribution of a part of the Sage library.
+    It provides an interface to cddlib, the library for polyhedral
+    representation conversion using the double description method.
+
+extra:
+  emscripten_tests:
+    python:
+      pytest_files:
+      - test_passagemath_cddlib.py
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/passagemath-cddlib/test_passagemath_cddlib.py
+++ b/recipes/recipes_emscripten/passagemath-cddlib/test_passagemath_cddlib.py
@@ -1,0 +1,5 @@
+import pytest
+
+
+def test_import_passagemath_cddlib():
+    import passagemath_cddlib


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: passagemath-cddlib
- **Version**: 10.8.5

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

