### PR TITLE
Build OpenBLAS with `WASM128_GENERIC` as a target

### DIFF
--- a/recipes/recipes_emscripten/openblas/build.sh
+++ b/recipes/recipes_emscripten/openblas/build.sh
@@ -14,10 +14,12 @@ export BUILD_CORES=-j1
 
 export USE_THREAD=0
 
+# WASM128_GENERIC enables WASM SIMD128 kernels (SGEMM/DGEMM, DAXPY, SUM, DOT, ROT, TRSM).
+# Makefile.wasm adds -msimd128 automatically for this architecture.
 emmake make shared \
     $BUILD_CORES \
     HOSTCC=gcc \
-    TARGET=RISCV64_GENERIC
+    TARGET=WASM128_GENERIC
 
 emmake make install PREFIX=$PREFIX
 
@@ -29,7 +31,7 @@ cat > "${PREFIX}/lib/pkgconfig/openblas.pc" <<EOF
 prefix=\${pcfiledir}/../..
 libdir=\${prefix}/lib
 includedir=\${prefix}/include
-openblas_config=USE_THREAD=0 TARGET=RISCV64_GENERIC
+openblas_config=USE_THREAD=0 TARGET=WASM128_GENERIC
 version=${PKG_VERSION}
 Name: openblas
 Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version

--- a/recipes/recipes_emscripten/openblas/recipe.yaml
+++ b/recipes/recipes_emscripten/openblas/recipe.yaml
@@ -22,7 +22,7 @@ source:
   - patches/0008-Clear-FEXTRALIB-when-linking-shared-library.patch
 
 build:
-  number: 0
+  number: 1
 
   files:
     exclude:

--- a/recipes/recipes_emscripten/openblas/recipe.yaml
+++ b/recipes/recipes_emscripten/openblas/recipe.yaml
@@ -31,7 +31,7 @@ build:
 requirements:
   build:
   - ${{ compiler('c') }}
-  - flang_${{ target_platform }} >= 20.1
+  - ${{ compiler('fortran') }}
   - cmake
   - make
   host:


### PR DESCRIPTION
## Package Details
- **Package Name**: openblas
- **Version**: 0.3.34

## OpenBLAS CBLAS microbenchmark (no NumPy)

Comparison of emscripten-forge OpenBLAS **0.3.31** (`TARGET=RISCV64_GENERIC`) against a local build of OpenBLAS **0.3.34** (`TARGET=WASM128_GENERIC`), measured with a direct CBLAS harness (no NumPy).

### Headline results

| Category | Geomean speedup | Median speedup | Notes |
|---|---:|---:|---|
| All ops ≥ 0.1 ms | **1.59×** | 1.44× | WASM faster on 28 / 28; RISCV never >5% ahead |
| BLAS3 ≥ 0.1 ms | **1.69×** | 1.44× | GEMM / SYRK / TRSM |
| SGEMM | **2.39×** | 2.69× | Strongest win (single-precision SIMD) |
| DGEMM | **1.30×** | 1.43× | Double-precision GEMM |
| DTRSM | **1.23×** | 1.43× | Dedicated WASM TRSM kernels (0.3.33+) |
| DSYRK | **1.51×** | 1.44× | Follows GEMM |
| BLAS1 ≥ 0.01 ms | 1.09× | 1.05× | Mostly parity (DOT / AXPY / ASUM / ROT) |

Speedup = `t_RISCV / t_WASM` (values **> 1** mean WASM128 is faster).

Confirmed runtime configs:

- Baseline: `OpenBLAS 0.3.31 NO_AFFINITY RISCV64_GENERIC SINGLE_THREADED`
- Candidate: `OpenBLAS 0.3.34 NO_AFFINITY WASM128_GENERIC SINGLE_THREADED`

### Method

- **Language / API:** C + CBLAS (`cblas_dgemm`, `cblas_sgemm`, …)
- **Build:** `emcc` statically links each OpenBLAS `.a` plus `libflang_rt.runtime.a`
- **Run:** Node.js (`emscripten_get_now()` / `performance.now`)
- **Metric:** median wall time over warmups/repeats; L1 kernels batched (`inner` loops) to exceed timer quantum
- **Flags:** `-msimd128 -O2 -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=268435456`

```bash
emcc bench_cblas.c \
  -I$PREFIX/include \
  $PREFIX/lib/libopenblas.a \
  $LIBFLANG/lib/libflang_rt.runtime.a \
  -msimd128 -O2 \
  -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=268435456 \
  -o bench.js
node bench.js
```

### DGEMM

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 32 | 16.38 µs | 21.52 µs | 0.76× |
| 64 | 58.39 µs | 47.14 µs | 1.24× |
| 128 | 439.36 µs | 307.55 µs | 1.43× |
| 256 | 3.521 ms | 2.354 ms | 1.50× |
| 512 | 27.273 ms | 19.410 ms | 1.41× |
| 1024 | 223.316 ms | 155.649 ms | 1.43× |
| 1536 | 757.105 ms | 524.512 ms | 1.44× |
| 2048 | 1.784 s | 1.246 s | 1.43× |

### SGEMM

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 32 | 15.56 µs | 12.52 µs | 1.24× |
| 64 | 56.95 µs | 28.88 µs | 1.97× |
| 128 | 455.09 µs | 172.62 µs | 2.64× |
| 256 | 3.498 ms | 1.320 ms | 2.65× |
| 512 | 27.945 ms | 10.225 ms | 2.73× |
| 1024 | 227.861 ms | 80.603 ms | 2.83× |
| 1536 | 768.601 ms | 272.835 ms | 2.82× |
| 2048 | 1.807 s | 642.298 ms | 2.81× |

### DSYRK

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 32 | 33.05 µs | 12.49 µs | 2.65× |
| 64 | 31.09 µs | 25.27 µs | 1.23× |
| 128 | 219.17 µs | 162.39 µs | 1.35× |
| 256 | 1.746 ms | 1.197 ms | 1.46× |
| 512 | 13.816 ms | 9.774 ms | 1.41× |
| 1024 | 112.543 ms | 77.801 ms | 1.45× |
| 1536 | 378.944 ms | 261.067 ms | 1.45× |
| 2048 | 890.284 ms | 620.576 ms | 1.43× |

### DTRSM

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 32 | 7.10 µs | 14.86 µs | 0.48× |
| 64 | 42.01 µs | 35.25 µs | 1.19× |
| 128 | 258.70 µs | 197.36 µs | 1.31× |
| 256 | 1.856 ms | 1.147 ms | 1.62× |
| 512 | 14.494 ms | 10.127 ms | 1.43× |
| 1024 | 114.902 ms | 79.566 ms | 1.44× |
| 1536 | 382.672 ms | 266.276 ms | 1.44× |
| 2048 | 905.682 ms | 627.342 ms | 1.44× |

### DGEMV

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 32 | 534.28 ns | 664.07 ns | 0.80× |
| 64 | 1.85 µs | 2.10 µs | 0.88× |
| 128 | 7.58 µs | 7.12 µs | 1.06× |
| 256 | 32.05 µs | 31.14 µs | 1.03× |
| 512 | 130.53 µs | 111.60 µs | 1.17× |
| 1024 | 523.26 µs | 521.58 µs | 1.00× |
| 1536 | 1.510 ms | 1.290 ms | 1.17× |
| 2048 | 2.555 ms | 2.457 ms | 1.04× |

### DDOT

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 16 | 9.96 ns | 8.71 ns | 1.14× |
| 32 | 16.29 ns | 24.57 ns | 0.66× |
| 64 | 32.97 ns | 49.79 ns | 0.66× |
| 128 | 63.29 ns | 101.10 ns | 0.63× |
| 256 | 136.87 ns | 108.40 ns | 1.26× |
| 512 | 265.13 ns | 240.37 ns | 1.10× |
| 1024 | 528.39 ns | 457.80 ns | 1.15× |
| 2048 | 1.03 µs | 858.54 ns | 1.20× |
| 4096 | 2.13 µs | 1.77 µs | 1.21× |
| 8192 | 4.14 µs | 3.47 µs | 1.19× |
| 16384 | 8.24 µs | 7.39 µs | 1.11× |
| 65536 | 33.06 µs | 31.14 µs | 1.06× |

### DAXPY

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 16 | 11.39 ns | 11.01 ns | 1.03× |
| 32 | 11.32 ns | 17.51 ns | 0.65× |
| 64 | 18.89 ns | 26.07 ns | 0.72× |
| 128 | 35.83 ns | 28.40 ns | 1.26× |
| 256 | 79.04 ns | 68.65 ns | 1.15× |
| 512 | 153.36 ns | 139.88 ns | 1.10× |
| 1024 | 290.60 ns | 260.98 ns | 1.11× |
| 2048 | 599.78 ns | 499.75 ns | 1.20× |
| 4096 | 1.18 µs | 922.58 ns | 1.28× |
| 8192 | 3.64 µs | 1.99 µs | 1.83× |
| 16384 | 4.56 µs | 4.26 µs | 1.07× |
| 65536 | 18.25 µs | 17.32 µs | 1.05× |

### DASUM

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 16 | 7.33 ns | 13.76 ns | 0.53× |
| 32 | 14.86 ns | 25.57 ns | 0.58× |
| 64 | 30.39 ns | 24.23 ns | 1.25× |
| 128 | 61.58 ns | 48.69 ns | 1.26× |
| 256 | 121.94 ns | 113.62 ns | 1.07× |
| 512 | 259.94 ns | 228.78 ns | 1.14× |
| 1024 | 522.15 ns | 462.98 ns | 1.13× |
| 2048 | 1.02 µs | 832.58 ns | 1.23× |
| 4096 | 2.10 µs | 1.73 µs | 1.22× |
| 8192 | 4.03 µs | 3.83 µs | 1.05× |
| 16384 | 8.17 µs | 7.84 µs | 1.04× |
| 65536 | 33.30 µs | 30.87 µs | 1.08× |

### DROT

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 16 | 13.98 ns | 18.69 ns | 0.75× |
| 32 | 25.24 ns | 33.01 ns | 0.76× |
| 64 | 46.93 ns | 62.11 ns | 0.76× |
| 128 | 95.49 ns | 75.57 ns | 1.26× |
| 256 | 180.84 ns | 165.58 ns | 1.09× |
| 512 | 369.00 ns | 329.78 ns | 1.12× |
| 1024 | 721.05 ns | 638.89 ns | 1.13× |
| 2048 | 1.47 µs | 1.19 µs | 1.23× |
| 4096 | 2.95 µs | 2.36 µs | 1.25× |
| 8192 | 6.94 µs | 5.23 µs | 1.33× |
| 16384 | 11.26 µs | 10.90 µs | 1.03× |
| 65536 | 45.07 µs | 43.85 µs | 1.03× |

### SDOT

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 16 | 11.26 ns | 22.59 ns | 0.50× |
| 32 | 17.11 ns | 24.58 ns | 0.70× |
| 64 | 32.32 ns | 46.54 ns | 0.69× |
| 128 | 63.26 ns | 50.08 ns | 1.26× |
| 256 | 133.46 ns | 111.38 ns | 1.20× |
| 512 | 265.18 ns | 240.24 ns | 1.10× |
| 1024 | 528.31 ns | 457.83 ns | 1.15× |
| 2048 | 1.03 µs | 988.65 ns | 1.04× |
| 4096 | 2.11 µs | 1.73 µs | 1.22× |
| 8192 | 4.14 µs | 3.59 µs | 1.15× |
| 16384 | 8.24 µs | 7.68 µs | 1.07× |
| 65536 | 32.37 µs | 31.47 µs | 1.03× |

### SAXPY

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 16 | 4.41 ns | 6.59 ns | 0.67× |
| 32 | 6.22 ns | 11.47 ns | 0.54× |
| 64 | 10.56 ns | 16.40 ns | 0.64× |
| 128 | 18.09 ns | 14.74 ns | 1.23× |
| 256 | 34.82 ns | 29.53 ns | 1.18× |
| 512 | 79.00 ns | 70.04 ns | 1.13× |
| 1024 | 157.91 ns | 138.26 ns | 1.14× |
| 2048 | 284.83 ns | 244.95 ns | 1.16× |
| 4096 | 597.79 ns | 446.91 ns | 1.34× |
| 8192 | 1.13 µs | 998.93 ns | 1.13× |
| 16384 | 2.28 µs | 2.17 µs | 1.05× |
| 65536 | 11.25 µs | 8.37 µs | 1.34× |

### SROT

| n | RISCV64 0.3.31 | WASM128 0.3.34 | Speedup |
|---:|---:|---:|---:|
| 16 | 6.94 ns | 10.46 ns | 0.66× |
| 32 | 13.01 ns | 19.27 ns | 0.68× |
| 64 | 24.18 ns | 32.87 ns | 0.74× |
| 128 | 48.19 ns | 37.77 ns | 1.28× |
| 256 | 92.75 ns | 83.74 ns | 1.11× |
| 512 | 185.06 ns | 161.75 ns | 1.14× |
| 1024 | 362.89 ns | 299.77 ns | 1.21× |
| 2048 | 740.09 ns | 602.82 ns | 1.23× |
| 4096 | 1.44 µs | 1.15 µs | 1.25× |
| 8192 | 2.89 µs | 2.58 µs | 1.12× |
| 16384 | 5.67 µs | 5.41 µs | 1.05× |
| 65536 | 25.78 µs | 22.02 µs | 1.17× |

### Largest WASM128 wins (≥ 0.1 ms)

| Op | n | RISCV64 | WASM128 | Speedup |
|---|---:|---:|---:|---:|
| sgemm | 1024 | 227.861 ms | 80.603 ms | 2.83× |
| sgemm | 1536 | 768.601 ms | 272.835 ms | 2.82× |
| sgemm | 2048 | 1.807 s | 642.298 ms | 2.81× |
| sgemm | 512 | 27.945 ms | 10.225 ms | 2.73× |
| sgemm | 256 | 3.498 ms | 1.320 ms | 2.65× |
| sgemm | 128 | 455.09 µs | 172.62 µs | 2.64× |
| dtrsm | 256 | 1.856 ms | 1.147 ms | 1.62× |
| dgemm | 256 | 3.521 ms | 2.354 ms | 1.50× |
| dsyrk | 256 | 1.746 ms | 1.197 ms | 1.46× |
| dsyrk | 1536 | 378.944 ms | 261.067 ms | 1.45× |
| dsyrk | 1024 | 112.543 ms | 77.801 ms | 1.45× |
| dtrsm | 1024 | 114.902 ms | 79.566 ms | 1.44× |
| dtrsm | 2048 | 905.682 ms | 627.342 ms | 1.44× |
| dgemm | 1536 | 757.105 ms | 524.512 ms | 1.44× |
| dtrsm | 1536 | 382.672 ms | 266.276 ms | 1.44× |

### Takeaways

1. **SGEMM is ~2.4× faster** and **DGEMM ~1.30× faster** with `WASM128_GENERIC` — the SIMD kernels show up cleanly without NumPy overhead.
2. **DTRSM (~1.2×)** and **DSYRK (~1.5×)** improve similarly; TRSM benefits from the WASM-specific kernels added in 0.3.33+.
3. **L1 kernels (DOT / AXPY / ASUM / ROT)** stay near parity; only very large vectors show modest wins.
4. Shipping `TARGET=WASM128_GENERIC` on emscripten-forge is justified versus the current `RISCV64_GENERIC` workaround.

### Artifacts

- Logs:
  - [`result-cblas-riscv64.log`](https://github.com/user-attachments/files/30971959/result-cblas-riscv64.log)
  - [`result-cblas-wasm128.log`](https://github.com/user-attachments/files/30971962/result-cblas-wasm128.log)
- Source: [`bench_cblas.c`](https://github.com/user-attachments/files/30971939/bench_cblas.c)
- JSON: [`openblas_cblas_riscv_vs_wasm128.json`](https://github.com/user-attachments/files/30971964/openblas_cblas_riscv_vs_wasm128.json)

