### PR TITLE
Enable maintenance-free README translation sync

### DIFF
--- a/.github/hy-mt2.json
+++ b/.github/hy-mt2.json
@@ -1,0 +1,17 @@
+{
+  "sourceReadme": "README.md",
+  "targets": [
+    {
+      "language": "zh-CN",
+      "path": "README_zh-CN.md"
+    },
+    {
+      "language": "ja",
+      "path": "README_ja.md"
+    },
+    {
+      "language": "es",
+      "path": "README_es.md"
+    }
+  ]
+}


### PR DESCRIPTION
## Never hand-maintain a translated README again

Translated READMEs are accurate exactly once: the day they land. They go stale
the next time you edit `README.md`, and keeping them current is
manual work forever.

The **[HY MT2 README Sync GitHub App](https://github.com/apps/hy-mt2-github-translator)** takes that work
off your plate. It watches your source README and, whenever it changes, opens a
pull request that re-translates only the paragraphs that actually changed.
**It only ever opens pull requests — it never commits to your default branch
and never merges anything itself**, so nothing lands without your review.

**It's free.** Translation runs on our infrastructure using
[Tencent Hunyuan MT (HY MT2)](https://github.com/Tencent-Hunyuan/Hy-MT2), so there's no repository
secret, no Actions settings toggle, and no CI minutes on your side.

## Turning it on

1. Merge this PR — it carries the config the App needs, already written for you.
2. Install the App and select this repository. [install](https://github.com/apps/hy-mt2-github-translator)
3. Grant it contents and pull-request access — it only ever writes its own
   pull-request branch.

That's the whole setup.

## What's in this PR

One data file — `.github/hy-mt2.json` — recording your source
README (`README.md`) and the translated READMEs to keep in sync:

- `README_zh-CN.md` (zh-CN)
- `README_ja.md` (ja)
- `README_es.md` (es)

It is pure data: **no workflow, no script, no secret, and no code.** Only the
App ever reads it, so until you install the App this PR changes nothing.

## No lock-in

- Uninstall the App whenever you like and the syncing simply stops.
- Want different languages later? Edit the `targets` in
  `.github/hy-mt2.json` — that file is the only thing the App reads.
- Not interested at all? Closing this PR costs you nothing and leaves the
  translations from the companion PR untouched.