### PR TITLE
Update hdf5 to 1.14.6; rebuild h5py

### DIFF
--- a/recipes/recipes_emscripten/h5py/build.sh
+++ b/recipes/recipes_emscripten/h5py/build.sh
@@ -1,11 +1,4 @@
 
-# add ad-hoc code to load the shared libs
-tmp_file="$(mktemp)"
-printf 'import ctypes;ctypes.CDLL("/lib/libhdf5.so");ctypes.CDLL("/lib/libhdf5_hl.so")\n' > "$tmp_file"
-cat "h5py/__init__.py" >> "$tmp_file"
-mv "$tmp_file" "h5py/__init__.py"
-
-
 # remove the emcc symlink in the $BUILD_PREFIX/bin
 rm $BUILD_PREFIX/bin/emcc
 
@@ -30,7 +23,7 @@ export H5PY_DIRECT_VFD='0'
 export HDF5_MPI=OFF
 
 # Explitly set HDF5 version
-export HDF5_VERSION=1.12.3
+export HDF5_VERSION=1.14.6
 
 ${PYTHON} -m pip install . -vvv
 

--- a/recipes/recipes_emscripten/h5py/recipe.yaml
+++ b/recipes/recipes_emscripten/h5py/recipe.yaml
@@ -13,7 +13,7 @@ source:
   - patches/configure.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipes/recipes_emscripten/h5py/test_h5py.py
+++ b/recipes/recipes_emscripten/h5py/test_h5py.py
@@ -35,3 +35,19 @@ def test_usage():
 
     f = h5py.File("mytestfile.hdf5", "r")
     assert sorted(list(f.keys())) == ["mydataset", "subgroup"]
+
+
+def test_dimscales(tmp_path):
+    """Exercises the HL dimscale reopen path across a File close/open cycle."""
+    import h5py
+
+    path = str(tmp_path / "dimscales.h5")
+    with h5py.File(path, "w") as f:
+        scale = f.create_dataset("x", data=[0.0, 1.0, 2.0, 3.0])
+        scale.make_scale("x")
+        data = f.create_dataset("temp", data=[10.0, 20.0, 30.0, 40.0])
+        data.dims[0].attach_scale(scale)
+
+    with h5py.File(path, "r") as f:
+        assert h5py.h5ds.is_scale(f["x"].id)
+        assert f["temp"].dims[0][0].name == "/x"

--- a/recipes/recipes_emscripten/hdf5/build.sh
+++ b/recipes/recipes_emscripten/hdf5/build.sh
@@ -3,8 +3,6 @@ cd build
 
 export LDFLAGS="-sNODERAWFS=1 -sUSE_ZLIB=1 -sFORCE_FILESYSTEM=1"
 
-cp ${RECIPE_DIR}/settings/* ../src/
-
 emcmake cmake .. \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DH5_HAVE_GETPWUID=OFF \
@@ -21,13 +19,11 @@ emcmake cmake .. \
     -DHDF5_BUILD_EXAMPLES=OFF \
     -DHDF5_BUILD_TOOLS=OFF \
     -DHDF5_BUILD_UTILS=OFF \
+    -DHDF5_BUILD_HL_LIB=ON \
     -DHDF5_ENABLE_Z_LIB_SUPPORT=ON \
     -DHDF5_ENABLE_ROS3_VFD=OFF \
     -DZLIB_INCLUDE_DIR=${PREFIX}/include \
     -DZLIB_LIBRARY=${PREFIX}/lib/libz.a
-
-cp ${RECIPE_DIR}/settings/* ../src/
-cp ${RECIPE_DIR}/settings/* src/
 
 emmake make -j 4
 emmake make install

--- a/recipes/recipes_emscripten/hdf5/patches/0001-fenv-fe-invalid-guard.patch
+++ b/recipes/recipes_emscripten/hdf5/patches/0001-fenv-fe-invalid-guard.patch
@@ -1,0 +1,22 @@
+Emscripten's <bits/fenv.h> defines only rounding modes and
+FE_ALL_EXCEPT=0; FE_INVALID is not defined because WASM has no
+floating-point exception flags. Guard the FE_INVALID clear so
+the build proceeds; under WASM there are no FP exceptions to
+clear, so the guarded branch is a legitimate no-op. This fix
+seems to already be in hdf5 2.x and the patch can likely be
+removed when upgrading.
+
+--- a/src/H5Tinit_float.c
++++ b/src/H5Tinit_float.c
+@@ -608,9 +608,11 @@
+ #endif
+
+ done:
++#ifdef FE_INVALID
+     /* Clear any FE_INVALID exceptions from NaN handling */
+     if (feclearexcept(FE_INVALID) != 0)
+         HSYS_GOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "can't clear floating-point exceptions");
++#endif
+
+     /* Restore the original environment */
+     if (feupdateenv(&saved_fenv) != 0)

--- a/recipes/recipes_emscripten/hdf5/patches/0002-drop-soversion.patch
+++ b/recipes/recipes_emscripten/hdf5/patches/0002-drop-soversion.patch
@@ -1,0 +1,81 @@
+Skip VERSION/SOVERSION under emscripten so every NEEDED entry records the bare
+"libhdf5.so" and the runtime loader doesn't double load libhdf5 because of
+different names for the same library. This is tested by the associated dimscale
+test in h5py.
+
+Mechanism (see also https://github.com/emscripten-forge/recipes/pull/6007):
+
+h5py depends on libhdf5_hl (-lhdf5_hl) and on libhdf5 (-lhdf5). But libhdf5_hl
+itself also depends on libhdf5, albeit with the *versioned* instead of just the
+bare name. On emscripten, with VERSION/SOVERSION stamped on libhdf5, libhdf5_hl
+records NEEDED = libhdf5.so.310.5.1 while consumers that link with bare -lhdf5
+(e.g. h5py's Cython extensions) record NEEDED = libhdf5.so. In contrast to
+native, names are *not* harmonized to major version at link time, and also not
+resolved to realpaths to deduplicate symlinks. We may therefore end up with
+instance A of libhdf5 loaded to satisfy libhdf5_hl and instance B loaded to
+satisfy h5py's Cython extensions. 
+
+However, in wasm partial deduplication still happens. After load, a global
+"GOT" symbol table is built that contains all symbols in one name space. In the
+case of duplicate symbols, the first symbol added wins, and others with the
+same name are ignored with duplicate symbol warnings. Practically, this means
+for each duplicate symbol, only one library's instance is accessible through
+the GOT table.
+
+But this doesn't concern *static* variables that aren't exported and don't go
+through the GOT table. Those static variable can, in principle, influence
+global state at load time and lead to incoherent state if two instances of the
+same library are loaded.
+
+The second escape hatch is dlopen as used by CPython. When emscripten
+instantiates a dlopen'd side module, or any side module pulled in transitively,
+it resolves that module's *function imports* against the specific dependency
+named in its own NEEDED list, not through the global GOT. So even though the
+GOT-first-wins rule points every libhdf5 symbol at instance A, the h5py Cython
+.so (whose NEEDED lists both libhdf5.so and libhdf5_hl.so) has its direct calls
+into libhdf5 bound to instance B, while libhdf5_hl (itself NEEDING
+libhdf5.so.310.5.1) has its calls into libhdf5 bound to instance A. A single
+dlopen of one h5py .so therefore ends up reaching different libhdf5 instances.
+
+In the presence of instance-wide state, this makes problems. In this case,
+H5CX_head_g, the head pointer of HDF5's API-context stack, is a static in
+H5CX.c. It has no external name and therefore no GOT slot: every intra-libhdf5
+reference to it compiles to a direct data reference into that instance's
+separate memory. So each libhdf5 instance has its own H5CX_head_g.
+
+And because of dlopen, inside a single Python call chain, execution alternates
+between instances. A public API call entered via instance B pushes onto B's
+H5CX_head_g. That code then calls into HDF5's cache layer via calls that go
+through the global GOT, which resolves them to instance A (first-wins). A's
+H5C_protect then reads instance A's H5CX_head_g which is empty, because the
+corresponding push was on B. HDF5 detects the tag mismatch and reports "ring
+type mismatch occurred for cache entry."
+
+We traced this by adding print statements to H5CX__push_common, H5CX_pop and
+H5CX_get_tag with printfs of &H5CX_head_g and *H5CX_head_g, then running h5py's
+dimscale test. The log shows two distinct &H5CX_head_g addresses, an
+interleaved push-on-B / read-on-A sequence at the failure point, and the empty
+stack that produces the bad tag. We also used a minimal reproducer linked in
+the above PR to test link behavior directly locally.
+
+The final fix is simple, skipping SOVERSION so both consumers record the same
+NEEDED string sidesteps the whole thing. A more general fix would be nice but
+it's unclear how it should look like at the moment.
+
+
+--- a/config/cmake/HDF5Macros.cmake
++++ b/config/cmake/HDF5Macros.cmake
+@@ -22,10 +22,10 @@
+     else ()
+       set (LIBHDF_VERSION ${HDF5_${libpackage}_PACKAGE_SOVERSION_MAJOR})
+     endif ()
+-    set_target_properties (${libtarget} PROPERTIES VERSION ${PACKAGE_SOVERSION})
++    if (NOT EMSCRIPTEN)
++      set_target_properties (${libtarget} PROPERTIES VERSION ${PACKAGE_SOVERSION})
++    endif ()
+     if (WIN32)
+         set (${LIB_OUT_NAME} "${LIB_OUT_NAME}-${LIBHDF_VERSION}")
+-    else ()
++    elseif (NOT EMSCRIPTEN)
+         set_target_properties (${libtarget} PROPERTIES SOVERSION ${LIBHDF_VERSION})
+     endif ()

--- a/recipes/recipes_emscripten/hdf5/recipe.yaml
+++ b/recipes/recipes_emscripten/hdf5/recipe.yaml
@@ -1,14 +1,17 @@
 context:
-  version: 1.12.3
-  maj_min_ver: 1.12
+  version: 1.14.6
+  maj_min_ver: 1.14
 
 package:
   name: hdf5
   version: ${{ version }}
 
 source:
-  url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${{ maj_min_ver }}/hdf5-${{version }}/src/hdf5-${{ version }}.tar.gz
-  sha256: c15adf34647918dd48150ea1bd9dffd3b32a3aec5298991d56048cc3d39b4f6f
+  url: https://support.hdfgroup.org/releases/hdf5/v${{ maj_min_ver | replace(".", "_") }}/v${{ version | replace(".", "_") }}/downloads/hdf5-${{ version }}.tar.gz
+  sha256: e4defbac30f50d64e1556374aa49e574417c9e72c6b1de7a4ff88c4b1bea6e9b
+  patches:
+  - patches/0001-fenv-fe-invalid-guard.patch
+  - patches/0002-drop-soversion.patch
 
 build:
   number: 0
@@ -20,6 +23,14 @@ requirements:
   - ${{ compiler("c") }}
   host:
   - zlib
+
+tests:
+- package_contents:
+    files:
+    - include/hdf5.h
+    - include/hdf5_hl.h
+    - lib/libhdf5.so
+    - lib/libhdf5_hl.so
 
 about:
   homepage: https://www.hdfgroup.org/solutions/hdf5/

--- a/variant.yaml
+++ b/variant.yaml
@@ -383,7 +383,7 @@ harfbuzz:
 hdf4:
   - 4.2
 hdf5:
-  - 1.12.3
+  - 1.14.6
 icu:
   - '73'
 ipopt:


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- ~[ ] ⚠️ Bump build number if the version remains unchanged.~ Version changed.
- [x] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**:  hdf5
- **Version**:  1.14.6

## Build Notes

- This updated was initiated by a hard failure in netcdf when writing files (see #5951)
- It's a small update to 1.14.6. Upstream is already at 2.x since Nov 2025. Another update may be needed soon.

There are two patches here, both quite simple but the second difficult to find even with Opus 4.7 assistance:

- the simple one  0001-fenv-fe-invalid-guard.patch guards FE_INVALID use in H5Tinit_float.c which emscripten does not declare. This patch is already upstream in hdf5 2.x and can probably be dropped once we update further
      https://github.com/HDFGroup/hdf5/blob/f8844a64c639f7ba33592a7948d4adacacb2d451/src/H5Tinit_float.c#L614-L617
 - the more complex one, patches/0002-drop-soversion.patch: skips VERSION/SOVERSION under EMSCRIPTEN so libhdf5_hl.so records bare "libhdf5.so" as its NEEDED entry. Otherwise it records "libhdf5.so.310.5.1" while other packages link with -lhdf5 and record "libhdf5.so". The emscripten loader seems to dedupe by string identity (not realpath) and ends up loading libhdf5.so twice. One visible symptom of this was that the hdf5 metadata cache errors when calls cross between those two loaded instances, something which blocks simple file reading and also affects  netcdf4 transitively. We discovered dual loading by consequently tracing back the error to hdf5 (a metadata ring error), then outputting memory addresses and realizing that there were two addresses where there should only be one at some point, causing the actual failure. Note that this is a hot fix and a proper solution that also works for other libraries would be nicer to have. We added a dimension-scale round-trip test to h5py to test the failure path associated with this patch.