### PR TITLE
Update xeus-ocaml from 0.2.8 to 0.2.10, OCaml 5.5.0, fix opam root

### DIFF
--- a/recipes/recipes_emscripten/xeus-ocaml/build.sh
+++ b/recipes/recipes_emscripten/xeus-ocaml/build.sh
@@ -9,7 +9,7 @@ set -ex
   unset CC CXX CFLAGS CXXFLAGS LDFLAGS OPAMSWITCH
   export OPAMROOT=$SRC_DIR/opam_root
   cd ocaml
-  opam init --disable-sandboxing --no --compiler=5.4.0
+  opam init --disable-sandboxing --no --compiler=5.5.0
   opam install dune
   opam exec -- dune pkg lock
   opam exec -- dune build --profile release

--- a/recipes/recipes_emscripten/xeus-ocaml/recipe.yaml
+++ b/recipes/recipes_emscripten/xeus-ocaml/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.2.9
+  version: 0.2.10
 
 package:
   name: xeus-ocaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/davy39/xeus-ocaml/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: 43d330603022f0d58bf0a11b08cee88eea3d53a738d0aff261bd38ea562705a9
+  sha256: 6ea09c94538b2a13fce17e4c3257e5937cea799888da4fc4f1b309e6c9f98a3b
 
 requirements:
   build:


### PR DESCRIPTION
- Bump version to 0.2.10 with new sha256
- Use a private OPAMROOT and unset OPAMSWITCH so opam init fetches the real opam repository (the conda-forge opam root only ships an empty repo, which broke 'opam install dune' with 'No package named dune found')
- Build with OCaml 5.5.0 to match the v0.2.10 tag
- Unset LDFLAGS before cmake: native -Wl flags are rejected by wasm-ld
