### PR TITLE
Constrain r-base v4.5.3 build in cross-r-base

### DIFF
--- a/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/cross-r-base_emscripten-wasm32/recipe.yaml
@@ -1,17 +1,17 @@
 context:
   name: cross-r-base_emscripten-wasm32
-  version: 4.6.1
+  version: 4.5.3
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 build:
-  number: 0
+  number: 2
 
 requirements:
   run:
-  - r-base ==${{ version }}
+  - r-base ==${{ version }} h15dba0b_1
   - emscripten_emscripten-wasm32
 
 tests:

--- a/recipes/recipes_emscripten/r-later/recipe.yaml
+++ b/recipes/recipes_emscripten/r-later/recipe.yaml
@@ -15,9 +15,9 @@ source:
   - patches/0001-Disable-multi-threading.patch
 
 build:
-  number: 5
+  number: 6
   # Dependencies not yet available for R 4.6.0 on conda-forge
-  skip: ${{ r_base == '4.6.0' }}
+  skip: ${{ r_base == '4.6.1' }}
   script: $R CMD INSTALL $R_ARGS .
 
 requirements:
@@ -27,7 +27,6 @@ requirements:
   - ${{ compiler('cxx') }}
   - r-rcpp
   - r-rlang
-  - r-base ==4.5.3 h15dba0b_1
   host:
   - r-base ==${{ r_base }}
   - r-rcpp


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

- The newest builds of `r-base` v4.5.3 depends on `gxx_linux` -> `binutils_linux`. The activation script of `binutils_linux` sets many environment variables which conflict with our build process.

```bash
CFLAGS=-march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -fno-merge-constants -isystem
```

- This pins `r-base` to a previous build which does not depend on `binutils_linux`.