### PR TITLE
Update rebound from 5.0.1 to 5.1.0

### DIFF
--- a/recipes/recipes_emscripten/rebound/patches/0001-skip-c-extension-on-emscripten.patch
+++ b/recipes/recipes_emscripten/rebound/patches/0001-skip-c-extension-on-emscripten.patch
@@ -1,8 +1,8 @@
---- a/setup.py	2026-07-02 13:26:02.036248410 +0200
-+++ b/setup.py	2026-07-02 13:26:13.421075170 +0200
-@@ -42,12 +42,17 @@
-     extra_compile_args += ["-march=native", "-DAVX512"]
- 
+--- a/setup.py
++++ b/setup.py
+@@ -90,12 +90,7 @@
+         super().build_extensions()
+
  ##### C Extension
 -libreboundmodule = Extension(
 -    "librebound",
@@ -12,18 +12,8 @@
 -    extra_compile_args=extra_compile_args,
 -)
 -
--setup(ext_modules=[libreboundmodule])
-+# On emscripten, librebound is built and installed separately as a
-+# standalone shared library (see the librebound conda package).
-+# Skip building the C extension here; only install the Python wrapper.
-+if sys.platform == "emscripten":
-+    setup()
-+else:
-+    libreboundmodule = Extension(
-+        "librebound",
-+        sources=sorted(glob("src/*.c")),
-+        include_dirs=["src"],
-+        extra_link_args=extra_link_args,
-+        extra_compile_args=extra_compile_args,
-+    )
-+    setup(ext_modules=[libreboundmodule])
+-setup(ext_modules=[libreboundmodule], cmdclass={"build_ext": build_ext_avx512})
++# Emscripten build: librebound is packaged separately as a standalone
++# shared library. Skip building the C extension here; only install the
++# Python wrapper.
++setup()

--- a/recipes/recipes_emscripten/rebound/patches/0004-remove-emscripten-sleep.patch
+++ b/recipes/recipes_emscripten/rebound/patches/0004-remove-emscripten-sleep.patch
@@ -21,11 +21,11 @@ resumes as if it was never paused (pause is not meaningful without ASYNCIFY).
 +        break;
  #else
          usleep(1000);
- #endif
-@@ -399,7 +399,6 @@ static void* reb_simulation_integrate_raw(void* args){
+ #endif 
+@@ -399,6 +399,5 @@ static void* reb_simulation_integrate_raw(void* args){
          if (t1-t0>1000./120.){ // max framerate 120Hz
              t0 = t1;
 -            emscripten_sleep(0); // allow drawing and event handling
          }
 
- #endif
+ #endif 

--- a/recipes/recipes_emscripten/rebound/recipe.yaml
+++ b/recipes/recipes_emscripten/rebound/recipe.yaml
@@ -1,10 +1,10 @@
 context:
   name: rebound
-  version: 5.0.1
+  version: 5.1.0
 
 source:
 - url: https://pypi.io/packages/source/r/rebound/rebound-${{ version }}.tar.gz
-  sha256: 0ddf41cfe48153c60bc97c7c7232a558bc31c98861a3506d12aef8c161b26fc5
+  sha256: 55457bbd9f48617eca9359d360d88448b11c9e5e8f0c1d2e62c8fc71031145fb
   patches:
   - patches/0001-skip-c-extension-on-emscripten.patch
   - patches/0002-load-librebound-from-prefix.patch


### PR DESCRIPTION
Continues #5998 (bot update): rebases the version bump and adapts the emscripten patches for 5.1.0.

- `0001-skip-c-extension-on-emscripten.patch`: setup.py restructured upstream (added `cmdclass=` to the top-level `setup()` call); rewritten to make the emscripten branch unconditionally call `setup()` since cross-python reports the build host's `sys.platform`, not `emscripten`.
- `0004-remove-emscripten-sleep.patch`: context re-anchored to 5.1.0's `simulation.c`.