### PR TITLE
Add psutil

### DIFF
--- a/recipes/recipes_emscripten/psutil/recipe.yaml
+++ b/recipes/recipes_emscripten/psutil/recipe.yaml
@@ -26,16 +26,12 @@ build:
 
 requirements:
   build:
-    - if: build_platform != target_platform
-      then:
-        - python
-        - cross-python_${{ target_platform }}
+    - python
+    - cross-python_${{ target_platform }}
     - ${{ compiler("c") }}
+    - pip
   host:
     - python
-    - pip
-    - setuptools >=43
-    - wheel
   run:
     - python
 

--- a/recipes/recipes_emscripten/psutil/recipe.yaml
+++ b/recipes/recipes_emscripten/psutil/recipe.yaml
@@ -40,15 +40,15 @@ requirements:
     - python
 
 tests:
-  - python:
-      imports:
-        - psutil
-        - if: linux
-          then: psutil._psutil_linux
-        - if: osx
-          then: psutil._psutil_osx
-        - if: win
-          then: psutil._psutil_windows
+- script: pytester
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+  files:
+    recipe:
+    - test_psutil.py
 
 about:
   license: BSD-3-Clause

--- a/recipes/recipes_emscripten/psutil/recipe.yaml
+++ b/recipes/recipes_emscripten/psutil/recipe.yaml
@@ -1,0 +1,69 @@
+schema_version: 1
+
+context:
+  version: "7.2.2"
+  sha256: 0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372
+
+package:
+  name: psutil
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/psutil/psutil-${{ version }}.tar.gz
+  sha256: ${{ sha256 }}
+
+build:
+  number: 0
+  script:
+    # macOS renamed this variable, but it is `NULL` in either case.
+    # Workaround the missing definition by setting it to `0`.
+    #
+    # xref: https://github.com/giampaolo/psutil/issues/2354
+    - if: osx
+      then: export CFLAGS="${CFLAGS} -DkIOMainPortDefault=0"
+    - ${{ PYTHON }} -m pip install --ignore-installed --no-deps .
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+  host:
+    - python
+    - pip
+    - setuptools >=43
+    - wheel
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - psutil
+        - if: linux
+          then: psutil._psutil_linux
+        - if: osx
+          then: psutil._psutil_osx
+        - if: win
+          then: psutil._psutil_windows
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: A cross-platform process and system utilities module for Python
+  description: |
+    psutil (process and system utilities) is a cross-platform library for
+    retrieving information on running processes and system utilization (CPU,
+    memory, disks, network) in Python. It is useful mainly for system
+    monitoring, profiling and limiting process resources and management of
+    running processes.
+  homepage: https://github.com/giampaolo/psutil
+  repository: https://github.com/giampaolo/psutil
+  documentation: https://psutil.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - bocklund

--- a/recipes/recipes_emscripten/psutil/recipe.yaml
+++ b/recipes/recipes_emscripten/psutil/recipe.yaml
@@ -31,7 +31,6 @@ requirements:
         - python
         - cross-python_${{ target_platform }}
     - ${{ compiler("c") }}
-    - ${{ stdlib("c") }}
   host:
     - python
     - pip

--- a/recipes/recipes_emscripten/psutil/recipe.yaml
+++ b/recipes/recipes_emscripten/psutil/recipe.yaml
@@ -1,16 +1,17 @@
 schema_version: 1
 
 context:
+  name: psutil
   version: "7.2.2"
-  sha256: 0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372
 
 package:
-  name: psutil
+  name: ${{ name }}
   version: ${{ version }}
 
+
 source:
-  url: https://pypi.org/packages/source/p/psutil/psutil-${{ version }}.tar.gz
-  sha256: ${{ sha256 }}
+  url: https://pypi.org/packages/source/p/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372
 
 build:
   number: 0

--- a/recipes/recipes_emscripten/psutil/test_psutil.py
+++ b/recipes/recipes_emscripten/psutil/test_psutil.py
@@ -1,4 +1,5 @@
 
 def test_psutil():
     import psutil
-    psutil.cpu_percent(interval=1, percpu=True)
+    assert psutil.__version__
+    assert psutil.cpu_count() >= 1

--- a/recipes/recipes_emscripten/psutil/test_psutil.py
+++ b/recipes/recipes_emscripten/psutil/test_psutil.py
@@ -1,0 +1,4 @@
+
+def test_psutil():
+    import psutil
+    psutil.cpu_percent(interval=1, percpu=True)


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**:  psutil
- **Version**: 7.2.2

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->
