### PR TITLE
Rebuild cockle_fs to use patched emscripten PROXYFS.rename

### DIFF
--- a/recipes/recipes_emscripten/cockle_fs/build.sh
+++ b/recipes/recipes_emscripten/cockle_fs/build.sh
@@ -1,7 +1,3 @@
-# Need tsc installed and available in PATH to use --emit-tsd
-npm install typescript
-export PATH=$SRC_DIR/node_modules/typescript/bin:$PATH
-
 touch fs.c
 emcc fs.c -o fs.js \
     -Os \

--- a/recipes/recipes_emscripten/cockle_fs/recipe.yaml
+++ b/recipes/recipes_emscripten/cockle_fs/recipe.yaml
@@ -6,16 +6,15 @@ package:
   name: ${{ name }}
   version: ${{ version }}
 
-source:
-
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
     - ${{ compiler("c") }}
     - cmake
     - nodejs
+    - typescript<6
 
 tests:
 - package_contents:


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [ ] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: cockle_fs
- **Version**: 0.3.0

## Build Notes

Rebuild to use patched emscripten `PROXYFS.rename` (#6067). Also moved `typescript` to be a build-time dependency rather than manually installing it.
