### PR TITLE
add regina-normal

### DIFF
--- a/recipes/recipes/regina-normal/build.sh
+++ b/recipes/recipes/regina-normal/build.sh
@@ -3,7 +3,7 @@
 export CFLAGS="$CFLAGS -fPIC -O3"
 export CXXFLAGS="$CXXFLAGS -fPIC -O3"
 
-sed -i "s/platform_extra_link_args = \['-s'\]/platform_extra_link_args = []/" setup.py
+export _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata__emscripten_wasm32-emscripten
 
 ${PYTHON} setup.py package_assemble
 ${PYTHON} -m pip install . -vv --no-build-isolation

--- a/recipes/recipes/regina-normal/build.sh
+++ b/recipes/recipes/regina-normal/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export CFLAGS="$CFLAGS -fPIC -O3"
+export CXXFLAGS="$CXXFLAGS -fPIC -O3"
+
+${PYTHON} setup.py package_assemble
+
+${PYTHON} -m pip install . -vv

--- a/recipes/recipes/regina-normal/build.sh
+++ b/recipes/recipes/regina-normal/build.sh
@@ -3,4 +3,5 @@
 export CFLAGS="$CFLAGS -fPIC -O3"
 export CXXFLAGS="$CXXFLAGS -fPIC -O3"
 
+${PYTHON} setup.py package_assemble
 ${PYTHON} -m pip install . -vv

--- a/recipes/recipes/regina-normal/build.sh
+++ b/recipes/recipes/regina-normal/build.sh
@@ -3,6 +3,4 @@
 export CFLAGS="$CFLAGS -fPIC -O3"
 export CXXFLAGS="$CXXFLAGS -fPIC -O3"
 
-${PYTHON} setup.py package_assemble
-
 ${PYTHON} -m pip install . -vv

--- a/recipes/recipes/regina-normal/build.sh
+++ b/recipes/recipes/regina-normal/build.sh
@@ -4,4 +4,4 @@ export CFLAGS="$CFLAGS -fPIC -O3"
 export CXXFLAGS="$CXXFLAGS -fPIC -O3"
 
 ${PYTHON} setup.py package_assemble
-${PYTHON} -m pip install . -vv
+${PYTHON} -m pip install . -vv --no-build-isolation

--- a/recipes/recipes/regina-normal/build.sh
+++ b/recipes/recipes/regina-normal/build.sh
@@ -3,5 +3,7 @@
 export CFLAGS="$CFLAGS -fPIC -O3"
 export CXXFLAGS="$CXXFLAGS -fPIC -O3"
 
+sed -i "s/platform_extra_link_args = \['-s'\]/platform_extra_link_args = []/" setup.py
+
 ${PYTHON} setup.py package_assemble
 ${PYTHON} -m pip install . -vv --no-build-isolation

--- a/recipes/recipes/regina-normal/recipe.yaml
+++ b/recipes/recipes/regina-normal/recipe.yaml
@@ -15,15 +15,14 @@ build:
 
 requirements:
   build:
-  - python
-  - cross-python_emscripten-wasm32
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
+  - cross-python_emscripten-wasm32
+  host:
+  - python
   - pip
   - setuptools
   - wheel
-  host:
-  - python
   - gmp
   - zlib
   - bzip2

--- a/recipes/recipes/regina-normal/recipe.yaml
+++ b/recipes/recipes/regina-normal/recipe.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: ${{ target_platform != 'emscripten-wasm32' }}
 
 requirements:
   build:

--- a/recipes/recipes/regina-normal/recipe.yaml
+++ b/recipes/recipes/regina-normal/recipe.yaml
@@ -16,7 +16,7 @@ build:
 requirements:
   build:
   - python
-  - cross-python_${{ target_platform }}
+  - cross-python_emscripten-wasm32
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
   - pip

--- a/recipes/recipes/regina-normal/recipe.yaml
+++ b/recipes/recipes/regina-normal/recipe.yaml
@@ -17,7 +17,6 @@ requirements:
   build:
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
-  - cross-python_emscripten-wasm32
   - pip <25
   host:
   - python

--- a/recipes/recipes/regina-normal/recipe.yaml
+++ b/recipes/recipes/regina-normal/recipe.yaml
@@ -15,14 +15,15 @@ build:
 
 requirements:
   build:
+  - python
+  - cross-python_${{ target_platform }}
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
-  - cross-python_emscripten-wasm32
-  host:
-  - python
   - pip
   - setuptools
   - wheel
+  host:
+  - python
   - gmp
   - zlib
   - bzip2

--- a/recipes/recipes/regina-normal/recipe.yaml
+++ b/recipes/recipes/regina-normal/recipe.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  skip: ${{ target_platform != 'emscripten-wasm32' }}
 
 requirements:
   build:

--- a/recipes/recipes/regina-normal/recipe.yaml
+++ b/recipes/recipes/regina-normal/recipe.yaml
@@ -1,0 +1,43 @@
+context:
+  name: regina-normal
+  version: 7.3.1
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/3-manifolds/regina_wheels/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 9a42bd39c552982c22520dc2e247834351445de2832fcd789203cf3aa4fc4d57
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - ${{ compiler('c') }}
+  - ${{ compiler('cxx') }}
+  - cross-python_emscripten-wasm32
+  host:
+  - python
+  - pip
+  - setuptools
+  - wheel
+  - gmp
+  - zlib
+  - bzip2
+  run:
+  - python
+  - gmp
+  - zlib
+  - bzip2
+
+about:
+  homepage: https://regina-normal.github.io/
+  license: GPL-2.0-or-later
+  license_file: README.rst
+  summary: Self-contained Python packages of the low-dimensional topology software Regina, installable off PyPI using pip.
+
+extra:
+  recipe-maintainers:
+  - wangyenshu

--- a/recipes/recipes/regina-normal/recipe.yaml
+++ b/recipes/recipes/regina-normal/recipe.yaml
@@ -18,6 +18,7 @@ requirements:
   - ${{ compiler('c') }}
   - ${{ compiler('cxx') }}
   - cross-python_emscripten-wasm32
+  - pip <25
   host:
   - python
   - pip


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [ ] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: regina-normal
- **Version**: 7.3.1

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

