### PR TITLE
Fix tinyarray 1.2.5 wasm object layout

### DIFF
--- a/recipes/recipes_emscripten/tinyarray/patches/0001-fix-wasm-object-layout.patch
+++ b/recipes/recipes_emscripten/tinyarray/patches/0001-fix-wasm-object-layout.patch
@@ -1,0 +1,31 @@
+diff --git a/src/array.hh b/src/array.hh
+index a7e2ba5..11f00a6 100644
+--- a/src/array.hh
++++ b/src/array.hh
+@@ -94,6 +94,13 @@ MOD_INIT_FUNC(tinyarray);
+ template <typename T>
+ class Array : public Array_base {
+ public:
++    // PyVarObject is only 4-byte aligned on wasm32, while double and
++    // complex<double> require 8-byte alignment.  Therefore, the first item
++    // does not necessarily start immediately after Array_base.
++    static Py_ssize_t item_offset() {
++        return sizeof(Array<T>) - sizeof(T);
++    }
++
+     T *data() {
+         if (ob_base.ob_size >= -1) {
+             // ndim == 0 or 1
+diff --git a/src/array.cc b/src/array.cc
+index 3de04e7..3694b6d 100644
+--- a/src/array.cc
++++ b/src/array.cc
+@@ -1897,7 +1897,7 @@ template <typename T>
+ PyTypeObject Array<T>::pytype = {
+     PyVarObject_HEAD_INIT(&PyType_Type, 0)
+     pyname,
+-    sizeof(Array_base),             // tp_basicsize
++    Array<T>::item_offset(),         // tp_basicsize
+     sizeof(T),                      // tp_itemsize
+     (destructor)PyObject_Del,       // tp_dealloc
+     0,                              // tp_print

--- a/recipes/recipes_emscripten/tinyarray/recipe.yaml
+++ b/recipes/recipes_emscripten/tinyarray/recipe.yaml
@@ -9,10 +9,12 @@ package:
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: 5d47b3d475a30478ee72d6afe238c3d3683b3a3f9d425bb2f6384270b2c8799b
+  patches:
+  - patches/0001-fix-wasm-object-layout.patch
 
 build:
-  number: 2
-  script: ${PYTHON} -m pip install . ${PIP_ARGS}
+  number: 3
+  script: LD_LIBRARY_PATH=${BUILD_PREFIX}/lib ${PYTHON} -m pip install . ${PIP_ARGS}
 
   files:
     exclude:
@@ -39,6 +41,7 @@ tests:
     build:
     - pytester
     run:
+    - numpy
     - pytester-run
 
 about:

--- a/recipes/recipes_emscripten/tinyarray/test_import_tinyarray.py
+++ b/recipes/recipes_emscripten/tinyarray/test_import_tinyarray.py
@@ -1,2 +1,14 @@
-def test_import_tinyarray():
-    import tinyarray  # noqa: F401
+import numpy as np
+import tinyarray as ta
+
+
+def test_multidimensional_aligned_dtypes():
+    for dtype in (float, complex):
+        for shape in ((1, 2), (2, 3), (2, 2, 2)):
+            array = ta.ones(shape, dtype)
+
+            assert ta.array(np.asarray(array)) == array
+            assert array + array == 2 * array
+
+        matrix = ta.ones((2, 2), dtype)
+        assert ta.dot(matrix, matrix) == ta.array([[2, 2], [2, 2]])


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [ ] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: tinyarray
- **Version**: 1.2.5

## Build Notes

The current tinyarray packaging is broken because it needs to be patched for wasm memory layout, this PR fixes that and calls the build with correct paths. Because there is no version bump, the PR title does not follow the requirements (not sure what the right one should be).