### PR TITLE
Update openblas from 0.3.31 to 0.3.32

### DIFF
--- a/recipes/recipes_emscripten/openblas/patches/0001-Remove-march-flags.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0001-Remove-march-flags.patch
@@ -3,6 +3,8 @@ From: Isabel Paredes <isabel.paredes@quantstack.net>
 Date: Mon, 8 Dec 2025 07:47:46 +0000
 Subject: [PATCH 1/8] Remove -march flags
 
+Co-authored-by: Julien Jerphanion <git@jjerphan.xyz>
+
 ---
  Makefile.prebuild | 4 ----
  Makefile.riscv64  | 4 ----
@@ -50,5 +52,5 @@ index ab463f53d..4a8b17f96 100644
  endif
  
 -- 
-2.51.0
+2.55.0
 

--- a/recipes/recipes_emscripten/openblas/patches/0002-Skip-linktest.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0002-Skip-linktest.patch
@@ -3,15 +3,17 @@ From: Isabel Paredes <isabel.paredes@quantstack.net>
 Date: Mon, 8 Dec 2025 07:50:30 +0000
 Subject: [PATCH 2/8] Skip linktest
 
+Co-authored-by: Julien Jerphanion <git@jjerphan.xyz>
+
 ---
  exports/Makefile | 15 +++++++--------
  1 file changed, 7 insertions(+), 8 deletions(-)
 
 diff --git a/exports/Makefile b/exports/Makefile
-index 176b1a766..9a80fd7ca 100644
+index 6e7927915..d299031ef 100644
 --- a/exports/Makefile
 +++ b/exports/Makefile
-@@ -199,18 +199,18 @@ ifeq ($(F_COMPILER), INTEL)
+@@ -203,18 +203,18 @@ ifeq ($(F_COMPILER), INTEL)
  	$(FC) $(FFLAGS) $(LDFLAGS) -shared -o ../$(LIBSONAME) \
  	-Wl,--whole-archive $< -Wl,--no-whole-archive \
  	-Wl,-soname,$(INTERNALNAME) $(EXTRALIB)
@@ -33,7 +35,7 @@ index 176b1a766..9a80fd7ca 100644
  else
  #for LSB
  	env LSBCC_SHAREDLIBS=gfortran $(CC) $(CFLAGS) $(LDFLAGS) -shared -o ../$(LIBSONAME) \
-@@ -238,7 +238,7 @@ endif
+@@ -242,7 +242,7 @@ endif
  	$(CC) $(CFLAGS) $(LDFLAGS)  -shared -o ../$(LIBSONAME) \
  	-Wl,--whole-archive $< -Wl,--no-whole-archive \
  	$(FEXTRALIB) $(EXTRALIB)
@@ -42,7 +44,7 @@ index 176b1a766..9a80fd7ca 100644
  	rm -f linktest
  
  endif
-@@ -256,7 +256,7 @@ ifeq ($(OSNAME), SunOS)
+@@ -260,7 +260,7 @@ ifeq ($(OSNAME), SunOS)
  so : ../$(LIBSONAME)
  	$(CC) $(CFLAGS) $(LDFLAGS)  -shared -o ../$(LIBSONAME) \
  	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive $(EXTRALIB)
@@ -51,7 +53,7 @@ index 176b1a766..9a80fd7ca 100644
  	rm -f linktest
  
  endif
-@@ -312,9 +312,8 @@ objcopy.def : $(GENSYM) ../Makefile.system ../getarch.c
+@@ -316,9 +316,8 @@ objcopy.def : $(GENSYM) ../Makefile.system ../getarch.c
  objconv.def : $(GENSYM) ../Makefile.system ../getarch.c
  	./$(GENSYM) objconv $(ARCH) "$(BU)" $(EXPRECISION) $(NO_CBLAS)  $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" $(BUILD_LAPACK_DEPRECATED) $(BUILD_BFLOAT16) $(BUILD_HFLOAT16) $(BUILD_SINGLE) $(BUILD_DOUBLE) $(BUILD_COMPLEX) $(BUILD_COMPLEX16) > $(@F)
  
@@ -64,5 +66,5 @@ index 176b1a766..9a80fd7ca 100644
  linktest.c : $(GENSYM) ../Makefile.system ../getarch.c
  	./$(GENSYM) linktest  $(ARCH) "$(BU)" $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" $(BUILD_LAPACK_DEPRECATED) $(BUILD_BFLOAT16) $(BUILD_HFLOAT16) $(BUILD_SINGLE) $(BUILD_DOUBLE) $(BUILD_COMPLEX) $(BUILD_COMPLEX16) > linktest.c
 -- 
-2.51.0
+2.55.0
 

--- a/recipes/recipes_emscripten/openblas/patches/0003-Add-emscripten-as-supported-arch.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0003-Add-emscripten-as-supported-arch.patch
@@ -3,15 +3,17 @@ From: Isabel Paredes <isabel.paredes@quantstack.net>
 Date: Mon, 8 Dec 2025 07:51:01 +0000
 Subject: [PATCH 3/8] Add emscripten as supported arch
 
+Co-authored-by: Julien Jerphanion <git@jjerphan.xyz>
+
 ---
  getarch.c | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/getarch.c b/getarch.c
-index 8b7024809..f443d14f7 100644
+index d2dd8c6c4..4562a218a 100644
 --- a/getarch.c
 +++ b/getarch.c
-@@ -1949,6 +1949,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+@@ -1967,6 +1967,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  #define OPENBLAS_SUPPORTED
  #endif
  
@@ -24,5 +26,5 @@ index 8b7024809..f443d14f7 100644
  #error "This arch/CPU is not supported by OpenBLAS."
  #endif
 -- 
-2.51.0
+2.55.0
 

--- a/recipes/recipes_emscripten/openblas/patches/0004-Add-dummy-length-arguments-for-char-arguments.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0004-Add-dummy-length-arguments-for-char-arguments.patch
@@ -3,6 +3,8 @@ From: Ian Thomas <ianthomas23@gmail.com>
 Date: Mon, 8 Dec 2025 07:59:50 +0000
 Subject: [PATCH 4/8] Add dummy length arguments for char arguments
 
+Co-authored-by: Julien Jerphanion <git@jjerphan.xyz>
+
 ---
  common_interface.h          | 552 ++++++++++++++++++------------------
  interface/gbmv.c            |   2 +-
@@ -885,7 +887,7 @@ index 7a6581368..04172cb8d 100644
    char trans = *TRANS;
    blasint m = *M;
 diff --git a/interface/gemm.c b/interface/gemm.c
-index 4b1c9a93c..f0b3aa64c 100644
+index 60addbd2c..2266abeb7 100644
 --- a/interface/gemm.c
 +++ b/interface/gemm.c
 @@ -260,7 +260,7 @@ void NAME(char *TRANSA, char *TRANSB,
@@ -1910,5 +1912,5 @@ index b21bb9930..81eca2078 100644
  
    return 0;
 -- 
-2.51.0
+2.55.0
 

--- a/recipes/recipes_emscripten/openblas/patches/0005-Return-void-not-int.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0005-Return-void-not-int.patch
@@ -3,10 +3,12 @@ From: Ian Thomas <ianthomas23@gmail.com>
 Date: Mon, 8 Dec 2025 08:00:00 +0000
 Subject: [PATCH 5/8] Return void not int
 
+Co-authored-by: Julien Jerphanion <git@jjerphan.xyz>
+
 ---
  common_interface.h        | 240 +++++++++++++++++++-------------------
  driver/others/xerbla.c    |   8 +-
- interface/lapack/gesv.c   |  14 +--
+ interface/lapack/gesv.c   |  10 +-
  interface/lapack/getf2.c  |   8 +-
  interface/lapack/getrf.c  |   8 +-
  interface/lapack/getrs.c  |   8 +-
@@ -32,7 +34,7 @@ Subject: [PATCH 5/8] Return void not int
  interface/lapack/ztrti2.c |   8 +-
  interface/lapack/ztrtri.c |  10 +-
  interface/lapack/ztrtrs.c |  10 +-
- 28 files changed, 234 insertions(+), 234 deletions(-)
+ 28 files changed, 232 insertions(+), 232 deletions(-)
 
 diff --git a/common_interface.h b/common_interface.h
 index a510810ab..aa7494c83 100644
@@ -377,7 +379,7 @@ index 290f2833c..1d88c366d 100644
  
  #endif
 diff --git a/interface/lapack/gesv.c b/interface/lapack/gesv.c
-index 21fcc2097..a008a7238 100644
+index 61aa5c168..2263096cd 100644
 --- a/interface/lapack/gesv.c
 +++ b/interface/lapack/gesv.c
 @@ -60,7 +60,7 @@
@@ -402,8 +404,8 @@ index 21fcc2097..a008a7238 100644
  
    *Info = 0;
  
--  if (args.m == 0 || args.n == 0) return 0;
-+  if (args.m == 0 || args.n == 0) return;
+-  if (args.m == 0) return 0;
++  if (args.m == 0) return;
  
    IDEBUG_START;
  
@@ -416,18 +418,6 @@ index 21fcc2097..a008a7238 100644
    sa = (FLOAT *)((BLASLONG)buffer + GEMM_OFFSET_A);
    sb = (FLOAT *)(((BLASLONG)sa + ((GEMM_P * GEMM_Q * COMPSIZE * SIZE + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
  #endif
-@@ -117,9 +117,9 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
- 
- #if defined(_WIN64) && defined(_M_ARM64)
-   #ifdef COMPLEX
--    if (args.m * args.n <= 300) 
-+    if (args.m * args.n <= 300)
-   #else
--    if (args.m * args.n <= 500) 
-+    if (args.m * args.n <= 500)
-   #endif
-       args.nthreads = 1;
-   else if (args.m * args.n <= 1000)
 @@ -171,5 +171,5 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
  
    IDEBUG_END;
@@ -1340,5 +1330,5 @@ index 2b195e615..da1ae7ded 100644
  
  }
 -- 
-2.51.0
+2.55.0
 

--- a/recipes/recipes_emscripten/openblas/patches/0006-Int-to-void-return-types-of-lapack-functions-used-by.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0006-Int-to-void-return-types-of-lapack-functions-used-by.patch
@@ -4,6 +4,8 @@ Date: Mon, 8 Dec 2025 08:07:39 +0000
 Subject: [PATCH 6/8] Int to void return types of lapack functions used by
  lapacke
 
+Co-authored-by: Julien Jerphanion <git@jjerphan.xyz>
+
 ---
  lapack-netlib/LAPACKE/include/lapack.h | 66 +++++++++++++-------------
  1 file changed, 33 insertions(+), 33 deletions(-)
@@ -284,5 +286,5 @@ index 0ed9ad01a..88393b787 100644
      lapack_int const* n,
      lapack_complex_double* A, lapack_int const* lda,
 -- 
-2.51.0
+2.55.0
 

--- a/recipes/recipes_emscripten/openblas/patches/0007-Enable-LAPACK_FORTRAN_STDLEN_END-for-lapacke-calling.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0007-Enable-LAPACK_FORTRAN_STDLEN_END-for-lapacke-calling.patch
@@ -4,6 +4,8 @@ Date: Mon, 8 Dec 2025 17:10:40 +0000
 Subject: [PATCH 7/8] Enable LAPACK_FORTRAN_STDLEN_END for lapacke calling
  lapack
 
+Co-authored-by: Julien Jerphanion <git@jjerphan.xyz>
+
 ---
  lapack-netlib/LAPACKE/include/lapack.h | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
@@ -25,5 +27,5 @@ index 88393b787..2c437314c 100644
  #ifndef FORTRAN_STRLEN
    #define FORTRAN_STRLEN size_t
 -- 
-2.51.0
+2.55.0
 

--- a/recipes/recipes_emscripten/openblas/patches/0008-Clear-FEXTRALIB-when-linking-shared-library.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0008-Clear-FEXTRALIB-when-linking-shared-library.patch
@@ -3,12 +3,14 @@ From: Ian Thomas <ianthomas23@gmail.com>
 Date: Fri, 13 Mar 2026 09:07:45 +0000
 Subject: [PATCH] Clear FEXTRALIB when linking shared library
 
+Co-authored-by: Julien Jerphanion <git@jjerphan.xyz>
+
 ---
  exports/Makefile | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/exports/Makefile b/exports/Makefile
-index 9a80fd7ca..47e0aa284 100644
+index d299031ef..b996237c0 100644
 --- a/exports/Makefile
 +++ b/exports/Makefile
 @@ -88,6 +88,8 @@ ifneq (,$(filter 1 2,$(NOFORTRAN)))
@@ -21,5 +23,5 @@ index 9a80fd7ca..47e0aa284 100644
  
  libs::
 -- 
-2.51.0
+2.55.0
 

--- a/recipes/recipes_emscripten/openblas/recipe.yaml
+++ b/recipes/recipes_emscripten/openblas/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: openblas
-  version: 0.3.31
+  version: 0.3.32
 
 package:
   name: ${{ name }}
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://github.com/OpenMathLib/OpenBLAS/archive/v${{ version }}.tar.gz
-  sha256: 6dd2a63ac9d32643b7cc636eab57bf4e57d0ed1fff926dfbc5d3d97f2d2be3a6
+  sha256: f8a1138e01fddca9e4c29f9684fd570ba39dedc9ca76055e1425d5d4b1a4a766
   patches:
-  # Branch containing these patches is v0.3.31-emforge at https://github.com/ianthomas23/OpenBLAS
-  # Use `git format-patch v0.3.31..v0.3.31-emforge` to create patch files.
+  # Branch containing these patches is v0.3.32-emforge at https://github.com/jjerphan/OpenBLAS
+  # Use `git format-patch v0.3.32..v0.3.32-emforge` to create patch files.
   - patches/0001-Remove-march-flags.patch
   - patches/0002-Skip-linktest.patch
   - patches/0003-Add-emscripten-as-supported-arch.patch
@@ -22,7 +22,7 @@ source:
   - patches/0008-Clear-FEXTRALIB-when-linking-shared-library.patch
 
 build:
-  number: 5
+  number: 0
 
   files:
     exclude:


### PR DESCRIPTION
## Package Details
- **Package Name**: openblas
- **Version**: 0.3.32

## Build Notes

Patches have been rebased and marginally adapted (see the comment).

Close https://github.com/emscripten-forge/recipes/pull/5188.