### PR TITLE
Add multilingual README support for zh-CN, ja, es

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 #
 
+<!-- hy-mt2-i18n:start -->
+**English** · [中文](./README_zh-CN.md) · [日本語](./README_ja.md) · [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
 [![CI](https://img.shields.io/badge/emscripten_forge-docs-yellow)](https://emscripten-forge.org)
 [![CI](https://img.shields.io/badge/emscripten_forge-blog-pink)](https://emscripten-forge.org/blog/)
 

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,27 @@
+# 目标
+
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | [中文](./README_zh-CN.md) | [日本語](./README_ja.md) | **Español**
+<!-- hy-mt2-i18n:end -->
+
+将下方的 Markdown 格式数据翻译为西班牙语。
+
+# 严格约束
+1. **只输出译文**：仅返回翻译后的内容，不要包含任何其他文字。
+2. **结构锁定**：绝对保持原有的 Markdown 数据结构、缩进、标题层级、表格、链接、URL、徽章、代码块和行内代码完全不变。
+3. **选择性翻译**：仅翻译面向用户展示的可见自然语言内容（正文、标题、说明文字和表格文本）。
+4. **禁止修改**：**严禁**翻译或更改代码标签、键名、变量占位符（如 {{var}}、${var}、%s、%d 等）、命令示例、文件路径、项目名、API 名、包名、模型名、标识符和代码符号；除非原文已经给出对应译名。
+
+# 数据输入
+源文件：README.md
+
+Markdown 内容：
+<img src="docs/assets/banner.svg" alt="Emscripten-forge Banner" style="width: 80%;">
+
+#
+
+[![CI](https://img.shields.io/badge/emscripten_forge-docs-yellow)](https://emscripten-forge.org)
+[![CI](https://img.shields.io/badge/emscripten_forge-blog-pink)](https://emscripten-forge.org/blog/)
+
+
+Visite [emscripten-forge.org](https://emscripten-forge.org) para obtener más información y la documentación.

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,27 @@
+# 任务目标
+
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | [中文](./README_zh-CN.md) | **日本語** | [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
+将下方 Markdown 格式数据翻译为日语。
+
+# 严格约束
+1. **只输出译文**：仅输出翻译后的结果，不包含任何其他内容。
+2. **结构锁定**：绝对保持原有的 Markdown 数据结构、缩进、标题层级、表格、链接、URL、徽章、代码块和行内代码完全不变。
+3. **选择性翻译**：仅翻译面向用户展示的可见自然语言内容（正文、标题、说明文字和表格文本）。
+4. **禁止修改**：**严禁**翻译或更改代码标签、键名、变量占位符（如 {{var}}、${var}、%s、%d 等）、命令示例、文件路径、项目名、API 名、包名、模型名、标识符和代码符号；除非原文已经给出对应译名。
+
+# 数据输入
+源文件：README.md
+
+Markdown 内容：
+<img src="docs/assets/banner.svg" alt="Emscripten-forge Banner" style="width: 80%;">
+
+#
+
+[![CI](https://img.shields.io/badge/emscripten_forge-docs-yellow)](https://emscripten-forge.org)
+[![CI](https://img.shields.io/badge/emscripten_forge-blog-pink)](https://emscripten-forge.org/blog/)
+
+
+更多信息及文档请访问 [emscripten-forge.org](https://emscripten-forge.org)。

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,0 +1,27 @@
+# 任务目标
+
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | **中文** | [日本語](./README_ja.md) | [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
+将下方 Markdown 格式数据翻译为中文。
+
+# 严格约束
+1. **只输出译文**。不要添加任何额外的文字或格式。
+2. **结构锁定**：必须完全保持原有的 Markdown 数据结构、缩进、标题层级、表格、链接、URL、徽章、代码块和行内代码不变。
+3. **选择性翻译**：仅翻译面向用户展示的可见自然语言内容（正文、标题、说明文字和表格文本）。
+4. **禁止修改**：**严禁**翻译或更改代码标签、键名、变量占位符（如 {{var}}、${var}、%s、%d 等）、命令示例、文件路径、项目名、API 名、包名、模型名、标识符和代码符号；除非原文已经给出对应译名。
+
+# 数据输入
+源文件：README.md
+
+Markdown 内容：
+<img src="docs/assets/banner.svg" alt="Emscripten-forge Banner" style="width: 80%;">
+
+#
+
+[![CI](https://img.shields.io/badge/emscripten_forge-docs-yellow)](https://emscripten-forge.org)
+[![CI](https://img.shields.io/badge/emscripten_forge-blog-pink)](https://emscripten-forge.org/blog/)
+
+
+如需更多信息及文档，请访问 [emscripten-forge.org](https://emscripten-forge.org)。


### PR DESCRIPTION
## What this PR does

Adds README support for Simplified Chinese, Japanese, and Spanish so readers of those languages
can follow your project just as easily.

This is additive and opt-in: no existing content or code is changed, and the
new files are safe to close or delete at any time.

## Why we opened this PR

We're the team behind [Tencent Hunyuan MT (HY MT2)](https://github.com/Tencent-Hunyuan/Hy-MT2),
a translation model we recently open-sourced. We're using it to help open
source projects we appreciate reach readers in more languages.

We'd also love your feedback — both on the new READMEs in this PR and on the
[model](https://github.com/Tencent-Hunyuan/Hy-MT2#contact-us) itself.

## Scope of changes

**New README files (with language-switcher links)**

- README_zh-CN.md
- README_ja.md
- README_es.md

**Existing READMEs updated with language-switcher links only**

- README.md

That's the entire change: 4 files. Nothing else is touched.

> Worried about the upkeep? A separate companion PR can help keep these
> translations in sync automatically going forward — adopt it only if you
> want to.