### PR TITLE
shared libproj; tests and rebuild for pyproj

### DIFF
--- a/recipes/recipes_emscripten/proj/build.sh
+++ b/recipes/recipes_emscripten/proj/build.sh
@@ -9,7 +9,7 @@ cd build
 # to build without curl we need to disable projsync too
 emcmake cmake ${CMAKE_ARGS} .. \
       -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_SHARED_LIBS=ON \
       -DBUILD_APPS=OFF \
       -DBUILD_TESTING=OFF \
       -DENABLE_CURL=OFF \

--- a/recipes/recipes_emscripten/proj/patches/0001-drop-soversion-emscripten.patch
+++ b/recipes/recipes_emscripten/proj/patches/0001-drop-soversion-emscripten.patch
@@ -1,0 +1,35 @@
+Skip VERSION/SOVERSION under emscripten so libproj.so has no version suffix.
+
+Based on what we have inferred so far (deeper research may still be needed):
+wasm appears to have no SONAME equivalent of ELF's DT_SONAME, so a shared
+library cannot declare a canonical name independent of its filename. wasm-ld
+seems to record the input filename it resolved via -l<name> / -L<path> search
+into the consumer's dylink.0 NEEDED list. When SOVERSION is stamped, CMake
+produces libproj.so.25 and consumers linking through that symlink chain end
+up with NEEDED "libproj.so.25", while consumers linked by bare -lproj may
+record NEEDED "libproj.so". Emscripten's runtime module registry (LDSO in
+library_dylink.js) appears to key side modules by NEEDED string with no path
+normalization or version dedup, so the two strings load two copies of the
+same library.
+
+Skipping SOVERSION on emscripten forces one canonical name across the graph.
+
+--- a/src/lib_proj.cmake
++++ b/src/lib_proj.cmake
+@@ -555,9 +555,11 @@
+     INSTALL_NAME_DIR ${PROJ_INSTALL_NAME_DIR}
+     CLEAN_DIRECT_OUTPUT 1)
+ else()
+-  set_target_properties(proj
+-    PROPERTIES
+-    VERSION "${PROJ_BUILD_VERSION}"
+-    SOVERSION "${PROJ_SOVERSION}"
+-    CLEAN_DIRECT_OUTPUT 1)
++  if(NOT EMSCRIPTEN)
++    set_target_properties(proj
++      PROPERTIES
++      VERSION "${PROJ_BUILD_VERSION}"
++      SOVERSION "${PROJ_SOVERSION}"
++      CLEAN_DIRECT_OUTPUT 1)
++  endif()
+ endif()

--- a/recipes/recipes_emscripten/proj/recipe.yaml
+++ b/recipes/recipes_emscripten/proj/recipe.yaml
@@ -9,9 +9,11 @@ package:
 source:
   url: https://download.osgeo.org/proj/proj-${{ version }}.tar.gz
   sha256: af5b731c145c1d13c4e3b4eeb7d167e94e845e440f71e3496b4ed8dae0291960
+  patches:
+  - patches/0001-drop-soversion-emscripten.patch
 
 build:
-  number: 0
+  number: 1
 
   files:
     exclude:
@@ -35,7 +37,7 @@ tests:
 - package_contents:
     files:
     - include/proj.h
-    - lib/libproj.a
+    - lib/libproj.so
     - lib/pkgconfig/proj.pc
 
 about:

--- a/recipes/recipes_emscripten/pyproj/build.sh
+++ b/recipes/recipes_emscripten/pyproj/build.sh
@@ -14,7 +14,7 @@ export PROJ_DIR=$PREFIX
 
 # if version is not set, the python build script
 # tries to call the proj binary to get the version
-export PROJ_VERSION="9.7.1"
+export PROJ_VERSION="9.8.1"
 
 ${PYTHON} -m pip install -vv .
 

--- a/recipes/recipes_emscripten/pyproj/recipe.yaml
+++ b/recipes/recipes_emscripten/pyproj/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c
 
 build:
-  number: 2
+  number: 3
 
   files:
     exclude:
@@ -33,8 +33,7 @@ requirements:
   - ${{ compiler('c') }}
   host:
   - python
-  - pip
-  - proj == 9.7.1
+  - proj == 9.8.1
   run:
   - python
   - proj

--- a/recipes/recipes_emscripten/pyproj/test_pyproj.py
+++ b/recipes/recipes_emscripten/pyproj/test_pyproj.py
@@ -1,4 +1,60 @@
+import math
 
 
-def test_import():
-    from pyproj import Proj, transform
+def test_version():
+    import pyproj
+    assert pyproj.__proj_version__.startswith("9.")
+
+
+def test_crs_from_epsg():
+    from pyproj import CRS
+    crs = CRS.from_epsg(4326)
+    assert crs.is_geographic
+    assert "WGS 84" in crs.name
+
+
+def test_crs_from_wkt_roundtrip():
+    from pyproj import CRS
+    wkt = CRS.from_epsg(3857).to_wkt()
+    assert CRS.from_wkt(wkt).to_epsg() == 3857
+
+
+def test_transformer_wgs84_to_webmercator():
+    from pyproj import Transformer
+    t = Transformer.from_crs(4326, 3857, always_xy=True)
+    x, y = t.transform(0.0, 0.0)
+    assert abs(x) < 1e-6 and abs(y) < 1e-6
+    x, y = t.transform(2.3522, 48.8566)
+    assert math.isclose(x, 261848.15, rel_tol=1e-4)
+    assert math.isclose(y, 6250566.72, rel_tol=1e-4)
+
+
+def test_transformer_roundtrip():
+    from pyproj import Transformer
+    fwd = Transformer.from_crs(4326, 3857, always_xy=True)
+    back = Transformer.from_crs(3857, 4326, always_xy=True)
+    lon, lat = -122.4194, 37.7749
+    x, y = fwd.transform(lon, lat)
+    lon2, lat2 = back.transform(x, y)
+    assert math.isclose(lon, lon2, abs_tol=1e-9)
+    assert math.isclose(lat, lat2, abs_tol=1e-9)
+
+
+def test_geod_wgs84_distance():
+    from pyproj import Geod
+    g = Geod(ellps="WGS84")
+    _, _, dist = g.inv(-73.9857, 40.7484, 2.2945, 48.8584)
+    assert math.isclose(dist, 5845209.47, rel_tol=1e-6)
+
+
+def test_database_query():
+    from pyproj.database import query_crs_info
+    infos = query_crs_info(auth_name="EPSG", pj_types=["GEOGRAPHIC_2D_CRS"])
+    codes = {info.code for info in infos}
+    assert "4326" in codes
+
+
+def test_list_enums():
+    from pyproj.enums import ProjVersion, WktVersion
+    assert ProjVersion.PROJ_5.value
+    assert WktVersion.WKT2_2019.value


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- ~[] Or reset build number to 0 if updating the package to a newer version~

---

## PR Formatting
- [ ] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]` (unsure since this isn't a package update)
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: libproj, pyproj
- **Version**: unchanged versions

## Build Notes

- I build proj as shared library in this PR. This seems to reduce size from 118Mb (pyproj) to 1.8MB (pyproj) + 4.6MB (libproj) since pyproj otherwise embeds and duplicates much of proj's functionality across it's ~10 .so files. A shared build therefore seems to be the right call here.
- I deactivated the SONAME in the build as we did in PR [#6001](https://github.com/emscripten-forge/recipes/pull/6007), for the same reason that the wasm linker identifies libraries by full name without understanding of semantic version or deduplication of symlinks. This means that two libraries loading the *same* proj in two different ways, end up with two instances of it which is usually unintended and throws exceptions if each instance handles its own state.
- I added a set of additional tests to this.
- I also remove pip from the host build dependencies since it seems it is already provided by cross_python. The additional pip threw a build error (locally on my machine), likely because of duplication. Removing it seems to work fine.