### PR TITLE
Add passagemath-qepcad

### DIFF
--- a/recipes/recipes_emscripten/passagemath-qepcad/recipe.yaml
+++ b/recipes/recipes_emscripten/passagemath-qepcad/recipe.yaml
@@ -1,0 +1,65 @@
+context:
+  version: 10.8.5
+
+package:
+  name: passagemath-qepcad
+  version: ${{ version }}
+
+source:
+- url: https://pypi.org/packages/source/p/passagemath-qepcad/passagemath_qepcad-${{ version }}.tar.gz
+  sha256: 00689c52e2b281eb7a19f7c2947874fec10e2284fff69fc9dde940a5b1d16323
+
+build:
+  script: ${{ PYTHON }} -m pip install .
+  number: 0
+
+requirements:
+  build:
+  - python
+  - crossenv >=1.2
+  - cross-python_emscripten-wasm32
+  - ${{ compiler("c") }}
+  - ${{ compiler("cxx") }}
+  - pip
+  - passagemath-setup
+  - passagemath-environment
+  - cython
+  - cysignals
+  - pkgconfig
+  - passagemath-abi == ${{ version }}
+  host:
+  - python
+  run:
+  - python
+  - tarski
+  - cysignals
+  - passagemath-environment
+  - passagemath-repl
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_passagemath_qepcad.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+    - passagemath-symbolics
+
+about:
+  license: GPL-2.0-or-later
+  license_file: README.rst
+  summary: 'passagemath: Quantifier elimination by partial cylindrical algebraic decomposition with QEPCAD'
+  description: |
+    Distribution of a part of the Sage library.
+    It provides an interface to QEPCAD.
+
+extra:
+  emscripten_tests:
+    python:
+      pytest_files:
+      - test_passagemath_qepcad.py
+  recipe-maintainers:
+  - mkoeppe

--- a/recipes/recipes_emscripten/passagemath-qepcad/test_passagemath_qepcad.py
+++ b/recipes/recipes_emscripten/passagemath-qepcad/test_passagemath_qepcad.py
@@ -1,0 +1,5 @@
+import pytest
+
+
+def test_import_passagemath_qepcad():
+    import passagemath_qepcad


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: passagemath-qepcad
- **Version**: 10.8.5

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

Adding this package, with thanks to @wangyenshu for packaging qepcad as part of tarski in https://github.com/emscripten-forge/recipes/pull/5740