### PR TITLE
Fix Kwant 1.5.0 recipe

### DIFF
--- a/recipes/recipes_emscripten/kwant/build.sh
+++ b/recipes/recipes_emscripten/kwant/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export LIBRARY_PATH="${PREFIX}/lib"
-export LD_LIBRARY_PATH="${PREFIX}/lib"
+export LD_LIBRARY_PATH="${BUILD_PREFIX}/lib"
 
 $PYTHON setup.py build --cython
 $PYTHON setup.py install

--- a/recipes/recipes_emscripten/kwant/recipe.yaml
+++ b/recipes/recipes_emscripten/kwant/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: kwant
   version: 1.5.0
-  build: 0
+  build: 1
 
 package:
   name: ${{ name }}
@@ -21,7 +21,6 @@ source:
 
 build:
   number: ${{ build }}
-  string: py${{ py }}h${{ PKG_HASH }}_${{ build }}
   skip: match(python, "<3.9") or python_impl == 'pypy'
 
 requirements:

--- a/recipes/recipes_emscripten/kwant/recipe.yaml
+++ b/recipes/recipes_emscripten/kwant/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: kwant
   version: 1.5.0
-  build: 1
+  build_number: 1
 
 package:
   name: ${{ name }}
@@ -20,7 +20,7 @@ source:
     - patches/0007-disable-mumps.patch
 
 build:
-  number: ${{ build }}
+  number: ${{ build_number }}
   skip: match(python, "<3.9") or python_impl == 'pypy'
 
 requirements:

--- a/recipes/recipes_emscripten/kwant/test_import_kwant.py
+++ b/recipes/recipes_emscripten/kwant/test_import_kwant.py
@@ -1,2 +1,12 @@
-def test_import_kwant():
-    import kwant  # noqa: F401
+import kwant
+
+
+def test_two_site_system():
+    lattice = kwant.lattice.square(norbs=1)
+    system = kwant.Builder()
+    system[lattice(0, 0)] = 1
+    system[lattice(1, 0)] = 2
+    system[lattice.neighbors()] = -1
+
+    hamiltonian = system.finalized().hamiltonian_submatrix()
+    assert hamiltonian.tolist() == [[1, -1], [-1, 2]]


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [ ] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: kwant
- **Version**: 1.5.0

## Build Notes
This is a follow-up to #6082 (tinyarray is a kwant's dependency) and it fixes the linking in a similar way.