### PR TITLE
Patch emscripten's `PROXYFS.rename` to remove target before rename

### DIFF
--- a/recipes/recipes/emscripten_emscripten-wasm32/patches/0007-Unlink-target-in-PROXYFS-rename.patch
+++ b/recipes/recipes/emscripten_emscripten-wasm32/patches/0007-Unlink-target-in-PROXYFS-rename.patch
@@ -1,0 +1,26 @@
+From 9bdfc795308e1f09e8476f7f95a30373ca7dcddf Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Mon, 27 Jul 2026 10:28:22 +0100
+Subject: [PATCH] Unlink target in PROXYFS rename
+
+---
+ src/lib/libproxyfs.js | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/lib/libproxyfs.js b/src/lib/libproxyfs.js
+index 6a2a9d35e..e536daa3f 100644
+--- a/src/lib/libproxyfs.js
++++ b/src/lib/libproxyfs.js
+@@ -106,6 +106,9 @@ addToLibrary({
+       rename(oldNode, newDir, newName) {
+         var oldPath = PROXYFS.realPath(oldNode);
+         var newPath = PATH.join2(PROXYFS.realPath(newDir), newName);
++        try {
++          FS.unlink(newPath);
++        } catch(e) {}
+         try {
+           oldNode.mount.opts.fs.rename(oldPath, newPath);
+           oldNode.name = newName;
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
+++ b/recipes/recipes/emscripten_emscripten-wasm32/recipe.yaml
@@ -4,7 +4,7 @@ context:
   abi_version: 4.0.9
 
 build:
-  number: 8
+  number: 9
 
 outputs:
   - package:


### PR DESCRIPTION
If you do a `rename` syscall on a `PROXYFS` filesystem you can leave the filesystem in an inconsistent state as the file operations themselves are performed correctly but the `PROXYFS` maintains a `nameTable` cache which is not cleared correctly. The sequence of filesystem calls to reproduce this is:

1. Create `source` file
2. Create `target` file
3. `rename(source, target)`
4. Delete `target`
5. Create `target` file again - this fails

The fix is to explicitly remove the `target` in the `PROXYFS.rename` call, which is that this patch does. I believe this is a bug in emscripten which needs the same patch in `PROXYFS` that was added to `library_nodefs.js` in emscripten-core/emscripten#23074.

It is quite difficult to reproduce this error as most high-level use of `rename` functionality tends to explicitly remove the target before the rename anyway. I can reproduce it in a simple C file using the above sequence, compiled to wasm and used in the JupyterLite terminal which uses `PROXYFS` to access the JupyterLite shared drive. `git2cpp` uses the problem workflow a lot and what led me to look at this.

After this is merged I will need to rebuild `cockle_fs` and all of the `cockle` command packages, although I will only rebuild those I know are problematic as the others will pick up the fix on their next rebuild anyway. In time I will look into upstreaming this fix to emscripten itself.

If we don't want to patch emscripten with this, I can separately patch each recipe that needs this but of course that will touch many more recipes.