### PR TITLE
Rebuild netcdf4; Rebuild libnetcdf; fix runtime failure due to missing listxattr

### DIFF
--- a/recipes/recipes_emscripten/libnetcdf/patches/skip-daos-emscripten.patch
+++ b/recipes/recipes_emscripten/libnetcdf/patches/skip-daos-emscripten.patch
@@ -1,0 +1,25 @@
+DAOS container detection uses listxattr/getxattr which are declared in
+Emscripten's <sys/xattr.h> but not implemented at runtime — the built .so
+fails to load with "cannot resolve symbol listxattr". DAOS makes no sense
+in a WASM sandbox anyway. Short-circuit isdaoscontainer() under
+__EMSCRIPTEN__ so the xattr code is never reached.
+
+--- a/libdispatch/dinfermodel.c
++++ b/libdispatch/dinfermodel.c
+@@ -1594,6 +1594,10 @@
+ static int
+ isdaoscontainer(const char* path)
+ {
++#ifdef __EMSCRIPTEN__
++    (void)path;
++    return NC_ENOTNC;
++#else
+     int stat = NC_ENOTNC; /* default is that this is not a DAOS container */
+ #ifndef _WIN32
+ #ifdef USE_HDF5
+@@ -1669,6 +1673,7 @@
+ #endif
+     errno = 0; /* reset */
+     return stat;
++#endif /* __EMSCRIPTEN__ */
+ }

--- a/recipes/recipes_emscripten/libnetcdf/recipe.yaml
+++ b/recipes/recipes_emscripten/libnetcdf/recipe.yaml
@@ -12,9 +12,10 @@ source:
   patches:
   - patches/parallel-disable.patch
   - patches/hdf5-parallel-disable.patch
+  - patches/skip-daos-emscripten.patch
 
 build:
-  number: 0
+  number: 1
 
   files:
     exclude:

--- a/recipes/recipes_emscripten/netcdf4/recipe.yaml
+++ b/recipes/recipes_emscripten/netcdf4/recipe.yaml
@@ -13,9 +13,9 @@ source:
   - patches/0001-Fix-unknown-arg-R-PREFIX-lib.patch
 
 build:
-  number: 2
+  number: 3
   script:
-  - export LDFLAGS="-L$PREFIX/lib -lhdf5 $LDFLAGS"
+  - export LDFLAGS="-L$PREFIX/lib -lhdf5 -lhdf5_hl $LDFLAGS"
   - ${PYTHON} -m pip install . -vvv
 
   files:

--- a/recipes/recipes_emscripten/netcdf4/test_netcdf4.py
+++ b/recipes/recipes_emscripten/netcdf4/test_netcdf4.py
@@ -1,7 +1,33 @@
-def test_netcdf4():
-  from netCDF4 import Dataset
-  rootgrp = Dataset("test.nc", "w", format="NETCDF4")
-  rootgrp.data_model == "NETCDF4"
-  rootgrp.close()
+import numpy as np
+import netCDF4
+from netCDF4 import Dataset
 
 
+def test_versions():
+    print("netCDF4:", netCDF4.__version__)
+    print("libnetcdf:", netCDF4.__netcdf4libversion__)
+    print("libhdf5:", netCDF4.__hdf5libversion__)
+
+
+def test_netcdf3_write_read(tmp_path):
+    path = str(tmp_path / "c.nc")
+    with Dataset(path, "w", format="NETCDF3_CLASSIC") as ds:
+        ds.createDimension("x", 4)
+        v = ds.createVariable("temp", "f8", ("x",))
+        v[:] = np.arange(4.0)
+    with Dataset(path, "r") as ds:
+        assert ds.variables["temp"].shape == (4,)
+
+
+def test_netcdf4_roundtrip(tmp_path):
+    """End-to-end netcdf-4 round-trip: dim + variable + attribute."""
+    path = str(tmp_path / "v.nc")
+    with Dataset(path, "w", format="NETCDF4") as ds:
+        ds.title = "hello"
+        ds.createDimension("x", 4)
+        v = ds.createVariable("temp", "f8", ("x",))
+        v[:] = np.arange(4.0)
+    with Dataset(path, "r") as ds:
+        assert ds.title == "hello"
+        assert "x" in ds.dimensions
+        np.testing.assert_array_equal(ds.variables["temp"][:], np.arange(4.0))

--- a/variant.yaml
+++ b/variant.yaml
@@ -449,7 +449,7 @@ libmatio:
 libmicrohttpd:
   - 0.9
 libnetcdf:
-  - 4.9.3
+  - 4.10.1
 libopencv:
   - 4.5.5
 libpcap:


### PR DESCRIPTION
Edited after splitting out new PR #6007 . 

# Summary 

Fixes the runtime failure `xarray.open_dataset(...)` → `netCDF4.Dataset` → `nc_open` → `H5DSis_scale` → `Dynamic linking error: cannot resolve symbol H5DSis_scale` in the browser, and the follow-on `RuntimeError: ring type mismatch occurred for cache entry` that surfaces once `H5DSis_scale` is reachable.

# Build Notes

- **netcdf4**: add `-lhdf5_hl` to LDFLAGS. This may not strictly be necessary since it seems to be activated by default. But it's probably safer to add. The bug we observed was related to this library.
- **libnetcdf**: skip the DAOS-container check under `__EMSCRIPTEN__`: netcdf-c 4.10.1 references `listxattr` from `libdispatch/dinfermodel.c`inside the DAOS-container probe, guarded by `HAVE_SYS_XATTR_H`. Emscripten's `<sys/xattr.h>` declares `listxattr` but the runtime doesn't implement it, so the built `.so` fails to load. `configure.ac` seems to have no DAOS knobs. We therefore patch the source to early-return `NC_ENOTNC` under `__EMSCRIPTEN__`. Attempting to set the variable `ac_cv_header_sys_xattr_h=no` produced garbled compile errors in the surrounding `isdaoscontainer()` function under `-std=gnu23` and was abandoned.
- `variant.yaml` bumped: `hdf5: 1.14.6`, `libnetcdf: 4.10.1`.