### PR TITLE
osx runner

### DIFF
--- a/.github/workflows/build_recipes.yaml
+++ b/.github/workflows/build_recipes.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
 
   build_recipes:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     env:
       FORCE_COLOR: 1
       TARGET_PLATFORM: emscripten-wasm32
@@ -103,10 +103,22 @@ jobs:
 
           # add github workspace to python path
           export PYTHONPATH="${GITHUB_WORKSPACE}:${PYTHONPATH}"
-          
+          case "$(uname -s)" in
+              Darwin)
+                  # macOS: only upload osx-arm64
+                  platforms=(osx-arm64)
+                  ;;
+              Linux)
+                  # Linux: upload Linux artifacts
+                  platforms=(emscripten-wasm32 linux-64 noarch)
+                  ;;
+              *)
+                  echo "Unsupported OS: $(uname -s)"
+                  exit 1
+                  ;;
+          esac
           overall_success=true
-          # Loop over {emscripten-wasm32, linux-64, noarch}
-          for platform in emscripten-wasm32 linux-64 noarch; do
+          for platform in "${platforms[@]}"; do
             if [ -d "${GITHUB_WORKSPACE}/output/${platform}" ]; then
               cd "${GITHUB_WORKSPACE}/output/${platform}"
               files=$(ls *.tar.bz2 2> /dev/null)

--- a/emci/find_recipes_with_changes.py
+++ b/emci/find_recipes_with_changes.py
@@ -1,6 +1,8 @@
 from .git_utils import find_files_with_changes
 from .constants import RECIPES_SUBDIR_MAPPING
 import os
+import platform
+
 
 def find_recipes_with_changes(old, new):
     files_with_changes = find_files_with_changes(old=old, new=new)
@@ -8,6 +10,11 @@ def find_recipes_with_changes(old, new):
     recipes_with_changes = {k: set() for k in RECIPES_SUBDIR_MAPPING.keys()}
     # print("recipes_with_changes", recipes_with_changes)
     for subdir in RECIPES_SUBDIR_MAPPING.keys():
+        if  platform.system() == "Darwin" and subdir == "recipes_emscripten":
+            # skip recipes_emscripten on macOS
+            # we only build recipes/recipes on macOS
+            continue
+            
         for file_with_change in files_with_changes:
             if file_with_change.startswith(f"recipes/{subdir}/"):
                 # print(file_with_change)


### PR DESCRIPTION
* adding osx/darwin runner to ci
* only build recipes from `recipes/recipes/**` (ie skipping `recipes/recipes_emscripten/**` when on darwin
* only upload from `osx-arm64` when on darwin, upload for `emscripten-wasm32,linux-64,noarch` when on linux