### PR TITLE
Run OpenBLAS test suite

### DIFF
--- a/recipes/recipes_emscripten/openblas/build.sh
+++ b/recipes/recipes_emscripten/openblas/build.sh
@@ -13,15 +13,52 @@ export LDFLAGS="$LDFLAGS $EM_FORGE_SIDE_MODULE_LDFLAGS $FCLIBS"
 export BUILD_CORES=-j1
 
 export USE_THREAD=0
-
 # WASM128_GENERIC enables WASM SIMD128 kernels (SGEMM/DGEMM, DAXPY, SUM, DOT, ROT, TRSM).
 # Makefile.wasm adds -msimd128 automatically for this architecture.
-emmake make shared \
-    $BUILD_CORES \
-    HOSTCC=gcc \
-    TARGET=WASM128_GENERIC
+export TARGET=WASM128_GENERIC
 
-emmake make install PREFIX=$PREFIX
+MAKE_ARGS=(
+    $BUILD_CORES
+    HOSTCC=gcc
+    TARGET="${TARGET}"
+    USE_THREAD=0
+)
+
+emmake make shared "${MAKE_ARGS[@]}"
+
+# ---------------------------------------------------------------------------
+# Run OpenBLAS tests under Node.
+#
+# The Fortran BLAS drivers in test/ and ctest/*.f crash flang 22 when targeting
+# wasm32-unknown-emscripten (segfault in ARM64FindSegmentsInFunction). Build the
+# library with Fortran as usual, but run tests with NOFORTRAN=1 so ctest uses its
+# pure-C drivers (c_*blat*c.c) and the Fortran-only test/ tree is skipped.
+#
+# Test binaries must be linked as standalone wasm executables (not SIDE_MODULE)
+# against the static archive. Patches 0009-0012 adapt the Makefiles/test ABI.
+#
+# OpenBLAS sets CROSS=1 for emscripten, which skips executing test binaries.
+# Override CROSS=0 for the test phase so node actually runs them.
+# ---------------------------------------------------------------------------
+# Complex L3 f2c drivers allocate large locals; the default 64KB wasm stack is
+# too small (stack overflow → OOB). 8MB is enough for c/z blat3.
+TEST_LINK_FLAGS="-fwasm-exceptions -sSUPPORT_LONGJMP=wasm -sALLOW_MEMORY_GROWTH=1 -sFORCE_FILESYSTEM=1 -sNODERAWFS=1 -sSTACK_SIZE=8MB"
+TEST_CCOMMON_OPT="$EM_FORGE_CFLAGS_BASE ${TEST_LINK_FLAGS} -Wno-implicit-function-declaration -Wno-macro-redefined"
+TEST_LDFLAGS="$EM_FORGE_LDFLAGS_BASE $FCLIBS ${TEST_LINK_FLAGS}"
+TEST_ARGS=(
+    "${MAKE_ARGS[@]}"
+    NOFORTRAN=1
+    CROSS=0
+    EXE=.js
+    CCOMMON_OPT="${TEST_CCOMMON_OPT}"
+    FCOMMON_OPT="${FFLAGS}"
+    LDFLAGS="${TEST_LDFLAGS}"
+)
+
+emmake make -C utest all "${TEST_ARGS[@]}"
+emmake make -C ctest all1 all2 all3 "${TEST_ARGS[@]}"
+
+emmake make install PREFIX=$PREFIX "${MAKE_ARGS[@]}"
 
 # OpenBLAS embeds absolute build-prefix paths in openblas.pc. Rewrite it to be
 # relocatable so dependents (e.g. NumPy) can find it via pkg-config after the
@@ -31,7 +68,7 @@ cat > "${PREFIX}/lib/pkgconfig/openblas.pc" <<EOF
 prefix=\${pcfiledir}/../..
 libdir=\${prefix}/lib
 includedir=\${prefix}/include
-openblas_config=USE_THREAD=0 TARGET=WASM128_GENERIC
+openblas_config=USE_THREAD=0 TARGET=${TARGET}
 version=${PKG_VERSION}
 Name: openblas
 Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version

--- a/recipes/recipes_emscripten/openblas/patches/0009-Skip-fork-based-utests-for-emscripten.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0009-Skip-fork-based-utests-for-emscripten.patch
@@ -1,0 +1,36 @@
+From 765fdfc97b0fc09ba08c11b698aa25d084f06256 Mon Sep 17 00:00:00 2001
+From: Julien Jerphanion <git@jjerphan.xyz>
+Date: Thu, 13 Aug 2026 09:45:45 +0200
+Subject: Skip fork-based utests for emscripten
+
+Signed-off-by: Julien Jerphanion <git@jjerphan.xyz>
+---
+ utest/Makefile | 12 ------------
+ 1 file changed, 12 deletions(-)
+
+diff --git a/utest/Makefile b/utest/Makefile
+index 07de0c2fc..5b602b1b0 100644
+--- a/utest/Makefile
++++ b/utest/Makefile
+@@ -41,18 +41,6 @@ endif
+ endif
+ endif
+ 
+-#this does not work with OpenMP nor with native Windows or Android threads
+-# FIXME TBD if this works on OSX, SunOS, POWER and zarch
+-ifeq ($(OSNAME), $(filter $(OSNAME),Linux CYGWIN_NT))
+-ifneq ($(USE_OPENMP), 1)
+-OBJS += test_fork.o
+-ifneq ($(NO_LAPACK), 1)
+-OBJS += test_post_fork_async.o
+-endif
+-endif
+-OBJS += test_post_fork.o
+-endif
+-
+ ifeq ($(C_COMPILER), PGI)
+ OBJS = utest_main2.o
+ endif
+-- 
+2.55.0
+

--- a/recipes/recipes_emscripten/openblas/patches/0010-Run-OpenBLAS-tests-under-node-for-emscripten.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0010-Run-OpenBLAS-tests-under-node-for-emscripten.patch
@@ -1,0 +1,168 @@
+From 0da4896e72822581b4538870f7015b6ed6175a27 Mon Sep 17 00:00:00 2001
+From: Julien Jerphanion <git@jjerphan.xyz>
+Date: Thu, 13 Aug 2026 09:45:45 +0200
+Subject: Run OpenBLAS tests under node for emscripten
+
+Signed-off-by: Julien Jerphanion <git@jjerphan.xyz>
+---
+ ctest/Makefile | 56 +++++++++++++++++++++++++-------------------------
+ utest/Makefile |  4 ++--
+ 2 files changed, 30 insertions(+), 30 deletions(-)
+
+diff --git a/ctest/Makefile b/ctest/Makefile
+index f4e947549..99013e398 100644
+--- a/ctest/Makefile
++++ b/ctest/Makefile
+@@ -84,29 +84,29 @@ all1: $(all1targets)
+ ifneq ($(CROSS), 1)
+ ifeq ($(USE_OPENMP), 1)
+ ifeq ($(BUILD_SINGLE),1)
+-	OMP_NUM_THREADS=2 ./xscblat1$(EXE)
++	OMP_NUM_THREADS=2 node ./xscblat1$(EXE)
+ endif
+ ifeq ($(BUILD_DOUBLE),1)
+-	OMP_NUM_THREADS=2 ./xdcblat1$(EXE)
++	OMP_NUM_THREADS=2 node ./xdcblat1$(EXE)
+ endif
+ ifeq ($(BUILD_COMPLEX),1)
+-	OMP_NUM_THREADS=2 ./xccblat1$(EXE)
++	OMP_NUM_THREADS=2 node ./xccblat1$(EXE)
+ endif
+ ifeq ($(BUILD_COMPLEX16),1)
+-	OMP_NUM_THREADS=2 ./xzcblat1$(EXE)
++	OMP_NUM_THREADS=2 node ./xzcblat1$(EXE)
+ endif
+ else
+ ifeq ($(BUILD_SINGLE),1)
+-	OPENBLAS_NUM_THREADS=2 ./xscblat1$(EXE)
++	OPENBLAS_NUM_THREADS=2 node ./xscblat1$(EXE)
+ endif
+ ifeq ($(BUILD_DOUBLE),1)
+-	OPENBLAS_NUM_THREADS=2 ./xdcblat1$(EXE)
++	OPENBLAS_NUM_THREADS=2 node ./xdcblat1$(EXE)
+ endif
+ ifeq ($(BUILD_COMPLEX),1)
+-	OPENBLAS_NUM_THREADS=2 ./xccblat1$(EXE)
++	OPENBLAS_NUM_THREADS=2 node ./xccblat1$(EXE)
+ endif
+ ifeq ($(BUILD_COMPLEX16),1)
+-	OPENBLAS_NUM_THREADS=2 ./xzcblat1$(EXE)
++	OPENBLAS_NUM_THREADS=2 node ./xzcblat1$(EXE)
+ endif
+ endif
+ endif
+@@ -129,29 +129,29 @@ all2: $(all2targets)
+ ifneq ($(CROSS), 1)
+ ifeq ($(USE_OPENMP), 1)
+ ifeq ($(BUILD_SINGLE),1)
+-	OMP_NUM_THREADS=2 ./xscblat2$(EXE) < sin2
++	OMP_NUM_THREADS=2 node ./xscblat2$(EXE) < sin2
+ endif
+ ifeq ($(BUILD_DOUBLE),1)
+-	OMP_NUM_THREADS=2 ./xdcblat2$(EXE) < din2
++	OMP_NUM_THREADS=2 node ./xdcblat2$(EXE) < din2
+ endif
+ ifeq ($(BUILD_COMPLEX),1)
+-	OMP_NUM_THREADS=2 ./xccblat2$(EXE) < cin2
++	OMP_NUM_THREADS=2 node ./xccblat2$(EXE) < cin2
+ endif
+ ifeq ($(BUILD_COMPLEX16),1)
+-	OMP_NUM_THREADS=2 ./xzcblat2$(EXE) < zin2
++	OMP_NUM_THREADS=2 node ./xzcblat2$(EXE) < zin2
+ endif
+ else
+ ifeq ($(BUILD_SINGLE),1)
+-	OPENBLAS_NUM_THREADS=2 ./xscblat2$(EXE) < sin2
++	OPENBLAS_NUM_THREADS=2 node ./xscblat2$(EXE) < sin2
+ endif
+ ifeq ($(BUILD_DOUBLE),1)
+-	OPENBLAS_NUM_THREADS=2 ./xdcblat2$(EXE) < din2
++	OPENBLAS_NUM_THREADS=2 node ./xdcblat2$(EXE) < din2
+ endif
+ ifeq ($(BUILD_COMPLEX),1)
+-	OPENBLAS_NUM_THREADS=2 ./xccblat2$(EXE) < cin2
++	OPENBLAS_NUM_THREADS=2 node ./xccblat2$(EXE) < cin2
+ endif
+ ifeq ($(BUILD_COMPLEX16),1)
+-	OPENBLAS_NUM_THREADS=2 ./xzcblat2$(EXE) < zin2
++	OPENBLAS_NUM_THREADS=2 node ./xzcblat2$(EXE) < zin2
+ endif
+ endif
+ endif
+@@ -181,46 +181,46 @@ all3: $(all3targets)
+ ifneq ($(CROSS), 1)
+ ifeq ($(USE_OPENMP), 1)
+ ifeq ($(BUILD_SINGLE),1)
+-	OMP_NUM_THREADS=2 ./xscblat3$(EXE) < sin3
++	OMP_NUM_THREADS=2 node ./xscblat3$(EXE) < sin3
+ endif
+ ifeq ($(BUILD_DOUBLE),1)
+-	OMP_NUM_THREADS=2 ./xdcblat3$(EXE) < din3
++	OMP_NUM_THREADS=2 node ./xdcblat3$(EXE) < din3
+ endif
+ ifeq ($(BUILD_COMPLEX),1)
+-	OMP_NUM_THREADS=2 ./xccblat3$(EXE) < cin3
++	OMP_NUM_THREADS=2 node ./xccblat3$(EXE) < cin3
+ endif
+ ifeq ($(BUILD_COMPLEX16),1)
+-	OMP_NUM_THREADS=2 ./xzcblat3$(EXE) < zin3
++	OMP_NUM_THREADS=2 node ./xzcblat3$(EXE) < zin3
+ endif
+ else
+ ifeq ($(BUILD_SINGLE),1)
+-	OPENBLAS_NUM_THREADS=2 ./xscblat3$(EXE) < sin3
++	OPENBLAS_NUM_THREADS=2 node ./xscblat3$(EXE) < sin3
+ endif
+ ifeq ($(BUILD_DOUBLE),1)
+-	OPENBLAS_NUM_THREADS=2 ./xdcblat3$(EXE) < din3
++	OPENBLAS_NUM_THREADS=2 node ./xdcblat3$(EXE) < din3
+ endif
+ ifeq ($(BUILD_COMPLEX),1)
+-	OPENBLAS_NUM_THREADS=2 ./xccblat3$(EXE) < cin3
++	OPENBLAS_NUM_THREADS=2 node ./xccblat3$(EXE) < cin3
+ endif
+ ifeq ($(BUILD_COMPLEX16),1)
+-	OPENBLAS_NUM_THREADS=2 ./xzcblat3$(EXE) < zin3
++	OPENBLAS_NUM_THREADS=2 node ./xzcblat3$(EXE) < zin3
+ endif
+ endif
+ 
+ ifeq ($(SUPPORT_GEMM3M),1)
+ ifeq ($(USE_OPENMP), 1)
+ ifeq ($(BUILD_COMPLEX),1)
+-	OMP_NUM_THREADS=2 ./xccblat3_3m$(EXE) < cin3_3m
++	OMP_NUM_THREADS=2 node ./xccblat3_3m$(EXE) < cin3_3m
+ endif
+ ifeq ($(BUILD_COMPLEX16),1)
+-	OMP_NUM_THREADS=2 ./xzcblat3_3m$(EXE) < zin3_3m
++	OMP_NUM_THREADS=2 node ./xzcblat3_3m$(EXE) < zin3_3m
+ endif
+ else
+ ifeq ($(BUILD_COMPLEX),1)
+-	OPENBLAS_NUM_THREADS=2 ./xccblat3_3m$(EXE) < cin3_3m
++	OPENBLAS_NUM_THREADS=2 node ./xccblat3_3m$(EXE) < cin3_3m
+ endif
+ ifeq ($(BUILD_COMPLEX16),1)
+-	OPENBLAS_NUM_THREADS=2 ./xzcblat3_3m$(EXE) < zin3_3m
++	OPENBLAS_NUM_THREADS=2 node ./xzcblat3_3m$(EXE) < zin3_3m
+ endif
+ endif
+ endif
+diff --git a/utest/Makefile b/utest/Makefile
+index 5b602b1b0..2d264df09 100644
+--- a/utest/Makefile
++++ b/utest/Makefile
+@@ -74,8 +74,8 @@ endif
+ 
+ run_test: $(UTESTBIN) $(UTESTEXTBIN)
+ ifneq ($(CROSS), 1)
+-	./$(UTESTBIN)
+-	./$(UTESTEXTBIN)
++	node ./$(UTESTBIN)
++	node ./$(UTESTEXTBIN)
+ endif
+ 
+ clean:
+-- 
+2.55.0
+

--- a/recipes/recipes_emscripten/openblas/patches/0011-Return-int-from-ctest-F77-wrappers-for-wasm-ABI.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0011-Return-int-from-ctest-F77-wrappers-for-wasm-ABI.patch
@@ -1,0 +1,1969 @@
+From baf9d42f3442b9acb8b2e2a65c7eb8cb346c506f Mon Sep 17 00:00:00 2001
+From: Julien Jerphanion <git@jjerphan.xyz>
+Date: Thu, 13 Aug 2026 09:46:19 +0200
+Subject: Return int from ctest F77 wrappers for wasm ABI
+
+Signed-off-by: Julien Jerphanion <git@jjerphan.xyz>
+---
+ ctest/c_c2chke.c    |  3 ++-
+ ctest/c_c3chke.c    |  3 ++-
+ ctest/c_c3chke_3m.c |  3 ++-
+ ctest/c_cblas1.c    | 28 ++++++++++++-------------
+ ctest/c_cblas2.c    | 51 ++++++++++++++++++++++++++++++---------------
+ ctest/c_cblas3.c    | 27 ++++++++++++++++--------
+ ctest/c_cblas3_3m.c | 30 +++++++++++++++++---------
+ ctest/c_d2chke.c    |  3 ++-
+ ctest/c_d3chke.c    |  3 ++-
+ ctest/c_dblas1.c    | 28 ++++++++++++-------------
+ ctest/c_dblas2.c    | 48 ++++++++++++++++++++++++++++--------------
+ ctest/c_dblas3.c    | 18 ++++++++++------
+ ctest/c_s2chke.c    |  3 ++-
+ ctest/c_s3chke.c    |  3 ++-
+ ctest/c_sblas1.c    | 28 ++++++++++++-------------
+ ctest/c_sblas2.c    | 48 ++++++++++++++++++++++++++++--------------
+ ctest/c_sblas3.c    | 18 ++++++++++------
+ ctest/c_z2chke.c    |  3 ++-
+ ctest/c_z3chke.c    |  3 ++-
+ ctest/c_z3chke_3m.c |  3 ++-
+ ctest/c_zblas1.c    | 28 ++++++++++++-------------
+ ctest/c_zblas2.c    | 51 ++++++++++++++++++++++++++++++---------------
+ ctest/c_zblas3.c    | 27 ++++++++++++++++--------
+ ctest/c_zblas3_3m.c | 30 +++++++++++++++++---------
+ 24 files changed, 308 insertions(+), 182 deletions(-)
+
+diff --git a/ctest/c_c2chke.c b/ctest/c_c2chke.c
+index 2129aad3f..52df56ac3 100644
+--- a/ctest/c_c2chke.c
++++ b/ctest/c_c2chke.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void F77_c2chke(char *rout) {
++int F77_c2chke(char *rout) {
+    char *sf = ( rout ) ;
+    float  A[2] = {0.0,0.0},
+           X[2] = {0.0,0.0},
+@@ -814,4 +814,5 @@ void F77_c2chke(char *rout) {
+        printf("******* %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_c3chke.c b/ctest/c_c3chke.c
+index 6b6b7684d..238c084b9 100644
+--- a/ctest/c_c3chke.c
++++ b/ctest/c_c3chke.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void  F77_c3chke(char *  rout) {
++int  F77_c3chke(char *  rout) {
+    char *sf = ( rout ) ;
+    float   A[4]     = {0.0,0.0,0.0,0.0},
+            B[4]     = {0.0,0.0,0.0,0.0},
+@@ -1696,4 +1696,5 @@ void  F77_c3chke(char *  rout) {
+        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_c3chke_3m.c b/ctest/c_c3chke_3m.c
+index 767d0cfeb..9ace90bf6 100644
+--- a/ctest/c_c3chke_3m.c
++++ b/ctest/c_c3chke_3m.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void  F77_c3chke(char *  rout) {
++int  F77_c3chke(char *  rout) {
+    char *sf = ( rout ) ;
+    float   A[4]     = {0.0,0.0,0.0,0.0},
+            B[4]     = {0.0,0.0,0.0,0.0},
+@@ -1924,4 +1924,5 @@ void  F77_c3chke(char *  rout) {
+        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_cblas1.c b/ctest/c_cblas1.c
+index 83925ad5e..34a03fbd4 100644
+--- a/ctest/c_cblas1.c
++++ b/ctest/c_cblas1.c
+@@ -9,53 +9,53 @@
+ #include "common.h"
+ #include "cblas_test.h"
+ 
+-void F77_caxpy(const int *N, OPENBLAS_CONST void *alpha, void *X,
++int F77_caxpy(const int *N, OPENBLAS_CONST void *alpha, void *X,
+                     const int *incX, void *Y, const int *incY)
+ {
+    cblas_caxpy(*N, alpha, X, *incX, Y, *incY);
+-   return;
++   return 0;
+ }
+ 
+-void F77_ccopy(const int *N, void *X, const int *incX,
++int F77_ccopy(const int *N, void *X, const int *incX,
+                     void *Y, const int *incY)
+ {
+    cblas_ccopy(*N, X, *incX, Y, *incY);
+-   return;
++   return 0;
+ }
+ 
+-void F77_cdotc(const int *N, void *X, const int *incX,
++int F77_cdotc(const int *N, void *X, const int *incX,
+                         void *Y, const int *incY, void *dotc)
+ {
+    cblas_cdotc_sub(*N, X, *incX, Y, *incY, dotc);
+-   return;
++   return 0;
+ }
+ 
+-void F77_cdotu(const int *N, void *X, const int *incX,
++int F77_cdotu(const int *N, void *X, const int *incX,
+                         void *Y, const int *incY,void *dotu)
+ {
+    cblas_cdotu_sub(*N, X, *incX, Y, *incY, dotu);
+-   return;
++   return 0;
+ }
+ 
+-void F77_cscal(const int *N, const void * *alpha, void *X,
++int F77_cscal(const int *N, const void * *alpha, void *X,
+                          const int *incX)
+ {
+    cblas_cscal(*N, alpha, X, *incX);
+-   return;
++   return 0;
+ }
+ 
+-void F77_csscal(const int *N, const float *alpha, void *X,
++int F77_csscal(const int *N, const float *alpha, void *X,
+                          const int *incX)
+ {
+    cblas_csscal(*N, *alpha, X, *incX);
+-   return;
++   return 0;
+ }
+ 
+-void F77_cswap( const int *N, void *X, const int *incX,
++int F77_cswap( const int *N, void *X, const int *incX,
+                           void *Y, const int *incY)
+ {
+    cblas_cswap(*N,X,*incX,Y,*incY);
+-   return;
++   return 0;
+ }
+ 
+ int F77_icamax(const int *N, OPENBLAS_CONST void *X, const int *incX)
+diff --git a/ctest/c_cblas2.c b/ctest/c_cblas2.c
+index 6511e5271..695a0c7c8 100644
+--- a/ctest/c_cblas2.c
++++ b/ctest/c_cblas2.c
+@@ -8,7 +8,7 @@
+ #include "common.h"
+ #include "cblas_test.h"
+ 
+-void F77_cgemv(int *order, char *transp, int *m, int *n,
++int F77_cgemv(int *order, char *transp, int *m, int *n,
+           OPENBLAS_CONST void *alpha,
+           CBLAS_TEST_COMPLEX *a, int *lda, OPENBLAS_CONST void *x, int *incx,
+           OPENBLAS_CONST void *beta, void *y, int *incy) {
+@@ -36,9 +36,10 @@ void F77_cgemv(int *order, char *transp, int *m, int *n,
+   else
+      cblas_cgemv( UNDEFINED, trans,
+                   *m, *n, alpha, a, *lda, x, *incx, beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_cgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
++int F77_cgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
+ 	      CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+ 	      CBLAS_TEST_COMPLEX *x, int *incx,
+ 	      CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *y, int *incy) {
+@@ -83,9 +84,10 @@ void F77_cgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
+   else
+      cblas_cgbmv( UNDEFINED, trans, *m, *n, *kl, *ku, alpha, a, *lda, x,
+ 		  *incx, beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_cgeru(int *order, int *m, int *n, CBLAS_TEST_COMPLEX *alpha,
++int F77_cgeru(int *order, int *m, int *n, CBLAS_TEST_COMPLEX *alpha,
+ 	 CBLAS_TEST_COMPLEX *x, int *incx, CBLAS_TEST_COMPLEX *y, int *incy,
+          CBLAS_TEST_COMPLEX *a, int *lda){
+ 
+@@ -112,9 +114,10 @@ void F77_cgeru(int *order, int *m, int *n, CBLAS_TEST_COMPLEX *alpha,
+      cblas_cgeru( CblasColMajor, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
+   else
+      cblas_cgeru( UNDEFINED, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
++  return 0;
+ }
+ 
+-void F77_cgerc(int *order, int *m, int *n, CBLAS_TEST_COMPLEX *alpha,
++int F77_cgerc(int *order, int *m, int *n, CBLAS_TEST_COMPLEX *alpha,
+ 	 CBLAS_TEST_COMPLEX *x, int *incx, CBLAS_TEST_COMPLEX *y, int *incy,
+          CBLAS_TEST_COMPLEX *a, int *lda) {
+   CBLAS_TEST_COMPLEX *A;
+@@ -140,9 +143,10 @@ void F77_cgerc(int *order, int *m, int *n, CBLAS_TEST_COMPLEX *alpha,
+      cblas_cgerc( CblasColMajor, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
+   else
+      cblas_cgerc( UNDEFINED, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
++  return 0;
+ }
+ 
+-void F77_chemv(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
++int F77_chemv(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
+       CBLAS_TEST_COMPLEX *a, int *lda, CBLAS_TEST_COMPLEX *x,
+       int *incx, CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *y, int *incy){
+ 
+@@ -170,9 +174,10 @@ void F77_chemv(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
+   else
+      cblas_chemv( UNDEFINED, uplo, *n, alpha, a, *lda, x, *incx,
+ 	   beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_chbmv(int *order, char *uplow, int *n, int *k,
++int F77_chbmv(int *order, char *uplow, int *n, int *k,
+      CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+      CBLAS_TEST_COMPLEX *x, int *incx, CBLAS_TEST_COMPLEX *beta,
+      CBLAS_TEST_COMPLEX *y, int *incy){
+@@ -234,9 +239,10 @@ int i,irow,j,jcol,LDA;
+    else
+      cblas_chbmv(UNDEFINED, uplo, *n, *k, alpha, a, *lda, x, *incx,
+                  beta, y, *incy );
++   return 0;
+ }
+ 
+-void F77_chpmv(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
++int F77_chpmv(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
+      CBLAS_TEST_COMPLEX *ap, CBLAS_TEST_COMPLEX *x, int *incx,
+      CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *y, int *incy){
+ 
+@@ -290,9 +296,10 @@ void F77_chpmv(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
+   else
+      cblas_chpmv( UNDEFINED, uplo, *n, alpha, ap, x, *incx, beta, y,
+                   *incy );
++  return 0;
+ }
+ 
+-void F77_ctbmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ctbmv(int *order, char *uplow, char *transp, char *diagn,
+      int *n, int *k, CBLAS_TEST_COMPLEX *a, int *lda, CBLAS_TEST_COMPLEX *x,
+      int *incx) {
+   CBLAS_TEST_COMPLEX *A;
+@@ -353,9 +360,10 @@ void F77_ctbmv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ctbmv(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
+    else
+      cblas_ctbmv(UNDEFINED, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
++  return 0;
+ }
+ 
+-void F77_ctbsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ctbsv(int *order, char *uplow, char *transp, char *diagn,
+       int *n, int *k, CBLAS_TEST_COMPLEX *a, int *lda, CBLAS_TEST_COMPLEX *x,
+       int *incx) {
+ 
+@@ -417,9 +425,10 @@ void F77_ctbsv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ctbsv(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
+   else
+      cblas_ctbsv(UNDEFINED, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
++  return 0;
+ }
+ 
+-void F77_ctpmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ctpmv(int *order, char *uplow, char *transp, char *diagn,
+       int *n, CBLAS_TEST_COMPLEX *ap, CBLAS_TEST_COMPLEX *x, int *incx) {
+   CBLAS_TEST_COMPLEX *A, *AP;
+   int i, j, k, LDA;
+@@ -472,9 +481,10 @@ void F77_ctpmv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ctpmv( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
+   else
+      cblas_ctpmv( UNDEFINED, uplo, trans, diag, *n, ap, x, *incx );
++  return 0;
+ }
+ 
+-void F77_ctpsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ctpsv(int *order, char *uplow, char *transp, char *diagn,
+      int *n, CBLAS_TEST_COMPLEX *ap, CBLAS_TEST_COMPLEX *x, int *incx) {
+   CBLAS_TEST_COMPLEX *A, *AP;
+   int i, j, k, LDA;
+@@ -527,9 +537,10 @@ void F77_ctpsv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ctpsv( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
+   else
+      cblas_ctpsv( UNDEFINED, uplo, trans, diag, *n, ap, x, *incx );
++  return 0;
+ }
+ 
+-void F77_ctrmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ctrmv(int *order, char *uplow, char *transp, char *diagn,
+      int *n, CBLAS_TEST_COMPLEX *a, int *lda, CBLAS_TEST_COMPLEX *x,
+       int *incx) {
+   CBLAS_TEST_COMPLEX *A;
+@@ -557,8 +568,9 @@ void F77_ctrmv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ctrmv(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx);
+   else
+      cblas_ctrmv(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx);
++  return 0;
+ }
+-void F77_ctrsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ctrsv(int *order, char *uplow, char *transp, char *diagn,
+        int *n, CBLAS_TEST_COMPLEX *a, int *lda, CBLAS_TEST_COMPLEX *x,
+               int *incx) {
+   CBLAS_TEST_COMPLEX *A;
+@@ -586,9 +598,10 @@ void F77_ctrsv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ctrsv(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx );
+    else
+      cblas_ctrsv(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx );
++  return 0;
+ }
+ 
+-void F77_chpr(int *order, char *uplow, int *n, float *alpha,
++int F77_chpr(int *order, char *uplow, int *n, float *alpha,
+ 	     CBLAS_TEST_COMPLEX *x, int *incx, CBLAS_TEST_COMPLEX *ap) {
+   CBLAS_TEST_COMPLEX *A, *AP;
+   int i,j,k,LDA;
+@@ -661,9 +674,10 @@ void F77_chpr(int *order, char *uplow, int *n, float *alpha,
+      cblas_chpr(CblasColMajor, uplo, *n, *alpha, x, *incx, ap );
+   else
+      cblas_chpr(UNDEFINED, uplo, *n, *alpha, x, *incx, ap );
++  return 0;
+ }
+ 
+-void F77_chpr2(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
++int F77_chpr2(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
+        CBLAS_TEST_COMPLEX *x, int *incx, CBLAS_TEST_COMPLEX *y, int *incy,
+        CBLAS_TEST_COMPLEX *ap) {
+   CBLAS_TEST_COMPLEX *A, *AP;
+@@ -738,9 +752,10 @@ void F77_chpr2(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
+      cblas_chpr2( CblasColMajor, uplo, *n, alpha, x, *incx, y, *incy, ap );
+   else
+      cblas_chpr2( UNDEFINED, uplo, *n, alpha, x, *incx, y, *incy, ap );
++  return 0;
+ }
+ 
+-void F77_cher(int *order, char *uplow, int *n, float *alpha,
++int F77_cher(int *order, char *uplow, int *n, float *alpha,
+   CBLAS_TEST_COMPLEX *x, int *incx, CBLAS_TEST_COMPLEX *a, int *lda) {
+   CBLAS_TEST_COMPLEX *A;
+   int i,j,LDA;
+@@ -770,9 +785,10 @@ void F77_cher(int *order, char *uplow, int *n, float *alpha,
+      cblas_cher( CblasColMajor, uplo, *n, *alpha, x, *incx, a, *lda );
+   else
+      cblas_cher( UNDEFINED, uplo, *n, *alpha, x, *incx, a, *lda );
++  return 0;
+ }
+ 
+-void F77_cher2(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
++int F77_cher2(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
+           CBLAS_TEST_COMPLEX *x, int *incx, CBLAS_TEST_COMPLEX *y, int *incy,
+ 	  CBLAS_TEST_COMPLEX *a, int *lda) {
+ 
+@@ -804,4 +820,5 @@ void F77_cher2(int *order, char *uplow, int *n, CBLAS_TEST_COMPLEX *alpha,
+      cblas_cher2( CblasColMajor, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
+   else
+      cblas_cher2( UNDEFINED, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
++  return 0;
+ }
+diff --git a/ctest/c_cblas3.c b/ctest/c_cblas3.c
+index 9f48c49b1..fa76148ba 100644
+--- a/ctest/c_cblas3.c
++++ b/ctest/c_cblas3.c
+@@ -12,7 +12,7 @@
+ #define  TEST_ROW_MJR	1
+ #define  UNDEFINED     -1
+ 
+-void F77_cgemm(int *order, char *transpa, char *transpb, int *m, int *n,
++int F77_cgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+      int *k, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+      CBLAS_TEST_COMPLEX *b, int *ldb, CBLAS_TEST_COMPLEX *beta,
+      CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -87,9 +87,10 @@ void F77_cgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+   else
+      cblas_cgemm( UNDEFINED, transa, transb, *m, *n, *k, alpha, a, *lda,
+                   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+ 
+-void F77_chemm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_chemm(int *order, char *rtlf, char *uplow, int *m, int *n,
+         CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+ 	CBLAS_TEST_COMPLEX *b, int *ldb, CBLAS_TEST_COMPLEX *beta,
+         CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -152,8 +153,9 @@ void F77_chemm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_chemm( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+                   beta, c, *ldc );
++  return 0;
+ }
+-void F77_csymm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_csymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+           CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+ 	  CBLAS_TEST_COMPLEX *b, int *ldb, CBLAS_TEST_COMPLEX *beta,
+           CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -206,9 +208,10 @@ void F77_csymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_csymm( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+                   beta, c, *ldc );
++  return 0;
+ }
+ 
+-void F77_cherk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_cherk(int *order, char *uplow, char *transp, int *n, int *k,
+      float *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+      float *beta, CBLAS_TEST_COMPLEX *c, int *ldc ) {
+ 
+@@ -262,9 +265,10 @@ void F77_cherk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_cherk(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+ 	         c, *ldc );
++  return 0;
+ }
+ 
+-void F77_csyrk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_csyrk(int *order, char *uplow, char *transp, int *n, int *k,
+      CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+      CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *c, int *ldc ) {
+ 
+@@ -318,8 +322,9 @@ void F77_csyrk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_csyrk(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda, beta,
+ 	         c, *ldc );
++  return 0;
+ }
+-void F77_cher2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_cher2k(int *order, char *uplow, char *transp, int *n, int *k,
+         CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+ 	CBLAS_TEST_COMPLEX *b, int *ldb, float *beta,
+         CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -382,8 +387,9 @@ void F77_cher2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_cher2k(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+ 		   b, *ldb, *beta, c, *ldc );
++  return 0;
+ }
+-void F77_csyr2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_csyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+          CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+ 	 CBLAS_TEST_COMPLEX *b, int *ldb, CBLAS_TEST_COMPLEX *beta,
+          CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -446,8 +452,9 @@ void F77_csyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_csyr2k(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+ 		   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+-void F77_ctrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_ctrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+        int *m, int *n, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a,
+        int *lda, CBLAS_TEST_COMPLEX *b, int *ldb) {
+   int i,j,LDA,LDB;
+@@ -504,9 +511,10 @@ void F77_ctrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_ctrmm(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+-void F77_ctrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_ctrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+          int *m, int *n, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a,
+          int *lda, CBLAS_TEST_COMPLEX *b, int *ldb) {
+   int i,j,LDA,LDB;
+@@ -563,6 +571,7 @@ void F77_ctrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_ctrsm(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+ 
+diff --git a/ctest/c_cblas3_3m.c b/ctest/c_cblas3_3m.c
+index f1b108c64..65c876559 100644
+--- a/ctest/c_cblas3_3m.c
++++ b/ctest/c_cblas3_3m.c
+@@ -12,7 +12,7 @@
+ #define  TEST_ROW_MJR	1
+ #define  UNDEFINED     -1
+ 
+-void F77_cgemm(int *order, char *transpa, char *transpb, int *m, int *n,
++int F77_cgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+      int *k, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+      CBLAS_TEST_COMPLEX *b, int *ldb, CBLAS_TEST_COMPLEX *beta,
+      CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -87,9 +87,10 @@ void F77_cgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+   else
+      cblas_cgemm( UNDEFINED, transa, transb, *m, *n, *k, alpha, a, *lda,
+                   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+ 
+-void F77_chemm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_chemm(int *order, char *rtlf, char *uplow, int *m, int *n,
+         CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+ 	CBLAS_TEST_COMPLEX *b, int *ldb, CBLAS_TEST_COMPLEX *beta,
+         CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -152,8 +153,9 @@ void F77_chemm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_chemm( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+                   beta, c, *ldc );
++  return 0;
+ }
+-void F77_csymm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_csymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+           CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+ 	  CBLAS_TEST_COMPLEX *b, int *ldb, CBLAS_TEST_COMPLEX *beta,
+           CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -206,9 +208,10 @@ void F77_csymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_csymm( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+                   beta, c, *ldc );
++  return 0;
+ }
+ 
+-void F77_cherk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_cherk(int *order, char *uplow, char *transp, int *n, int *k,
+      float *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+      float *beta, CBLAS_TEST_COMPLEX *c, int *ldc ) {
+ 
+@@ -262,9 +265,10 @@ void F77_cherk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_cherk(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+ 	         c, *ldc );
++  return 0;
+ }
+ 
+-void F77_csyrk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_csyrk(int *order, char *uplow, char *transp, int *n, int *k,
+      CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+      CBLAS_TEST_COMPLEX *beta, CBLAS_TEST_COMPLEX *c, int *ldc ) {
+ 
+@@ -318,8 +322,9 @@ void F77_csyrk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_csyrk(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda, beta,
+ 	         c, *ldc );
++  return 0;
+ }
+-void F77_cher2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_cher2k(int *order, char *uplow, char *transp, int *n, int *k,
+         CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+ 	CBLAS_TEST_COMPLEX *b, int *ldb, float *beta,
+         CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -382,8 +387,9 @@ void F77_cher2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_cher2k(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+ 		   b, *ldb, *beta, c, *ldc );
++  return 0;
+ }
+-void F77_csyr2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_csyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+          CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+ 	 CBLAS_TEST_COMPLEX *b, int *ldb, CBLAS_TEST_COMPLEX *beta,
+          CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -446,8 +452,9 @@ void F77_csyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_csyr2k(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+ 		   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+-void F77_ctrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_ctrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+        int *m, int *n, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a,
+        int *lda, CBLAS_TEST_COMPLEX *b, int *ldb) {
+   int i,j,LDA,LDB;
+@@ -504,9 +511,10 @@ void F77_ctrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_ctrmm(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+-void F77_ctrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_ctrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+          int *m, int *n, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a,
+          int *lda, CBLAS_TEST_COMPLEX *b, int *ldb) {
+   int i,j,LDA,LDB;
+@@ -563,11 +571,12 @@ void F77_ctrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_ctrsm(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+ 
+ 
+-void F77_cgemm3m(int *order, char *transpa, char *transpb, int *m, int *n,
++int F77_cgemm3m(int *order, char *transpa, char *transpb, int *m, int *n,
+      int *k, CBLAS_TEST_COMPLEX *alpha, CBLAS_TEST_COMPLEX *a, int *lda,
+      CBLAS_TEST_COMPLEX *b, int *ldb, CBLAS_TEST_COMPLEX *beta,
+      CBLAS_TEST_COMPLEX *c, int *ldc ) {
+@@ -642,6 +651,7 @@ void F77_cgemm3m(int *order, char *transpa, char *transpb, int *m, int *n,
+   else
+      cblas_cgemm3m( UNDEFINED, transa, transb, *m, *n, *k, alpha, a, *lda,
+                   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+ 
+ 
+diff --git a/ctest/c_d2chke.c b/ctest/c_d2chke.c
+index cb4ed8876..ce5588920 100644
+--- a/ctest/c_d2chke.c
++++ b/ctest/c_d2chke.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void F77_d2chke(char *rout) {
++int F77_d2chke(char *rout) {
+    char *sf = ( rout ) ;
+    double A[2] = {0.0,0.0},
+           X[2] = {0.0,0.0},
+@@ -777,4 +777,5 @@ void F77_d2chke(char *rout) {
+        printf("******* %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_d3chke.c b/ctest/c_d3chke.c
+index aff8380eb..8c4b87f55 100644
+--- a/ctest/c_d3chke.c
++++ b/ctest/c_d3chke.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void F77_d3chke(char *rout) {
++int F77_d3chke(char *rout) {
+    char *sf = ( rout ) ;
+    double A[2] = {0.0,0.0},
+           B[2] = {0.0,0.0},
+@@ -1259,4 +1259,5 @@ void F77_d3chke(char *rout) {
+        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_dblas1.c b/ctest/c_dblas1.c
+index cc43b89a1..f9cd7cb0d 100644
+--- a/ctest/c_dblas1.c
++++ b/ctest/c_dblas1.c
+@@ -14,18 +14,18 @@ double F77_dasum(const int *N, double *X, const int *incX)
+    return cblas_dasum(*N, X, *incX);
+ }
+ 
+-void F77_daxpy(const int *N, const double *alpha, OPENBLAS_CONST double *X,
++int F77_daxpy(const int *N, const double *alpha, OPENBLAS_CONST double *X,
+                     const int *incX, double *Y, const int *incY)
+ {
+    cblas_daxpy(*N, *alpha, X, *incX, Y, *incY);
+-   return;
++   return 0;
+ }
+ 
+-void F77_dcopy(const int *N, double *X, const int *incX,
++int F77_dcopy(const int *N, double *X, const int *incX,
+                     double *Y, const int *incY)
+ {
+    cblas_dcopy(*N, X, *incX, Y, *incY);
+-   return;
++   return 0;
+ }
+ 
+ double F77_ddot(const int *N, OPENBLAS_CONST double *X, const int *incX,
+@@ -39,39 +39,39 @@ double F77_dnrm2(const int *N, OPENBLAS_CONST double *X, const int *incX)
+    return cblas_dnrm2(*N, X, *incX);
+ }
+ 
+-void F77_drotg( double *a, double *b, double *c, double *s)
++int F77_drotg( double *a, double *b, double *c, double *s)
+ {
+    cblas_drotg(a,b,c,s);
+-   return;
++   return 0;
+ }
+ 
+-void F77_drot( const int *N, double *X, const int *incX, double *Y,
++int F77_drot( const int *N, double *X, const int *incX, double *Y,
+        const int *incY, const double *c, const double *s)
+ {
+ 
+    cblas_drot(*N,X,*incX,Y,*incY,*c,*s);
+-   return;
++   return 0;
+ }
+ 
+-void F77_drotm(const int *N, double *X, const int *incX, double *Y,
++int F77_drotm(const int *N, double *X, const int *incX, double *Y,
+                const int *incY, double *dparam)
+ {
+    cblas_drotm(*N, X, *incX, Y, *incY, dparam);
+-   return;
++   return 0;
+ }
+ 
+-void F77_dscal(const int *N, const double *alpha, double *X,
++int F77_dscal(const int *N, const double *alpha, double *X,
+                          const int *incX)
+ {
+    cblas_dscal(*N, *alpha, X, *incX);
+-   return;
++   return 0;
+ }
+ 
+-void F77_dswap( const int *N, double *X, const int *incX,
++int F77_dswap( const int *N, double *X, const int *incX,
+                           double *Y, const int *incY)
+ {
+    cblas_dswap(*N,X,*incX,Y,*incY);
+-   return;
++   return 0;
+ }
+ 
+ int F77_idamax(const int *N, OPENBLAS_CONST double *X, const int *incX)
+diff --git a/ctest/c_dblas2.c b/ctest/c_dblas2.c
+index ae3854c0e..7be317feb 100644
+--- a/ctest/c_dblas2.c
++++ b/ctest/c_dblas2.c
+@@ -8,7 +8,7 @@
+ #include "common.h"
+ #include "cblas_test.h"
+ 
+-void F77_dgemv(int *order, char *transp, int *m, int *n, double *alpha,
++int F77_dgemv(int *order, char *transp, int *m, int *n, double *alpha,
+ 	       double *a, int *lda, double *x, int *incx, double *beta,
+ 	       double *y, int *incy ) {
+ 
+@@ -33,9 +33,10 @@ void F77_dgemv(int *order, char *transp, int *m, int *n, double *alpha,
+   else
+      cblas_dgemv( UNDEFINED, trans,
+ 		  *m, *n, *alpha, a, *lda, x, *incx, *beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_dger(int *order, int *m, int *n, double *alpha, double *x, int *incx,
++int F77_dger(int *order, int *m, int *n, double *alpha, double *x, int *incx,
+ 	     double *y, int *incy, double *a, int *lda ) {
+ 
+   double *A;
+@@ -58,9 +59,10 @@ void F77_dger(int *order, int *m, int *n, double *alpha, double *x, int *incx,
+   }
+   else
+      cblas_dger( CblasColMajor, *m, *n, *alpha, x, *incx, y, *incy, a, *lda );
++  return 0;
+ }
+ 
+-void F77_dtrmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_dtrmv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, double *a, int *lda, double *x, int *incx) {
+   double *A;
+   int i,j,LDA;
+@@ -86,9 +88,10 @@ void F77_dtrmv(int *order, char *uplow, char *transp, char *diagn,
+   else {
+      cblas_dtrmv(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx);
+   }
++  return 0;
+ }
+ 
+-void F77_dtrsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_dtrsv(int *order, char *uplow, char *transp, char *diagn,
+ 	       int *n, double *a, int *lda, double *x, int *incx ) {
+   double *A;
+   int i,j,LDA;
+@@ -111,8 +114,9 @@ void F77_dtrsv(int *order, char *uplow, char *transp, char *diagn,
+    }
+    else
+      cblas_dtrsv(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx );
++  return 0;
+ }
+-void F77_dsymv(int *order, char *uplow, int *n, double *alpha, double *a,
++int F77_dsymv(int *order, char *uplow, int *n, double *alpha, double *a,
+ 	      int *lda, double *x, int *incx, double *beta, double *y,
+ 	      int *incy) {
+   double *A;
+@@ -134,9 +138,10 @@ void F77_dsymv(int *order, char *uplow, int *n, double *alpha, double *a,
+    else
+      cblas_dsymv(CblasColMajor, uplo, *n, *alpha, a, *lda, x, *incx,
+ 		 *beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_dsyr(int *order, char *uplow, int *n, double *alpha, double *x,
++int F77_dsyr(int *order, char *uplow, int *n, double *alpha, double *x,
+ 	     int *incx, double *a, int *lda) {
+   double *A;
+   int i,j,LDA;
+@@ -158,9 +163,10 @@ void F77_dsyr(int *order, char *uplow, int *n, double *alpha, double *x,
+    }
+    else
+      cblas_dsyr(CblasColMajor, uplo, *n, *alpha, x, *incx, a, *lda);
++  return 0;
+ }
+ 
+-void F77_dsyr2(int *order, char *uplow, int *n, double *alpha, double *x,
++int F77_dsyr2(int *order, char *uplow, int *n, double *alpha, double *x,
+ 	     int *incx, double *y, int *incy, double *a, int *lda) {
+   double *A;
+   int i,j,LDA;
+@@ -182,9 +188,10 @@ void F77_dsyr2(int *order, char *uplow, int *n, double *alpha, double *x,
+    }
+    else
+      cblas_dsyr2(CblasColMajor, uplo, *n, *alpha, x, *incx, y, *incy, a, *lda);
++  return 0;
+ }
+ 
+-void F77_dgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
++int F77_dgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
+ 	       double *alpha, double *a, int *lda, double *x, int *incx,
+ 	       double *beta, double *y, int *incy ) {
+ 
+@@ -220,9 +227,10 @@ void F77_dgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
+   else
+      cblas_dgbmv( CblasColMajor, trans, *m, *n, *kl, *ku, *alpha,
+ 		  a, *lda, x, *incx, *beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_dtbmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_dtbmv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, int *k, double *a, int *lda, double *x, int *incx) {
+   double *A;
+   int irow, jcol, i, j, LDA;
+@@ -266,9 +274,10 @@ void F77_dtbmv(int *order, char *uplow, char *transp, char *diagn,
+    }
+    else
+      cblas_dtbmv(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
++  return 0;
+ }
+ 
+-void F77_dtbsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_dtbsv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, int *k, double *a, int *lda, double *x, int *incx) {
+   double *A;
+   int irow, jcol, i, j, LDA;
+@@ -312,9 +321,10 @@ void F77_dtbsv(int *order, char *uplow, char *transp, char *diagn,
+   }
+   else
+      cblas_dtbsv(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
++  return 0;
+ }
+ 
+-void F77_dsbmv(int *order, char *uplow, int *n, int *k, double *alpha,
++int F77_dsbmv(int *order, char *uplow, int *n, int *k, double *alpha,
+ 	      double *a, int *lda, double *x, int *incx, double *beta,
+ 	      double *y, int *incy) {
+   double *A;
+@@ -357,9 +367,10 @@ void F77_dsbmv(int *order, char *uplow, int *n, int *k, double *alpha,
+    else
+      cblas_dsbmv(CblasColMajor, uplo, *n, *k, *alpha, a, *lda, x, *incx,
+ 		 *beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_dspmv(int *order, char *uplow, int *n, double *alpha, double *ap,
++int F77_dspmv(int *order, char *uplow, int *n, double *alpha, double *ap,
+ 	      double *x, int *incx, double *beta, double *y, int *incy) {
+   double *A,*AP;
+   int i,j,k,LDA;
+@@ -395,9 +406,10 @@ void F77_dspmv(int *order, char *uplow, int *n, double *alpha, double *ap,
+   else
+      cblas_dspmv( CblasColMajor, uplo, *n, *alpha, ap, x, *incx, *beta, y,
+ 		  *incy );
++  return 0;
+ }
+ 
+-void F77_dtpmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_dtpmv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, double *ap, double *x, int *incx) {
+   double *A, *AP;
+   int i, j, k, LDA;
+@@ -435,9 +447,10 @@ void F77_dtpmv(int *order, char *uplow, char *transp, char *diagn,
+   }
+   else
+      cblas_dtpmv( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
++  return 0;
+ }
+ 
+-void F77_dtpsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_dtpsv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, double *ap, double *x, int *incx) {
+   double *A, *AP;
+   int i, j, k, LDA;
+@@ -476,9 +489,10 @@ void F77_dtpsv(int *order, char *uplow, char *transp, char *diagn,
+   }
+   else
+      cblas_dtpsv( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
++  return 0;
+ }
+ 
+-void F77_dspr(int *order, char *uplow, int *n, double *alpha, double *x,
++int F77_dspr(int *order, char *uplow, int *n, double *alpha, double *x,
+ 	     int *incx, double *ap ){
+   double *A, *AP;
+   int i,j,k,LDA;
+@@ -528,9 +542,10 @@ void F77_dspr(int *order, char *uplow, int *n, double *alpha, double *x,
+   }
+   else
+      cblas_dspr( CblasColMajor, uplo, *n, *alpha, x, *incx, ap );
++  return 0;
+ }
+ 
+-void F77_dspr2(int *order, char *uplow, int *n, double *alpha, double *x,
++int F77_dspr2(int *order, char *uplow, int *n, double *alpha, double *x,
+ 	     int *incx, double *y, int *incy, double *ap ){
+   double *A, *AP;
+   int i,j,k,LDA;
+@@ -580,4 +595,5 @@ void F77_dspr2(int *order, char *uplow, int *n, double *alpha, double *x,
+   }
+   else
+      cblas_dspr2( CblasColMajor, uplo, *n, *alpha, x, *incx, y, *incy, ap );
++  return 0;
+ }
+diff --git a/ctest/c_dblas3.c b/ctest/c_dblas3.c
+index 936dea8d9..c57c7b082 100644
+--- a/ctest/c_dblas3.c
++++ b/ctest/c_dblas3.c
+@@ -12,7 +12,7 @@
+ #define  TEST_ROW_MJR	1
+ #define  UNDEFINED     -1
+ 
+-void F77_dgemm(int *order, char *transpa, char *transpb, int *m, int *n,
++int F77_dgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+               int *k, double *alpha, double *a, int *lda, double *b, int *ldb,
+               double *beta, double *c, int *ldc ) {
+ 
+@@ -73,8 +73,9 @@ void F77_dgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+   else
+      cblas_dgemm( UNDEFINED, transa, transb, *m, *n, *k, *alpha, a, *lda,
+                   b, *ldb, *beta, c, *ldc );
++  return 0;
+ }
+-void F77_dsymm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_dsymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+               double *alpha, double *a, int *lda, double *b, int *ldb,
+               double *beta, double *c, int *ldc ) {
+ 
+@@ -126,9 +127,10 @@ void F77_dsymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_dsymm( UNDEFINED, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
+                   *beta, c, *ldc );
++  return 0;
+ }
+ 
+-void F77_dsyrk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_dsyrk(int *order, char *uplow, char *transp, int *n, int *k,
+               double *alpha, double *a, int *lda,
+               double *beta, double *c, int *ldc ) {
+ 
+@@ -174,9 +176,10 @@ void F77_dsyrk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_dsyrk(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+ 	         c, *ldc );
++  return 0;
+ }
+ 
+-void F77_dsyr2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_dsyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+                double *alpha, double *a, int *lda, double *b, int *ldb,
+                double *beta, double *c, int *ldc ) {
+   int i,j,LDA,LDB,LDC;
+@@ -230,8 +233,9 @@ void F77_dsyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_dsyr2k(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda,
+ 		   b, *ldb, *beta, c, *ldc );
++  return 0;
+ }
+-void F77_dtrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_dtrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+               int *m, int *n, double *alpha, double *a, int *lda, double *b,
+               int *ldb) {
+   int i,j,LDA,LDB;
+@@ -280,9 +284,10 @@ void F77_dtrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_dtrmm(UNDEFINED, side, uplo, trans, diag, *m, *n, *alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+-void F77_dtrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_dtrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+               int *m, int *n, double *alpha, double *a, int *lda, double *b,
+               int *ldb) {
+   int i,j,LDA,LDB;
+@@ -331,4 +336,5 @@ void F77_dtrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_dtrsm(UNDEFINED, side, uplo, trans, diag, *m, *n, *alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+diff --git a/ctest/c_s2chke.c b/ctest/c_s2chke.c
+index 69cf042c3..9e2a2306d 100644
+--- a/ctest/c_s2chke.c
++++ b/ctest/c_s2chke.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void F77_s2chke(char *rout) {
++int F77_s2chke(char *rout) {
+    char *sf = ( rout ) ;
+    float  A[2] = {0.0,0.0},
+           X[2] = {0.0,0.0},
+@@ -777,4 +777,5 @@ void F77_s2chke(char *rout) {
+        printf("******* %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_s3chke.c b/ctest/c_s3chke.c
+index c8eae8c40..ffb3e76c1 100644
+--- a/ctest/c_s3chke.c
++++ b/ctest/c_s3chke.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void F77_s3chke(char *rout) {
++int F77_s3chke(char *rout) {
+    char *sf = ( rout ) ;
+    float  A[2] = {0.0,0.0},
+           B[2] = {0.0,0.0},
+@@ -1261,4 +1261,5 @@ void F77_s3chke(char *rout) {
+        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_sblas1.c b/ctest/c_sblas1.c
+index a562014a4..b7a0e1c0c 100644
+--- a/ctest/c_sblas1.c
++++ b/ctest/c_sblas1.c
+@@ -14,18 +14,18 @@ float F77_sasum(blasint *N, float *X, blasint *incX)
+    return cblas_sasum(*N, X, *incX);
+ }
+ 
+-void F77_saxpy(blasint *N, const float *alpha, OPENBLAS_CONST float *X,
++int F77_saxpy(blasint *N, const float *alpha, OPENBLAS_CONST float *X,
+                     blasint *incX, float *Y, blasint *incY)
+ {
+    cblas_saxpy(*N, *alpha, X, *incX, Y, *incY);
+-   return;
++   return 0;
+ }
+ 
+-void F77_scopy(blasint *N, OPENBLAS_CONST float *X, blasint *incX,
++int F77_scopy(blasint *N, OPENBLAS_CONST float *X, blasint *incX,
+                     float *Y, blasint *incY)
+ {
+    cblas_scopy(*N, X, *incX, Y, *incY);
+-   return;
++   return 0;
+ }
+ 
+ float F77_sdot(blasint *N, OPENBLAS_CONST float *X, blasint *incX,
+@@ -39,38 +39,38 @@ float F77_snrm2(blasint *N, OPENBLAS_CONST float *X, blasint *incX)
+    return cblas_snrm2(*N, X, *incX);
+ }
+ 
+-void F77_srotg( float *a, float *b, float *c, float *s)
++int F77_srotg( float *a, float *b, float *c, float *s)
+ {
+    cblas_srotg(a,b,c,s);
+-   return;
++   return 0;
+ }
+ 
+-void F77_srotm(blasint *N, float *X, blasint *incX, float *Y, blasint *incY,
++int F77_srotm(blasint *N, float *X, blasint *incX, float *Y, blasint *incY,
+                float *param)
+ {
+     cblas_srotm(*N, X, *incX, Y, *incY, param);
+-    return;
++    return 0;
+ }
+ 
+-void F77_srot( blasint *N, float *X, blasint *incX, float *Y,
++int F77_srot( blasint *N, float *X, blasint *incX, float *Y,
+               blasint *incY, const float  *c, const float  *s)
+ {
+    cblas_srot(*N,X,*incX,Y,*incY,*c,*s);
+-   return;
++   return 0;
+ }
+ 
+-void F77_sscal(blasint *N, const float *alpha, float *X,
++int F77_sscal(blasint *N, const float *alpha, float *X,
+                          blasint *incX)
+ {
+    cblas_sscal(*N, *alpha, X, *incX);
+-   return;
++   return 0;
+ }
+ 
+-void F77_sswap( blasint *N, float *X, blasint *incX,
++int F77_sswap( blasint *N, float *X, blasint *incX,
+                           float *Y, blasint *incY)
+ {
+    cblas_sswap(*N,X,*incX,Y,*incY);
+-   return;
++   return 0;
+ }
+ 
+ int F77_isamax(blasint *N, OPENBLAS_CONST float *X, blasint *incX)
+diff --git a/ctest/c_sblas2.c b/ctest/c_sblas2.c
+index fea4ca1ab..a728a16d4 100644
+--- a/ctest/c_sblas2.c
++++ b/ctest/c_sblas2.c
+@@ -8,7 +8,7 @@
+ #include "common.h"
+ #include "cblas_test.h"
+ 
+-void F77_sgemv(int *order, char *transp, int *m, int *n, float *alpha,
++int F77_sgemv(int *order, char *transp, int *m, int *n, float *alpha,
+ 	       float *a, int *lda, float *x, int *incx, float *beta,
+ 	       float *y, int *incy ) {
+ 
+@@ -33,9 +33,10 @@ void F77_sgemv(int *order, char *transp, int *m, int *n, float *alpha,
+   else
+      cblas_sgemv( UNDEFINED, trans,
+ 		  *m, *n, *alpha, a, *lda, x, *incx, *beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_sger(int *order, int *m, int *n, float *alpha, float *x, int *incx,
++int F77_sger(int *order, int *m, int *n, float *alpha, float *x, int *incx,
+ 	     float *y, int *incy, float *a, int *lda ) {
+ 
+   float *A;
+@@ -58,9 +59,10 @@ void F77_sger(int *order, int *m, int *n, float *alpha, float *x, int *incx,
+   }
+   else
+      cblas_sger( CblasColMajor, *m, *n, *alpha, x, *incx, y, *incy, a, *lda );
++  return 0;
+ }
+ 
+-void F77_strmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_strmv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, float *a, int *lda, float *x, int *incx) {
+   float *A;
+   int i,j,LDA;
+@@ -86,9 +88,10 @@ void F77_strmv(int *order, char *uplow, char *transp, char *diagn,
+   else {
+      cblas_strmv(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx);
+   }
++  return 0;
+ }
+ 
+-void F77_strsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_strsv(int *order, char *uplow, char *transp, char *diagn,
+ 	       int *n, float *a, int *lda, float *x, int *incx ) {
+   float *A;
+   int i,j,LDA;
+@@ -111,8 +114,9 @@ void F77_strsv(int *order, char *uplow, char *transp, char *diagn,
+    }
+    else
+      cblas_strsv(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx );
++  return 0;
+ }
+-void F77_ssymv(int *order, char *uplow, int *n, float *alpha, float *a,
++int F77_ssymv(int *order, char *uplow, int *n, float *alpha, float *a,
+ 	      int *lda, float *x, int *incx, float *beta, float *y,
+ 	      int *incy) {
+   float *A;
+@@ -134,9 +138,10 @@ void F77_ssymv(int *order, char *uplow, int *n, float *alpha, float *a,
+    else
+      cblas_ssymv(CblasColMajor, uplo, *n, *alpha, a, *lda, x, *incx,
+ 		 *beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_ssyr(int *order, char *uplow, int *n, float *alpha, float *x,
++int F77_ssyr(int *order, char *uplow, int *n, float *alpha, float *x,
+ 	     int *incx, float *a, int *lda) {
+   float *A;
+   int i,j,LDA;
+@@ -158,9 +163,10 @@ void F77_ssyr(int *order, char *uplow, int *n, float *alpha, float *x,
+    }
+    else
+      cblas_ssyr(CblasColMajor, uplo, *n, *alpha, x, *incx, a, *lda);
++  return 0;
+ }
+ 
+-void F77_ssyr2(int *order, char *uplow, int *n, float *alpha, float *x,
++int F77_ssyr2(int *order, char *uplow, int *n, float *alpha, float *x,
+ 	     int *incx, float *y, int *incy, float *a, int *lda) {
+   float *A;
+   int i,j,LDA;
+@@ -182,9 +188,10 @@ void F77_ssyr2(int *order, char *uplow, int *n, float *alpha, float *x,
+    }
+    else
+      cblas_ssyr2(CblasColMajor, uplo, *n, *alpha, x, *incx, y, *incy, a, *lda);
++  return 0;
+ }
+ 
+-void F77_sgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
++int F77_sgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
+ 	       float *alpha, float *a, int *lda, float *x, int *incx,
+ 	       float *beta, float *y, int *incy ) {
+ 
+@@ -220,9 +227,10 @@ void F77_sgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
+   else
+      cblas_sgbmv( CblasColMajor, trans, *m, *n, *kl, *ku, *alpha,
+ 		  a, *lda, x, *incx, *beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_stbmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_stbmv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, int *k, float *a, int *lda, float *x, int *incx) {
+   float *A;
+   int irow, jcol, i, j, LDA;
+@@ -266,9 +274,10 @@ void F77_stbmv(int *order, char *uplow, char *transp, char *diagn,
+    }
+    else
+      cblas_stbmv(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
++  return 0;
+ }
+ 
+-void F77_stbsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_stbsv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, int *k, float *a, int *lda, float *x, int *incx) {
+   float *A;
+   int irow, jcol, i, j, LDA;
+@@ -312,9 +321,10 @@ void F77_stbsv(int *order, char *uplow, char *transp, char *diagn,
+   }
+   else
+      cblas_stbsv(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
++  return 0;
+ }
+ 
+-void F77_ssbmv(int *order, char *uplow, int *n, int *k, float *alpha,
++int F77_ssbmv(int *order, char *uplow, int *n, int *k, float *alpha,
+ 	      float *a, int *lda, float *x, int *incx, float *beta,
+ 	      float *y, int *incy) {
+   float *A;
+@@ -357,9 +367,10 @@ void F77_ssbmv(int *order, char *uplow, int *n, int *k, float *alpha,
+    else
+      cblas_ssbmv(CblasColMajor, uplo, *n, *k, *alpha, a, *lda, x, *incx,
+ 		 *beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_sspmv(int *order, char *uplow, int *n, float *alpha, float *ap,
++int F77_sspmv(int *order, char *uplow, int *n, float *alpha, float *ap,
+ 	      float *x, int *incx, float *beta, float *y, int *incy) {
+   float *A,*AP;
+   int i,j,k,LDA;
+@@ -394,9 +405,10 @@ void F77_sspmv(int *order, char *uplow, int *n, float *alpha, float *ap,
+   else
+      cblas_sspmv( CblasColMajor, uplo, *n, *alpha, ap, x, *incx, *beta, y,
+ 		  *incy );
++  return 0;
+ }
+ 
+-void F77_stpmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_stpmv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, float *ap, float *x, int *incx) {
+   float *A, *AP;
+   int i, j, k, LDA;
+@@ -433,9 +445,10 @@ void F77_stpmv(int *order, char *uplow, char *transp, char *diagn,
+   }
+   else
+      cblas_stpmv( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
++  return 0;
+ }
+ 
+-void F77_stpsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_stpsv(int *order, char *uplow, char *transp, char *diagn,
+ 	      int *n, float *ap, float *x, int *incx) {
+   float *A, *AP;
+   int i, j, k, LDA;
+@@ -473,9 +486,10 @@ void F77_stpsv(int *order, char *uplow, char *transp, char *diagn,
+   }
+   else
+      cblas_stpsv( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
++  return 0;
+ }
+ 
+-void F77_sspr(int *order, char *uplow, int *n, float *alpha, float *x,
++int F77_sspr(int *order, char *uplow, int *n, float *alpha, float *x,
+ 	     int *incx, float *ap ){
+   float *A, *AP;
+   int i,j,k,LDA;
+@@ -524,9 +538,10 @@ void F77_sspr(int *order, char *uplow, int *n, float *alpha, float *x,
+   }
+   else
+      cblas_sspr( CblasColMajor, uplo, *n, *alpha, x, *incx, ap );
++  return 0;
+ }
+ 
+-void F77_sspr2(int *order, char *uplow, int *n, float *alpha, float *x,
++int F77_sspr2(int *order, char *uplow, int *n, float *alpha, float *x,
+ 	     int *incx, float *y, int *incy, float *ap ){
+   float *A, *AP;
+   int i,j,k,LDA;
+@@ -576,4 +591,5 @@ void F77_sspr2(int *order, char *uplow, int *n, float *alpha, float *x,
+   }
+   else
+      cblas_sspr2( CblasColMajor, uplo, *n, *alpha, x, *incx, y, *incy, ap );
++  return 0;
+ }
+diff --git a/ctest/c_sblas3.c b/ctest/c_sblas3.c
+index 10dc049a8..b3dd7e13e 100644
+--- a/ctest/c_sblas3.c
++++ b/ctest/c_sblas3.c
+@@ -9,7 +9,7 @@
+ #include "common.h"
+ #include "cblas_test.h"
+ 
+-void F77_sgemm(int *order, char *transpa, char *transpb, int *m, int *n,
++int F77_sgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+               int *k, float *alpha, float *a, int *lda, float *b, int *ldb,
+               float *beta, float *c, int *ldc ) {
+ 
+@@ -69,8 +69,9 @@ void F77_sgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+   else
+      cblas_sgemm( UNDEFINED, transa, transb, *m, *n, *k, *alpha, a, *lda,
+                   b, *ldb, *beta, c, *ldc );
++  return 0;
+ }
+-void F77_ssymm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_ssymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+               float *alpha, float *a, int *lda, float *b, int *ldb,
+               float *beta, float *c, int *ldc ) {
+ 
+@@ -122,9 +123,10 @@ void F77_ssymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_ssymm( UNDEFINED, side, uplo, *m, *n, *alpha, a, *lda, b, *ldb,
+                   *beta, c, *ldc );
++  return 0;
+ }
+ 
+-void F77_ssyrk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_ssyrk(int *order, char *uplow, char *transp, int *n, int *k,
+               float *alpha, float *a, int *lda,
+               float *beta, float *c, int *ldc ) {
+ 
+@@ -170,9 +172,10 @@ void F77_ssyrk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_ssyrk(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+ 	         c, *ldc );
++  return 0;
+ }
+ 
+-void F77_ssyr2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_ssyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+                float *alpha, float *a, int *lda, float *b, int *ldb,
+                float *beta, float *c, int *ldc ) {
+   int i,j,LDA,LDB,LDC;
+@@ -226,8 +229,9 @@ void F77_ssyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_ssyr2k(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda,
+ 		   b, *ldb, *beta, c, *ldc );
++  return 0;
+ }
+-void F77_strmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_strmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+               int *m, int *n, float *alpha, float *a, int *lda, float *b,
+               int *ldb) {
+   int i,j,LDA,LDB;
+@@ -276,9 +280,10 @@ void F77_strmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_strmm(UNDEFINED, side, uplo, trans, diag, *m, *n, *alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+-void F77_strsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_strsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+               int *m, int *n, float *alpha, float *a, int *lda, float *b,
+               int *ldb) {
+   int i,j,LDA,LDB;
+@@ -327,4 +332,5 @@ void F77_strsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_strsm(UNDEFINED, side, uplo, trans, diag, *m, *n, *alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+diff --git a/ctest/c_z2chke.c b/ctest/c_z2chke.c
+index 872b89fa8..7e89c0298 100644
+--- a/ctest/c_z2chke.c
++++ b/ctest/c_z2chke.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void F77_z2chke(char *rout) {
++int F77_z2chke(char *rout) {
+    char *sf = ( rout ) ;
+    double  A[2] = {0.0,0.0},
+           X[2] = {0.0,0.0},
+@@ -814,4 +814,5 @@ void F77_z2chke(char *rout) {
+        printf("******* %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_z3chke.c b/ctest/c_z3chke.c
+index 3bbb1ce10..090fb084f 100644
+--- a/ctest/c_z3chke.c
++++ b/ctest/c_z3chke.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void  F77_z3chke(char *  rout) {
++int  F77_z3chke(char *  rout) {
+    char *sf = ( rout ) ;
+    double  A[4]     = {0.0,0.0,0.0,0.0},
+            B[4]     = {0.0,0.0,0.0,0.0},
+@@ -1698,4 +1698,5 @@ void  F77_z3chke(char *  rout) {
+        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_z3chke_3m.c b/ctest/c_z3chke_3m.c
+index 7834934f5..007f07c0c 100644
+--- a/ctest/c_z3chke_3m.c
++++ b/ctest/c_z3chke_3m.c
+@@ -17,7 +17,7 @@ void chkxer(void) {
+    cblas_lerr = 1 ;
+ }
+ 
+-void  F77_z3chke(char *  rout) {
++int  F77_z3chke(char *  rout) {
+    char *sf = ( rout ) ;
+    double  A[4]     = {0.0,0.0,0.0,0.0},
+            B[4]     = {0.0,0.0,0.0,0.0},
+@@ -1928,4 +1928,5 @@ void  F77_z3chke(char *  rout) {
+        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+        cblas_test_fail();
+    }
++   return 0;
+ }
+diff --git a/ctest/c_zblas1.c b/ctest/c_zblas1.c
+index 14c90d049..106c260b0 100644
+--- a/ctest/c_zblas1.c
++++ b/ctest/c_zblas1.c
+@@ -9,53 +9,53 @@
+ #include "common.h"
+ #include "cblas_test.h"
+ 
+-void F77_zaxpy(const int *N, OPENBLAS_CONST void *alpha, void *X,
++int F77_zaxpy(const int *N, OPENBLAS_CONST void *alpha, void *X,
+                     const int *incX, void *Y, const int *incY)
+ {
+    cblas_zaxpy(*N, alpha, X, *incX, Y, *incY);
+-   return;
++   return 0;
+ }
+ 
+-void F77_zcopy(const int *N, void *X, const int *incX,
++int F77_zcopy(const int *N, void *X, const int *incX,
+                     void *Y, const int *incY)
+ {
+    cblas_zcopy(*N, X, *incX, Y, *incY);
+-   return;
++   return 0;
+ }
+ 
+-void F77_zdotc(const int *N, OPENBLAS_CONST void *X, const int *incX,
++int F77_zdotc(const int *N, OPENBLAS_CONST void *X, const int *incX,
+                      OPENBLAS_CONST void *Y, const int *incY,void *dotc)
+ {
+    cblas_zdotc_sub(*N, X, *incX, Y, *incY, dotc);
+-   return;
++   return 0;
+ }
+ 
+-void F77_zdotu(const int *N, void *X, const int *incX,
++int F77_zdotu(const int *N, void *X, const int *incX,
+                         void *Y, const int *incY,void *dotu)
+ {
+    cblas_zdotu_sub(*N, X, *incX, Y, *incY, dotu);
+-   return;
++   return 0;
+ }
+ 
+-void F77_zdscal(const int *N, const double *alpha, void *X,
++int F77_zdscal(const int *N, const double *alpha, void *X,
+                          const int *incX)
+ {
+    cblas_zdscal(*N, *alpha, X, *incX);
+-   return;
++   return 0;
+ }
+ 
+-void F77_zscal(const int *N, const void * *alpha, void *X,
++int F77_zscal(const int *N, const void * *alpha, void *X,
+                          const int *incX)
+ {
+    cblas_zscal(*N, alpha, X, *incX);
+-   return;
++   return 0;
+ }
+ 
+-void F77_zswap( const int *N, void *X, const int *incX,
++int F77_zswap( const int *N, void *X, const int *incX,
+                           void *Y, const int *incY)
+ {
+    cblas_zswap(*N,X,*incX,Y,*incY);
+-   return;
++   return 0;
+ }
+ 
+ int F77_izamax(const int *N, OPENBLAS_CONST void *X, const int *incX)
+diff --git a/ctest/c_zblas2.c b/ctest/c_zblas2.c
+index ca601e606..fb82d13f6 100644
+--- a/ctest/c_zblas2.c
++++ b/ctest/c_zblas2.c
+@@ -8,7 +8,7 @@
+ #include "common.h"
+ #include "cblas_test.h"
+ 
+-void F77_zgemv(int *order, char *transp, int *m, int *n,
++int F77_zgemv(int *order, char *transp, int *m, int *n,
+           OPENBLAS_CONST void *alpha,
+           CBLAS_TEST_ZOMPLEX *a, int *lda, OPENBLAS_CONST void *x, int *incx,
+           OPENBLAS_CONST void *beta, void *y, int *incy) {
+@@ -36,9 +36,10 @@ void F77_zgemv(int *order, char *transp, int *m, int *n,
+   else
+      cblas_zgemv( UNDEFINED, trans,
+                   *m, *n, alpha, a, *lda, x, *incx, beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_zgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
++int F77_zgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
+ 	      CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+ 	      CBLAS_TEST_ZOMPLEX *x, int *incx,
+ 	      CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *y, int *incy) {
+@@ -83,9 +84,10 @@ void F77_zgbmv(int *order, char *transp, int *m, int *n, int *kl, int *ku,
+   else
+      cblas_zgbmv( UNDEFINED, trans, *m, *n, *kl, *ku, alpha, a, *lda, x,
+ 		  *incx, beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_zgeru(int *order, int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha,
++int F77_zgeru(int *order, int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+ 	 CBLAS_TEST_ZOMPLEX *x, int *incx, CBLAS_TEST_ZOMPLEX *y, int *incy,
+          CBLAS_TEST_ZOMPLEX *a, int *lda){
+ 
+@@ -112,9 +114,10 @@ void F77_zgeru(int *order, int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+      cblas_zgeru( CblasColMajor, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
+   else
+      cblas_zgeru( UNDEFINED, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
++  return 0;
+ }
+ 
+-void F77_zgerc(int *order, int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha,
++int F77_zgerc(int *order, int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+ 	 CBLAS_TEST_ZOMPLEX *x, int *incx, CBLAS_TEST_ZOMPLEX *y, int *incy,
+          CBLAS_TEST_ZOMPLEX *a, int *lda) {
+   CBLAS_TEST_ZOMPLEX *A;
+@@ -140,9 +143,10 @@ void F77_zgerc(int *order, int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+      cblas_zgerc( CblasColMajor, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
+   else
+      cblas_zgerc( UNDEFINED, *m, *n, alpha, x, *incx, y, *incy, a, *lda );
++  return 0;
+ }
+ 
+-void F77_zhemv(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
++int F77_zhemv(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+       CBLAS_TEST_ZOMPLEX *a, int *lda, CBLAS_TEST_ZOMPLEX *x,
+       int *incx, CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *y, int *incy){
+ 
+@@ -170,9 +174,10 @@ void F77_zhemv(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+   else
+      cblas_zhemv( UNDEFINED, uplo, *n, alpha, a, *lda, x, *incx,
+ 	   beta, y, *incy );
++  return 0;
+ }
+ 
+-void F77_zhbmv(int *order, char *uplow, int *n, int *k,
++int F77_zhbmv(int *order, char *uplow, int *n, int *k,
+      CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+      CBLAS_TEST_ZOMPLEX *x, int *incx, CBLAS_TEST_ZOMPLEX *beta,
+      CBLAS_TEST_ZOMPLEX *y, int *incy){
+@@ -234,9 +239,10 @@ int i,irow,j,jcol,LDA;
+    else
+      cblas_zhbmv(UNDEFINED, uplo, *n, *k, alpha, a, *lda, x, *incx,
+                  beta, y, *incy );
++   return 0;
+ }
+ 
+-void F77_zhpmv(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
++int F77_zhpmv(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+      CBLAS_TEST_ZOMPLEX *ap, CBLAS_TEST_ZOMPLEX *x, int *incx,
+      CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *y, int *incy){
+ 
+@@ -290,9 +296,10 @@ void F77_zhpmv(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+   else
+      cblas_zhpmv( UNDEFINED, uplo, *n, alpha, ap, x, *incx, beta, y,
+                   *incy );
++  return 0;
+ }
+ 
+-void F77_ztbmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ztbmv(int *order, char *uplow, char *transp, char *diagn,
+      int *n, int *k, CBLAS_TEST_ZOMPLEX *a, int *lda, CBLAS_TEST_ZOMPLEX *x,
+      int *incx) {
+   CBLAS_TEST_ZOMPLEX *A;
+@@ -353,9 +360,10 @@ void F77_ztbmv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ztbmv(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
+    else
+      cblas_ztbmv(UNDEFINED, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
++  return 0;
+ }
+ 
+-void F77_ztbsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ztbsv(int *order, char *uplow, char *transp, char *diagn,
+       int *n, int *k, CBLAS_TEST_ZOMPLEX *a, int *lda, CBLAS_TEST_ZOMPLEX *x,
+       int *incx) {
+ 
+@@ -417,9 +425,10 @@ void F77_ztbsv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ztbsv(CblasColMajor, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
+   else
+      cblas_ztbsv(UNDEFINED, uplo, trans, diag, *n, *k, a, *lda, x, *incx);
++  return 0;
+ }
+ 
+-void F77_ztpmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ztpmv(int *order, char *uplow, char *transp, char *diagn,
+       int *n, CBLAS_TEST_ZOMPLEX *ap, CBLAS_TEST_ZOMPLEX *x, int *incx) {
+   CBLAS_TEST_ZOMPLEX *A, *AP;
+   int i, j, k, LDA;
+@@ -472,9 +481,10 @@ void F77_ztpmv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ztpmv( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
+   else
+      cblas_ztpmv( UNDEFINED, uplo, trans, diag, *n, ap, x, *incx );
++  return 0;
+ }
+ 
+-void F77_ztpsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ztpsv(int *order, char *uplow, char *transp, char *diagn,
+      int *n, CBLAS_TEST_ZOMPLEX *ap, CBLAS_TEST_ZOMPLEX *x, int *incx) {
+   CBLAS_TEST_ZOMPLEX *A, *AP;
+   int i, j, k, LDA;
+@@ -527,9 +537,10 @@ void F77_ztpsv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ztpsv( CblasColMajor, uplo, trans, diag, *n, ap, x, *incx );
+   else
+      cblas_ztpsv( UNDEFINED, uplo, trans, diag, *n, ap, x, *incx );
++  return 0;
+ }
+ 
+-void F77_ztrmv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ztrmv(int *order, char *uplow, char *transp, char *diagn,
+      int *n, CBLAS_TEST_ZOMPLEX *a, int *lda, CBLAS_TEST_ZOMPLEX *x,
+       int *incx) {
+   CBLAS_TEST_ZOMPLEX *A;
+@@ -557,8 +568,9 @@ void F77_ztrmv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ztrmv(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx);
+   else
+      cblas_ztrmv(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx);
++  return 0;
+ }
+-void F77_ztrsv(int *order, char *uplow, char *transp, char *diagn,
++int F77_ztrsv(int *order, char *uplow, char *transp, char *diagn,
+        int *n, CBLAS_TEST_ZOMPLEX *a, int *lda, CBLAS_TEST_ZOMPLEX *x,
+               int *incx) {
+   CBLAS_TEST_ZOMPLEX *A;
+@@ -586,9 +598,10 @@ void F77_ztrsv(int *order, char *uplow, char *transp, char *diagn,
+      cblas_ztrsv(CblasColMajor, uplo, trans, diag, *n, a, *lda, x, *incx );
+    else
+      cblas_ztrsv(UNDEFINED, uplo, trans, diag, *n, a, *lda, x, *incx );
++  return 0;
+ }
+ 
+-void F77_zhpr(int *order, char *uplow, int *n, double *alpha,
++int F77_zhpr(int *order, char *uplow, int *n, double *alpha,
+ 	     CBLAS_TEST_ZOMPLEX *x, int *incx, CBLAS_TEST_ZOMPLEX *ap) {
+   CBLAS_TEST_ZOMPLEX *A, *AP;
+   int i,j,k,LDA;
+@@ -661,9 +674,10 @@ void F77_zhpr(int *order, char *uplow, int *n, double *alpha,
+      cblas_zhpr(CblasColMajor, uplo, *n, *alpha, x, *incx, ap );
+   else
+      cblas_zhpr(UNDEFINED, uplo, *n, *alpha, x, *incx, ap );
++  return 0;
+ }
+ 
+-void F77_zhpr2(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
++int F77_zhpr2(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+        CBLAS_TEST_ZOMPLEX *x, int *incx, CBLAS_TEST_ZOMPLEX *y, int *incy,
+        CBLAS_TEST_ZOMPLEX *ap) {
+   CBLAS_TEST_ZOMPLEX *A, *AP;
+@@ -738,9 +752,10 @@ void F77_zhpr2(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+      cblas_zhpr2( CblasColMajor, uplo, *n, alpha, x, *incx, y, *incy, ap );
+   else
+      cblas_zhpr2( UNDEFINED, uplo, *n, alpha, x, *incx, y, *incy, ap );
++  return 0;
+ }
+ 
+-void F77_zher(int *order, char *uplow, int *n, double *alpha,
++int F77_zher(int *order, char *uplow, int *n, double *alpha,
+   CBLAS_TEST_ZOMPLEX *x, int *incx, CBLAS_TEST_ZOMPLEX *a, int *lda) {
+   CBLAS_TEST_ZOMPLEX *A;
+   int i,j,LDA;
+@@ -770,9 +785,10 @@ void F77_zher(int *order, char *uplow, int *n, double *alpha,
+      cblas_zher( CblasColMajor, uplo, *n, *alpha, x, *incx, a, *lda );
+   else
+      cblas_zher( UNDEFINED, uplo, *n, *alpha, x, *incx, a, *lda );
++  return 0;
+ }
+ 
+-void F77_zher2(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
++int F77_zher2(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+           CBLAS_TEST_ZOMPLEX *x, int *incx, CBLAS_TEST_ZOMPLEX *y, int *incy,
+ 	  CBLAS_TEST_ZOMPLEX *a, int *lda) {
+ 
+@@ -804,4 +820,5 @@ void F77_zher2(int *order, char *uplow, int *n, CBLAS_TEST_ZOMPLEX *alpha,
+      cblas_zher2( CblasColMajor, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
+   else
+      cblas_zher2( UNDEFINED, uplo, *n, alpha, x, *incx, y, *incy, a, *lda);
++  return 0;
+ }
+diff --git a/ctest/c_zblas3.c b/ctest/c_zblas3.c
+index aac46ddfa..270ca758d 100644
+--- a/ctest/c_zblas3.c
++++ b/ctest/c_zblas3.c
+@@ -11,7 +11,7 @@
+ #define  TEST_ROW_MJR	1
+ #define  UNDEFINED     -1
+ 
+-void F77_zgemm(int *order, char *transpa, char *transpb, int *m, int *n,
++int F77_zgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+      int *k, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+      CBLAS_TEST_ZOMPLEX *b, int *ldb, CBLAS_TEST_ZOMPLEX *beta,
+      CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -86,8 +86,9 @@ void F77_zgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+   else
+      cblas_zgemm( UNDEFINED, transa, transb, *m, *n, *k, alpha, a, *lda,
+                   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+-void F77_zhemm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_zhemm(int *order, char *rtlf, char *uplow, int *m, int *n,
+         CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+ 	CBLAS_TEST_ZOMPLEX *b, int *ldb, CBLAS_TEST_ZOMPLEX *beta,
+         CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -150,8 +151,9 @@ void F77_zhemm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_zhemm( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+                   beta, c, *ldc );
++  return 0;
+ }
+-void F77_zsymm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_zsymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+           CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+ 	  CBLAS_TEST_ZOMPLEX *b, int *ldb, CBLAS_TEST_ZOMPLEX *beta,
+           CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -204,9 +206,10 @@ void F77_zsymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_zsymm( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+                   beta, c, *ldc );
++  return 0;
+ }
+ 
+-void F77_zherk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_zherk(int *order, char *uplow, char *transp, int *n, int *k,
+      double *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+      double *beta, CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+ 
+@@ -260,9 +263,10 @@ void F77_zherk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_zherk(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+ 	         c, *ldc );
++  return 0;
+ }
+ 
+-void F77_zsyrk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_zsyrk(int *order, char *uplow, char *transp, int *n, int *k,
+      CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+      CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+ 
+@@ -316,8 +320,9 @@ void F77_zsyrk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_zsyrk(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda, beta,
+ 	         c, *ldc );
++  return 0;
+ }
+-void F77_zher2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_zher2k(int *order, char *uplow, char *transp, int *n, int *k,
+         CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+ 	CBLAS_TEST_ZOMPLEX *b, int *ldb, double *beta,
+         CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -380,8 +385,9 @@ void F77_zher2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_zher2k(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+ 		   b, *ldb, *beta, c, *ldc );
++  return 0;
+ }
+-void F77_zsyr2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_zsyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+          CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+ 	 CBLAS_TEST_ZOMPLEX *b, int *ldb, CBLAS_TEST_ZOMPLEX *beta,
+          CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -444,8 +450,9 @@ void F77_zsyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_zsyr2k(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+ 		   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+-void F77_ztrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_ztrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+        int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a,
+        int *lda, CBLAS_TEST_ZOMPLEX *b, int *ldb) {
+   int i,j,LDA,LDB;
+@@ -502,9 +509,10 @@ void F77_ztrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_ztrmm(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+-void F77_ztrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_ztrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+          int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a,
+          int *lda, CBLAS_TEST_ZOMPLEX *b, int *ldb) {
+   int i,j,LDA,LDB;
+@@ -561,6 +569,7 @@ void F77_ztrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_ztrsm(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+ 
+diff --git a/ctest/c_zblas3_3m.c b/ctest/c_zblas3_3m.c
+index 46ff467d0..187f2e8fb 100644
+--- a/ctest/c_zblas3_3m.c
++++ b/ctest/c_zblas3_3m.c
+@@ -11,7 +11,7 @@
+ #define  TEST_ROW_MJR	1
+ #define  UNDEFINED     -1
+ 
+-void F77_zgemm(int *order, char *transpa, char *transpb, int *m, int *n,
++int F77_zgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+      int *k, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+      CBLAS_TEST_ZOMPLEX *b, int *ldb, CBLAS_TEST_ZOMPLEX *beta,
+      CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -86,8 +86,9 @@ void F77_zgemm(int *order, char *transpa, char *transpb, int *m, int *n,
+   else
+      cblas_zgemm( UNDEFINED, transa, transb, *m, *n, *k, alpha, a, *lda,
+                   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+-void F77_zhemm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_zhemm(int *order, char *rtlf, char *uplow, int *m, int *n,
+         CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+ 	CBLAS_TEST_ZOMPLEX *b, int *ldb, CBLAS_TEST_ZOMPLEX *beta,
+         CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -150,8 +151,9 @@ void F77_zhemm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_zhemm( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+                   beta, c, *ldc );
++  return 0;
+ }
+-void F77_zsymm(int *order, char *rtlf, char *uplow, int *m, int *n,
++int F77_zsymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+           CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+ 	  CBLAS_TEST_ZOMPLEX *b, int *ldb, CBLAS_TEST_ZOMPLEX *beta,
+           CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -204,9 +206,10 @@ void F77_zsymm(int *order, char *rtlf, char *uplow, int *m, int *n,
+   else
+      cblas_zsymm( UNDEFINED, side, uplo, *m, *n, alpha, a, *lda, b, *ldb,
+                   beta, c, *ldc );
++  return 0;
+ }
+ 
+-void F77_zherk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_zherk(int *order, char *uplow, char *transp, int *n, int *k,
+      double *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+      double *beta, CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+ 
+@@ -260,9 +263,10 @@ void F77_zherk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_zherk(UNDEFINED, uplo, trans, *n, *k, *alpha, a, *lda, *beta,
+ 	         c, *ldc );
++  return 0;
+ }
+ 
+-void F77_zsyrk(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_zsyrk(int *order, char *uplow, char *transp, int *n, int *k,
+      CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+      CBLAS_TEST_ZOMPLEX *beta, CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+ 
+@@ -316,8 +320,9 @@ void F77_zsyrk(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_zsyrk(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda, beta,
+ 	         c, *ldc );
++  return 0;
+ }
+-void F77_zher2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_zher2k(int *order, char *uplow, char *transp, int *n, int *k,
+         CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+ 	CBLAS_TEST_ZOMPLEX *b, int *ldb, double *beta,
+         CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -380,8 +385,9 @@ void F77_zher2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_zher2k(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+ 		   b, *ldb, *beta, c, *ldc );
++  return 0;
+ }
+-void F77_zsyr2k(int *order, char *uplow, char *transp, int *n, int *k,
++int F77_zsyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+          CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+ 	 CBLAS_TEST_ZOMPLEX *b, int *ldb, CBLAS_TEST_ZOMPLEX *beta,
+          CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -444,8 +450,9 @@ void F77_zsyr2k(int *order, char *uplow, char *transp, int *n, int *k,
+   else
+      cblas_zsyr2k(UNDEFINED, uplo, trans, *n, *k, alpha, a, *lda,
+ 		   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+-void F77_ztrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_ztrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+        int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a,
+        int *lda, CBLAS_TEST_ZOMPLEX *b, int *ldb) {
+   int i,j,LDA,LDB;
+@@ -502,9 +509,10 @@ void F77_ztrmm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_ztrmm(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+-void F77_ztrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
++int F77_ztrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+          int *m, int *n, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a,
+          int *lda, CBLAS_TEST_ZOMPLEX *b, int *ldb) {
+   int i,j,LDA,LDB;
+@@ -561,10 +569,11 @@ void F77_ztrsm(int *order, char *rtlf, char *uplow, char *transp, char *diagn,
+   else
+      cblas_ztrsm(UNDEFINED, side, uplo, trans, diag, *m, *n, alpha,
+ 		   a, *lda, b, *ldb);
++  return 0;
+ }
+ 
+ 
+-void F77_zgemm3m(int *order, char *transpa, char *transpb, int *m, int *n,
++int F77_zgemm3m(int *order, char *transpa, char *transpb, int *m, int *n,
+      int *k, CBLAS_TEST_ZOMPLEX *alpha, CBLAS_TEST_ZOMPLEX *a, int *lda,
+      CBLAS_TEST_ZOMPLEX *b, int *ldb, CBLAS_TEST_ZOMPLEX *beta,
+      CBLAS_TEST_ZOMPLEX *c, int *ldc ) {
+@@ -639,5 +648,6 @@ void F77_zgemm3m(int *order, char *transpa, char *transpb, int *m, int *n,
+   else
+      cblas_zgemm3m( UNDEFINED, transa, transb, *m, *n, *k, alpha, a, *lda,
+                   b, *ldb, beta, c, *ldc );
++  return 0;
+ }
+ 
+-- 
+2.55.0
+

--- a/recipes/recipes_emscripten/openblas/patches/0012-Use-int-return-for-f2c-Subroutine-decls-in-ctest.patch
+++ b/recipes/recipes_emscripten/openblas/patches/0012-Use-int-return-for-f2c-Subroutine-decls-in-ctest.patch
@@ -1,0 +1,1020 @@
+From f495e5ffd89d1a16b491b009789858c344d1c827 Mon Sep 17 00:00:00 2001
+From: Julien Jerphanion <git@jjerphan.xyz>
+Date: Thu, 13 Aug 2026 09:46:19 +0200
+Subject: Use int return for f2c Subroutine decls in ctest
+
+Signed-off-by: Julien Jerphanion <git@jjerphan.xyz>
+---
+ ctest/c_cblat1c.c    |  6 +++---
+ ctest/c_cblat2c.c    | 36 ++++++++++++++++++------------------
+ ctest/c_cblat3c.c    | 20 ++++++++++----------
+ ctest/c_dblat1c.c    | 10 +++++-----
+ ctest/c_dblat2c.c    | 34 +++++++++++++++++-----------------
+ ctest/c_dblat3c.c    | 34 +++++++++++++++++-----------------
+ ctest/c_sblat1c.c    | 10 +++++-----
+ ctest/c_sblat2c.c    | 34 +++++++++++++++++-----------------
+ ctest/c_sblat3c.c    | 34 +++++++++++++++++-----------------
+ ctest/c_zblat1c.c    | 10 +++++-----
+ ctest/c_zblat2c.c    | 36 ++++++++++++++++++------------------
+ ctest/c_zblat3c.c    | 20 ++++++++++----------
+ ctest/c_zblat3c_3m.c | 10 +++++-----
+ 13 files changed, 147 insertions(+), 147 deletions(-)
+
+diff --git a/ctest/c_cblat1c.c b/ctest/c_cblat1c.c
+index df4318699..c3aa339af 100644
+--- a/ctest/c_cblat1c.c
++++ b/ctest/c_cblat1c.c
+@@ -433,12 +433,12 @@ static real c_b43 = (float)1.;
+     extern /* Subroutine */ int ctest_(integer*, complex*, complex*, complex*, real*);
+     static complex mwpcs[5], mwpct[5];
+     extern /* Subroutine */ int itest1_(integer*, integer*), stest1_(real*,real*,real*,real*);
+-    extern /* Subroutine */ void cscaltest_(integer*, complex*, complex*, integer*);
++    extern /* Subroutine */ int cscaltest_(integer*, complex*, complex*, integer*);
+     static complex cx[8];
+     extern real scnrm2test_(integer*, complex*, integer*);
+     static integer np1;
+     extern integer icamaxtest_(integer*, complex*, integer*);
+-    extern /* Subroutine */ void csscaltest_(integer*, real*, complex*, integer*);
++    extern /* Subroutine */ int csscaltest_(integer*, real*, complex*, integer*);
+     extern real scasumtest_(integer*, complex*, integer*);
+     static integer len;
+ 
+@@ -730,7 +730,7 @@ static real c_b43 = (float)1.;
+     static complex ctemp;
+     extern /* Subroutine */ int ctest_(integer*, complex*, complex*, complex*, real*);
+     static integer ksize;
+-    extern /* Subroutine */ void cdotctest_(integer*, complex*, integer*, complex*, integer*,complex*), ccopytest_(integer*, complex*, integer*, complex*, integer*), cdotutest_(integer*, complex*, integer*, complex*, integer*, complex*), 
++    extern /* Subroutine */ int cdotctest_(integer*, complex*, integer*, complex*, integer*,complex*), ccopytest_(integer*, complex*, integer*, complex*, integer*), cdotutest_(integer*, complex*, integer*, complex*, integer*, complex*), 
+ 	    cswaptest_(integer*, complex*, integer*, complex*, integer*), caxpytest_(integer*, complex*, complex*, integer*, complex*, integer*);
+     static integer ki, kn;
+     static complex cx[7], cy[7];
+diff --git a/ctest/c_cblat2c.c b/ctest/c_cblat2c.c
+index d961e9f5f..aa96f3bc0 100644
+--- a/ctest/c_cblat2c.c
++++ b/ctest/c_cblat2c.c
+@@ -314,7 +314,7 @@ static logical c_false = FALSE_;
+     static char snamet[12];
+     static real thresh;
+     static logical rorder;
+-    extern /* Subroutine */ void cc2chke_(char*);
++    extern /* Subroutine */ int cc2chke_(char*);
+     static integer layout;
+     static logical ltestt, tsterr;
+     static complex alf[7];
+@@ -887,8 +887,8 @@ L240:
+     static integer ia, ib, ic;
+     static logical banded;
+     static integer nc, nd, im, in, kl, ml, nk, nl, ku, ix, iy, ms, lx, ly, ns;
+-    extern /* Subroutine */ void ccgbmv_(integer*, char*, integer*, integer*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, complex*, integer*);
+-    extern /* Subroutine */ void ccgemv_(integer*, char*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, complex*, integer*);
++    extern /* Subroutine */ int ccgbmv_(integer*, char*, integer*, integer*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, complex*, integer*);
++    extern /* Subroutine */ int ccgemv_(integer*, char*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, complex*, integer*);
+     extern logical lceres_(char*, char*, integer*, integer*, complex*, complex*, integer*, ftnlen, ftnlen);
+     static char ctrans[14];
+     static real errmax;
+@@ -1340,10 +1340,10 @@ L140:
+     static integer nc, ik, in;
+     static logical packed;
+     static integer nk, ks, ix, iy, ns, lx, ly;
+-    extern /* Subroutine */ void cchbmv_(integer*, char*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, complex*, integer*);
+-    extern /* Subroutine */ void cchemv_(integer*, char*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, complex*, integer*);
++    extern /* Subroutine */ int cchbmv_(integer*, char*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, complex*, integer*);
++    extern /* Subroutine */ int cchemv_(integer*, char*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, complex*, integer*);
+     extern logical lceres_(char*, char*, integer*, integer*, complex*, complex*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cchpmv_(integer*, char*, integer*, complex*, complex*, complex*, integer*, complex*, complex*, integer*);
++    extern /* Subroutine */ int cchpmv_(integer*, char*, integer*, complex*, complex*, complex*, integer*, complex*, complex*, integer*);
+     static real errmax;
+     static complex transl;
+     static integer laa, lda;
+@@ -1785,15 +1785,15 @@ L130:
+     static logical packed;
+     static integer nk, ks, ix, ns, lx;
+     extern logical lceres_(char*, char*, integer*, integer*, complex*, complex*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cctbmv_(integer*, char*, char*, char*, integer*, integer*, complex*, integer*, complex*, integer*);
+-    extern /* Subroutine */ void cctbsv_(integer*, char*, char*, char*, integer*, integer*, complex*, integer*, complex*, integer*);
++    extern /* Subroutine */ int cctbmv_(integer*, char*, char*, char*, integer*, integer*, complex*, integer*, complex*, integer*);
++    extern /* Subroutine */ int cctbsv_(integer*, char*, char*, char*, integer*, integer*, complex*, integer*, complex*, integer*);
+     static char ctrans[14];
+-    extern /* Subroutine */ void cctpmv_(integer*, char*, char*, char*, integer*, complex*, complex*, integer*);
++    extern /* Subroutine */ int cctpmv_(integer*, char*, char*, char*, integer*, complex*, complex*, integer*);
+     static real errmax;
+-    extern /* Subroutine */ void cctrmv_(integer*, char*, char*, char*, integer*, complex*, integer*, complex*, integer*);
+-    extern /* Subroutine */ void cctpsv_(integer*, char*, char*, char*, integer*, complex*, complex*, integer*);
++    extern /* Subroutine */ int cctrmv_(integer*, char*, char*, char*, integer*, complex*, integer*, complex*, integer*);
++    extern /* Subroutine */ int cctpsv_(integer*, char*, char*, char*, integer*, complex*, complex*, integer*);
+     static complex transl;
+-    extern /* Subroutine */ void cctrsv_(integer*, char*, char*, char*, integer*, complex*, integer*, complex*, integer*);
++    extern /* Subroutine */ int cctrsv_(integer*, char*, char*, char*, integer*, complex*, integer*, complex*, integer*);
+     static char transs[1];
+     static integer laa, icd, lda;
+     extern logical lce_(complex*, complex*, integer*);
+@@ -2267,9 +2267,9 @@ L130:
+     static integer nargs;
+     static logical reset;
+     static integer incxs, incys, ia, nc, nd, im, in;
+-    extern /* Subroutine */ void ccgerc_(integer*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, integer*);
++    extern /* Subroutine */ int ccgerc_(integer*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, integer*);
+     static integer ms, ix, iy, ns, lx, ly;
+-    extern /* Subroutine */ void ccgeru_(integer*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, integer*);
++    extern /* Subroutine */ int ccgeru_(integer*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, integer*);
+     extern logical lceres_(char*, char*, integer*, integer*, complex*, complex*, integer*, ftnlen, ftnlen);
+     static real errmax;
+     static complex transl;
+@@ -2621,10 +2621,10 @@ L150:
+     static char uplo[1];
+     static integer i__, j, n;
+     extern /* Subroutine */ int cmake_(char*, char*, char*, integer*, integer*, complex*, integer*, complex*, integer*, integer*, integer*, logical*, complex*, ftnlen, ftnlen, ftnlen);
+-    extern /* Subroutine */ void ccher_(integer*, char*, integer*, real*, complex*, integer*, complex*, integer*);
++    extern /* Subroutine */ int ccher_(integer*, char*, integer*, real*, complex*, integer*, complex*, integer*);
+     static complex alpha, w[1];
+     static logical isame[13];
+-    extern /* Subroutine */ void cchpr_(integer*, char*, integer*, real*, complex*, integer*, complex*);
++    extern /* Subroutine */ int cchpr_(integer*, char*, integer*, real*, complex*, integer*, complex*);
+     extern /* Subroutine */ int cmvch_(char*, integer*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, complex*, integer*, complex*, real*, complex*, real*, real*, logical*, integer*, logical*, ftnlen);
+     static integer nargs;
+     static logical reset;
+@@ -2991,8 +2991,8 @@ L130:
+     static integer incxs, incys;
+     static logical upper;
+     static char uplos[1];
+-    extern /* Subroutine */ void ccher2_(integer*, char*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, integer*);
+-    extern /* Subroutine */ void cchpr2_(integer*, char*, integer*, complex*, complex*, integer*, complex*, integer*, complex*);
++    extern /* Subroutine */ int ccher2_(integer*, char*, integer*, complex*, complex*, integer*, complex*, integer*, complex*, integer*);
++    extern /* Subroutine */ int cchpr2_(integer*, char*, integer*, complex*, complex*, integer*, complex*, integer*, complex*);
+     static integer ia, ja, ic, nc, jj, lj, in;
+     static logical packed;
+     static integer ix, iy, ns, lx, ly;
+diff --git a/ctest/c_cblat3c.c b/ctest/c_cblat3c.c
+index afd9e593b..ae50293a9 100644
+--- a/ctest/c_cblat3c.c
++++ b/ctest/c_cblat3c.c
+@@ -327,7 +327,7 @@ int /* Main program */ main(void)
+     static char snamet[12], transa[1], transb[1];
+     static real thresh;
+     static logical rorder;
+-    extern /* Subroutine */ void cc3chke_(char *);
++    extern /* Subroutine */ int cc3chke_(char *);
+     static integer layout;
+     static logical ltestt, tsterr;
+     static complex alf[7];
+@@ -851,7 +851,7 @@ L230:
+ 	    *, char *, char *, integer *, integer *, integer *, complex *, 
+ 	    integer *, integer *, complex *, integer *);
+     integer ia, ib, ma, mb, na, nb, nc, ik, im, in;
+-    extern /* Subroutine */ void ccgemm_(integer *, char *, char *, integer *, 
++    extern /* Subroutine */ int ccgemm_(integer *, char *, char *, integer *, 
+ 	    integer *, integer *, complex *, complex *, integer *, complex *, 
+ 	    integer *, complex *, complex *, integer *);
+     integer ks, ms, ns;
+@@ -1263,13 +1263,13 @@ L130:
+ 	    *, char *, char *, integer *, integer *, complex *, integer *, 
+ 	    integer *, complex *, integer *);
+     integer ia, ib, na, nc, im, in;
+-    extern /* Subroutine */ void cchemm_(integer *, char *, char *, integer *, 
++    extern /* Subroutine */ int cchemm_(integer *, char *, char *, integer *, 
+ 	    integer *, complex *, complex *, integer *, complex *, integer *, 
+ 	    complex *, complex *, integer *);
+     integer ms, ns;
+     extern logical lceres_(char *, char *, integer *, integer *, complex *, 
+ 	    complex *, integer *);
+-    extern /* Subroutine */ void ccsymm_(integer *, char *, char *, integer *, 
++    extern /* Subroutine */ int ccsymm_(integer *, char *, char *, integer *, 
+ 	    integer *, complex *, complex *, integer *, complex *, integer *, 
+ 	    complex *, complex *, integer *);
+     real errmax;
+@@ -1663,11 +1663,11 @@ L120:
+     integer ia, na, nc, im, in, ms, ns;
+     extern logical lceres_(char *, char *, integer *, integer *, complex *, 
+ 	    complex *, integer *);
+-    extern /* Subroutine */ void cctrmm_(integer *, char *, char *, char *, 
++    extern /* Subroutine */ int cctrmm_(integer *, char *, char *, char *, 
+ 	    char *, integer *, integer *, complex *, complex *, integer *, 
+ 	    complex *, integer *);
+     char tranas[1], transa[1];
+-    extern /* Subroutine */ void cctrsm_(integer *, char *, char *, char *, 
++    extern /* Subroutine */ int cctrsm_(integer *, char *, char *, char *, 
+ 	    char *, integer *, integer *, complex *, complex *, integer *, 
+ 	    complex *, integer *);
+     real errmax;
+@@ -2138,7 +2138,7 @@ L160:
+ 	    integer *, char *, integer *, char *, char *, integer *, integer *
+ 	    , real *, integer *, real *, integer *);
+     integer ia, ib, jc, ma, na, nc, ik, in, jj, lj, ks;
+-    extern /* Subroutine */ void ccherk_(integer *, char *, char *, integer *, 
++    extern /* Subroutine */ int ccherk_(integer *, char *, char *, integer *, 
+ 	    integer *, real *, complex *, integer *, real *, complex *, 
+ 	    integer *);
+     integer ns;
+@@ -2146,7 +2146,7 @@ L160:
+     extern logical lceres_(char *, char *, integer *, integer *, complex *, 
+ 	    complex *, integer *);
+     real errmax;
+-    extern /* Subroutine */ void ccsyrk_(integer *, char *, char *, integer *, 
++    extern /* Subroutine */ int ccsyrk_(integer *, char *, char *, integer *, 
+ 	    integer *, complex *, complex *, integer *, complex *, complex *, 
+ 	    integer *);
+     char transs[1], transt[1];
+@@ -2638,12 +2638,12 @@ L130:
+ 	    complex *, integer *);
+     real errmax;
+     char transs[1], transt[1];
+-    extern /* Subroutine */ void ccher2k_(integer *, char *, char *, integer *,
++    extern /* Subroutine */ int ccher2k_(integer *, char *, char *, integer *,
+ 	     integer *, complex *, complex *, integer *, complex *, integer *,
+ 	     real *, complex *, integer *);
+     integer laa, lbb, lda, lcc, ldb, ldc;
+     extern logical lce_(complex *, complex *, integer *);
+-    extern /* Subroutine */ void ccsyr2k_(integer *, char *, char *, integer *,
++    extern /* Subroutine */ int ccsyr2k_(integer *, char *, char *, integer *,
+ 	     integer *, complex *, complex *, integer *, complex *, integer *,
+ 	     complex *, complex *, integer *);
+     complex als;
+diff --git a/ctest/c_dblat1c.c b/ctest/c_dblat1c.c
+index 909b0d83a..11485b909 100644
+--- a/ctest/c_dblat1c.c
++++ b/ctest/c_dblat1c.c
+@@ -332,7 +332,7 @@ static doublereal c_b34 = 1.;
+ 
+     /* Local variables */
+     static integer k;
+-    extern /* Subroutine */ void drotgtest_(doublereal*,doublereal*,doublereal*,doublereal*);
++    extern /* Subroutine */ int drotgtest_(doublereal*,doublereal*,doublereal*,doublereal*);
+     extern int stest1_(doublereal*,doublereal*,doublereal*,doublereal*);
+     static doublereal sa, sb, sc, ss;
+ 
+@@ -406,7 +406,7 @@ L40:
+     extern doublereal dnrm2test_(integer*, doublereal*, integer*);
+     static doublereal stemp[1], strue[8];
+     extern /* Subroutine */ int stest_(integer*,doublereal*,doublereal*,doublereal*,doublereal*);
+-    extern void dscaltest_(integer*,doublereal*,doublereal*,integer*);
++    extern int dscaltest_(integer*,doublereal*,doublereal*,integer*);
+     extern doublereal dasumtest_(integer*,doublereal*,integer*);
+     extern /* Subroutine */ int itest1_(integer*,integer*), stest1_(doublereal*,doublereal*,doublereal*,doublereal*);
+     static doublereal sx[8];
+@@ -520,7 +520,7 @@ L40:
+     extern doublereal ddottest_(integer*,doublereal*,integer*,doublereal*,integer*);
+     static integer i__, j, ksize;
+     extern /* Subroutine */ int stest_(integer*,doublereal*,doublereal*,doublereal*,doublereal*);
+-    extern void dcopytest_(integer*,doublereal*,integer*,doublereal*,integer*), dswaptest_(integer*,doublereal*,integer*,doublereal*,integer*), 
++    extern int dcopytest_(integer*,doublereal*,integer*,doublereal*,integer*), dswaptest_(integer*,doublereal*,integer*,doublereal*,integer*), 
+ 	    daxpytest_(integer*,doublereal*,doublereal*,integer*,doublereal*,integer*);
+     extern int stest1_(doublereal*,doublereal*,doublereal*,doublereal*);
+     static integer ki, kn, mx, my;
+@@ -622,10 +622,10 @@ L40:
+ 	    ;
+ 
+     /* Local variables */
+-    extern /* Subroutine */ void drottest_(integer*,doublereal*,integer*,doublereal*,integer*,doublereal*,doublereal*);
++    extern /* Subroutine */ int drottest_(integer*,doublereal*,integer*,doublereal*,integer*,doublereal*,doublereal*);
+     static integer i__, k, ksize;
+     extern /* Subroutine */int stest_(integer*,doublereal*,doublereal*,doublereal*,doublereal*);
+-    extern void drotmtest_(integer*,doublereal*,integer*,doublereal*,integer*,doublereal*);
++    extern int drotmtest_(integer*,doublereal*,integer*,doublereal*,integer*,doublereal*);
+     static integer ki, kn;
+     static doublereal dparam[5], sx[10], sy[10], stx[10], sty[10];
+ 
+diff --git a/ctest/c_dblat2c.c b/ctest/c_dblat2c.c
+index a802f0f3b..5d821b75f 100644
+--- a/ctest/c_dblat2c.c
++++ b/ctest/c_dblat2c.c
+@@ -305,7 +305,7 @@ static logical c_false = FALSE_;
+     static char snamet[12];
+     static doublereal thresh;
+     static logical rorder;
+-    extern /* Subroutine */ void cd2chke_(char*);
++    extern /* Subroutine */ int cd2chke_(char*);
+     static integer layout;
+     static logical ltestt, tsterr;
+     static doublereal alf[7];
+@@ -872,8 +872,8 @@ L240:
+     static integer ia, ib, ic;
+     static logical banded;
+     static integer nc, nd, im, in, kl, ml, nk, nl, ku, ix, iy, ms, lx, ly, ns;
+-    extern /* Subroutine */ void cdgbmv_(integer*, char*, integer*, integer*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
+-    extern /* Subroutine */ void cdgemv_(integer*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdgbmv_(integer*, char*, integer*, integer*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdgemv_(integer*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
+     extern logical lderes_(char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, ftnlen, ftnlen);
+     static char ctrans[14];
+     static doublereal errmax, transl;
+@@ -1315,10 +1315,10 @@ L140:
+     static logical packed;
+     static integer nk, ks, ix, iy, ns, lx, ly;
+     extern logical lderes_(char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cdsbmv_(integer*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
+-    extern /* Subroutine */ void cdspmv_(integer*, char*, integer*, doublereal*, doublereal*, doublereal*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdsbmv_(integer*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdspmv_(integer*, char*, integer*, doublereal*, doublereal*, doublereal*, integer*, doublereal*, doublereal*, integer*);
+     static doublereal errmax, transl;
+-    extern /* Subroutine */ void cdsymv_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdsymv_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
+     static integer laa, lda;
+     extern logical lde_(doublereal*, doublereal*, integer*);
+     static doublereal als, bls, err;
+@@ -1756,15 +1756,15 @@ L130:
+     static logical packed;
+     static integer nk, ks, ix, ns, lx;
+     extern logical lderes_(char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cdtbmv_(integer*, char*, char*, char*, integer*, integer*, doublereal*, integer*, doublereal*, integer*);
+-    extern /* Subroutine */ void cdtbsv_(integer*, char*, char*, char*, integer*, integer*, doublereal*, integer*, doublereal*, integer*);
++    extern /* Subroutine */ int cdtbmv_(integer*, char*, char*, char*, integer*, integer*, doublereal*, integer*, doublereal*, integer*);
++    extern /* Subroutine */ int cdtbsv_(integer*, char*, char*, char*, integer*, integer*, doublereal*, integer*, doublereal*, integer*);
+     static char ctrans[14];
+     static doublereal errmax;
+-    extern /* Subroutine */ void cdtpmv_(integer*, char*, char*, char*, integer*, doublereal*, doublereal*, integer*);
+-    extern /* Subroutine */ void cdtrmv_(integer*, char*, char*, char*, integer*, doublereal*, integer*, doublereal*, integer*);
++    extern /* Subroutine */ int cdtpmv_(integer*, char*, char*, char*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdtrmv_(integer*, char*, char*, char*, integer*, doublereal*, integer*, doublereal*, integer*);
+     static doublereal transl;
+-    extern /* Subroutine */ void cdtpsv_(integer*, char*, char*, char*, integer*, doublereal*, doublereal*, integer*);
+-    extern /* Subroutine */ void cdtrsv_(integer*, char*, char*, char*, integer*, doublereal*, integer*, doublereal*, integer*);
++    extern /* Subroutine */ int cdtpsv_(integer*, char*, char*, char*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdtrsv_(integer*, char*, char*, char*, integer*, doublereal*, integer*, doublereal*, integer*);
+     static char transs[1];
+     static integer laa, icd, lda;
+     extern logical lde_(doublereal*, doublereal*, integer*);
+@@ -2227,7 +2227,7 @@ L130:
+     static integer incx, incy;
+     static logical null;
+     static integer i__, j, m, n;
+-    extern /* Subroutine */ void cdger_(integer*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, integer*);
++    extern /* Subroutine */ int cdger_(integer*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, integer*);
+     extern /* Subroutine */ int dmake_(char* , char*, char*, integer*, integer*, doublereal*, integer*, doublereal*, integer*, integer*, integer*, logical*, doublereal*, ftnlen, ftnlen, ftnlen);
+     static doublereal alpha, w[1];
+     static logical isame[13];
+@@ -2567,11 +2567,11 @@ L150:
+     static logical isame[13];
+     extern /* Subroutine */ int dmvch_(char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*, doublereal*, doublereal*, doublereal*, doublereal*, doublereal*, logical*, integer*, logical*, ftnlen);
+     static integer nargs;
+-    extern /* Subroutine */ void cdspr_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*);
++    extern /* Subroutine */ int cdspr_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*);
+     static logical reset;
+     static char cuplo[14];
+     static integer incxs;
+-    extern /* Subroutine */ void cdsyr_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*);
++    extern /* Subroutine */ int cdsyr_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*);
+     static logical upper;
+     static char uplos[1];
+     static integer ia, ja, ic, nc, jj, lj, in;
+@@ -2927,8 +2927,8 @@ L130:
+     static integer incxs, incys;
+     static logical upper;
+     static char uplos[1];
+-    extern /* Subroutine */ void cdspr2_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*);
+-    extern /* Subroutine */ void cdsyr2_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, integer*);
++    extern /* Subroutine */ int cdspr2_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*);
++    extern /* Subroutine */ int cdsyr2_(integer*, char*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, integer*);
+     static integer ia, ja, ic, nc, jj, lj, in;
+     static logical packed;
+     static integer ix, iy, ns, lx, ly;
+diff --git a/ctest/c_dblat3c.c b/ctest/c_dblat3c.c
+index 7b83dc861..5d07f56ac 100644
+--- a/ctest/c_dblat3c.c
++++ b/ctest/c_dblat3c.c
+@@ -296,7 +296,7 @@ static logical c_false = FALSE_;
+     static char snamet[12], transa[1], transb[1];
+     static doublereal thresh;
+     static logical rorder;
+-    extern /* Subroutine */ void cd3chke_(char*);
++    extern /* Subroutine */ int cd3chke_(char*);
+     static integer layout;
+     static logical ltestt, tsterr;
+     static doublereal alf[7];
+@@ -792,9 +792,9 @@ L230:
+     static logical isame[13], trana, tranb;
+     static integer nargs;
+     static logical reset;
+-    extern /* Subroutine */ void dprcn1_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, integer*, doublereal*, integer*, integer*, doublereal*, integer*, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int dprcn1_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, integer*, doublereal*, integer*, integer*, doublereal*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer ia, ib, ma, mb, na, nb, nc, ik, im, in;
+-    extern /* Subroutine */ void cdgemm_(integer*, char*, char*, integer*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdgemm_(integer*, char*, char*, integer*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
+     static integer ks, ms, ns;
+     extern logical lderes_(char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, ftnlen, ftnlen);
+     static char tranas[1], tranbs[1], transa[1], transb[1];
+@@ -1129,7 +1129,7 @@ L130:
+ 
+ } /* dchk1_ */
+ 
+-/* Subroutine */ void dprcn1_(integer* nout, integer* nc, char* sname, integer* iorder, char* transa, char* transb, integer* m, integer* n, integer* k, doublereal* alpha, integer* lda, integer* ldb, doublereal* beta, integer* ldc, ftnlen sname_len, ftnlen transa_len, ftnlen transb_len)
++/* Subroutine */ int dprcn1_(integer* nout, integer* nc, char* sname, integer* iorder, char* transa, char* transb, integer* m, integer* n, integer* k, doublereal* alpha, integer* lda, integer* ldb, doublereal* beta, integer* ldc, ftnlen sname_len, ftnlen transa_len, ftnlen transb_len)
+ {
+ 
+     /* Local variables */
+@@ -1187,10 +1187,10 @@ L130:
+     static integer nargs;
+     static logical reset;
+     static char uplos[1];
+-    extern /* Subroutine */ void dprcn2_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, doublereal*, integer*, integer*, doublereal*, integer*, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int dprcn2_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, doublereal*, integer*, integer*, doublereal*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer ia, ib, na, nc, im, in, ms, ns;
+     extern logical lderes_(char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cdsymm_(integer*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdsymm_(integer*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
+     static doublereal errmax;
+     static integer laa, lbb, lda, lcc, ldb, ldc;
+     extern logical lde_(doublereal*, doublereal*, integer*);
+@@ -1506,7 +1506,7 @@ L120:
+ } /* dchk2_ */
+ 
+ 
+-/* Subroutine */ void dprcn2_(integer* nout, integer* nc, char* sname, integer* iorder, char* side, char* uplo, integer* m, integer* n, doublereal* alpha, integer* lda, integer* ldb, doublereal* beta, integer* ldc, ftnlen sname_len, ftnlen side_len, ftnlen uplo_len)
++/* Subroutine */ int dprcn2_(integer* nout, integer* nc, char* sname, integer* iorder, char* side, char* uplo, integer* m, integer* n, doublereal* alpha, integer* lda, integer* ldb, doublereal* beta, integer* ldc, ftnlen sname_len, ftnlen side_len, ftnlen uplo_len)
+ {
+ 
+     /* Local variables */
+@@ -1562,12 +1562,12 @@ L120:
+     static integer nargs;
+     static logical reset;
+     static char uplos[1];
+-    extern /* Subroutine */ void dprcn3_(integer*, integer*, char*, integer*, char*, char*, char*, char*, integer*, integer*, doublereal*, integer*, integer*, ftnlen, ftnlen, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int dprcn3_(integer*, integer*, char*, integer*, char*, char*, char*, char*, integer*, integer*, doublereal*, integer*, integer*, ftnlen, ftnlen, ftnlen, ftnlen, ftnlen);
+     static integer ia, na, nc, im, in, ms, ns;
+     extern logical lderes_(char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cdtrmm_(integer*, char*, char*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*);
++    extern /* Subroutine */ int cdtrmm_(integer*, char*, char*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*);
+     static char tranas[1], transa[1];
+-    extern /* Subroutine */ void cdtrsm_(integer*, char*, char*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*);
++    extern /* Subroutine */ int cdtrsm_(integer*, char*, char*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*);
+     static doublereal errmax;
+     static integer laa, icd, lbb, lda, ldb;
+     extern logical lde_(doublereal*, doublereal*, integer*);
+@@ -1950,7 +1950,7 @@ L160:
+ } /* dchk3_ */
+ 
+ 
+-/* Subroutine */ void dprcn3_(integer* nout, integer* nc, char* sname, integer* iorder, char* side, char* uplo, char* transa, char* diag, integer* m, integer* n, doublereal* alpha, integer* lda, integer* ldb, ftnlen sname_len, ftnlen side_len, ftnlen uplo_len, ftnlen transa_len, ftnlen diag_len)
++/* Subroutine */ int dprcn3_(integer* nout, integer* nc, char* sname, integer* iorder, char* side, char* uplo, char* transa, char* diag, integer* m, integer* n, doublereal* alpha, integer* lda, integer* ldb, ftnlen sname_len, ftnlen side_len, ftnlen uplo_len, ftnlen transa_len, ftnlen diag_len)
+ {
+ 
+     /* Local variables */
+@@ -2017,11 +2017,11 @@ L160:
+     static char trans[1];
+     static logical upper;
+     static char uplos[1];
+-    extern /* Subroutine */ void dprcn4_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, doublereal*, integer*, doublereal*, integer*, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int dprcn4_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, doublereal*, integer*, doublereal*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer ia, ib, jc, ma, na, nc, ik, in, jj, lj, ks, ns;
+     extern logical lderes_(char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, ftnlen, ftnlen);
+     static doublereal errmax;
+-    extern /* Subroutine */ void cdsyrk_(integer*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdsyrk_(integer*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, doublereal*, integer*);
+     static char transs[1];
+     static integer laa, lda, lcc, ldc;
+     extern logical lde_(doublereal*, doublereal*, integer*);
+@@ -2338,7 +2338,7 @@ L130:
+ } /* dchk4_ */
+ 
+ 
+-/* Subroutine */ void dprcn4_(integer* nout, integer* nc, char* sname, integer* iorder, char* uplo, char* transa, integer* n, integer* k, doublereal* alpha, integer* lda, doublereal* beta, integer* ldc, ftnlen sname_len, ftnlen uplo_len, ftnlen transa_len)
++/* Subroutine */ int dprcn4_(integer* nout, integer* nc, char* sname, integer* iorder, char* uplo, char* transa, integer* n, integer* k, doublereal* alpha, integer* lda, doublereal* beta, integer* ldc, ftnlen sname_len, ftnlen uplo_len, ftnlen transa_len)
+ {
+ 
+     /* Local variables */
+@@ -2395,14 +2395,14 @@ L130:
+     static char trans[1];
+     static logical upper;
+     static char uplos[1];
+-    extern /* Subroutine */ void dprcn5_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, doublereal*, integer*, integer*, doublereal*, integer*, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int dprcn5_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, doublereal*, integer*, integer*, doublereal*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer ia, ib, jc, ma, na, nc, ik, in, jj, lj, ks, ns;
+     extern logical lderes_(char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, ftnlen, ftnlen);
+     static doublereal errmax;
+     static char transs[1];
+     static integer laa, lbb, lda, lcc, ldb, ldc;
+     extern logical lde_(doublereal*, doublereal*, integer*);
+-    extern /* Subroutine */ void cdsyr2k_(integer*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
++    extern /* Subroutine */ int cdsyr2k_(integer*, char*, char*, integer*, integer*, doublereal*, doublereal*, integer*, doublereal*, integer*, doublereal*, doublereal*, integer*);
+     static doublereal als;
+     static integer ict, icu;
+     static doublereal err;
+@@ -2769,7 +2769,7 @@ L160:
+ } /* dchk5_ */
+ 
+ 
+-/* Subroutine */ void dprcn5_(integer* nout, integer* nc, char* sname, integer* iorder, char* uplo, char* transa, integer* n, integer* k, doublereal* alpha, integer* lda, integer* ldb, doublereal* beta, integer* ldc, ftnlen sname_len, ftnlen uplo_len, ftnlen transa_len)
++/* Subroutine */ int dprcn5_(integer* nout, integer* nc, char* sname, integer* iorder, char* uplo, char* transa, integer* n, integer* k, doublereal* alpha, integer* lda, integer* ldb, doublereal* beta, integer* ldc, ftnlen sname_len, ftnlen uplo_len, ftnlen transa_len)
+ {
+ 
+     /* Local variables */
+diff --git a/ctest/c_sblat1c.c b/ctest/c_sblat1c.c
+index dd6f1b5e4..eec0c3810 100644
+--- a/ctest/c_sblat1c.c
++++ b/ctest/c_sblat1c.c
+@@ -342,7 +342,7 @@ static real c_b34 = (float)1.;
+ 
+     /* Local variables */
+     static integer k;
+-    extern /* Subroutine */ void srotgtest_(real*,real*,real*,real*);
++    extern /* Subroutine */ int srotgtest_(real*,real*,real*,real*);
+     extern int stest1_(real*,real*,real*,real*);
+     static real sa, sb, sc, ss;
+ 
+@@ -437,7 +437,7 @@ L40:
+     extern real snrm2test_(integer*,real*,integer*);
+     static real stemp[1], strue[8];
+     extern /* Subroutine */ int stest_(integer*, real*,real*,real*,real*);
+-    extern void sscaltest_(integer*,real*,real*,integer*);
++    extern int sscaltest_(integer*,real*,real*,integer*);
+     extern real sasumtest_(integer*,real*,integer*);
+     extern /* Subroutine */ int itest1_(integer*,integer*), stest1_(real*,real*,real*,real*);
+     static real sx[8];
+@@ -595,7 +595,7 @@ L40:
+     extern real sdottest_(integer*,real*,integer*,real*,integer*);
+     static integer i__, j, ksize;
+     extern /* Subroutine */ int stest_(integer*,real*,real*,real*,real*);
+-    extern void scopytest_(integer*,real*,integer*,real*,integer*), sswaptest_(integer*,real*,integer*,real*,integer*), 
++    extern int scopytest_(integer*,real*,integer*,real*,integer*), sswaptest_(integer*,real*,integer*,real*,integer*), 
+ 	    saxpytest_(integer*,real*,real*,integer*,real*,integer*);
+     static integer ki;
+     extern /* Subroutine */ int stest1_(real*,real*,real*,real*);
+@@ -711,10 +711,10 @@ L40:
+ 	    1.17 };
+ 
+     /* Local variables */
+-    extern /* Subroutine */ void srottest_(integer*,real*,integer*,real*,integer*,real*,real*);
++    extern /* Subroutine */ int srottest_(integer*,real*,integer*,real*,integer*,real*,real*);
+     static integer i__, k, ksize;
+     extern /* Subroutine */ int stest_(integer*,real*,real*,real*,real*);
+-    extern void srotmtest_(integer*,real*,integer*,real*,integer*,real*);
++    extern int srotmtest_(integer*,real*,integer*,real*,integer*,real*);
+     static integer ki, kn;
+     static real sx[19], sy[19], sparam[5], stx[19], sty[19];
+ 
+diff --git a/ctest/c_sblat2c.c b/ctest/c_sblat2c.c
+index 9e359e6ff..308895dc9 100644
+--- a/ctest/c_sblat2c.c
++++ b/ctest/c_sblat2c.c
+@@ -306,7 +306,7 @@ extern /* Subroutine */ int schk6_(char* sname, real* eps, real* thresh, integer
+     static logical rorder;
+     static integer layout;
+     static logical ltestt;
+-    extern /* Subroutine */ void cs2chke_(char*);
++    extern /* Subroutine */ int cs2chke_(char*);
+     static logical tsterr;
+     static real alf[7];
+     static integer inc[7], nkb;
+@@ -867,8 +867,8 @@ L240:
+     static integer ia, ib, ic;
+     static logical banded;
+     static integer nc, nd, im, in, kl, ml, nk, nl, ku, ix, iy, ms, lx, ly, ns;
+-    extern /* Subroutine */ void csgbmv_(integer*, char*, integer*, integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
+-    extern /* Subroutine */ void csgemv_(integer*, char*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int csgbmv_(integer*, char*, integer*, integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int csgemv_(integer*, char*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
+     static char ctrans[14];
+     static real errmax;
+     extern logical lseres_(char* type__, char* uplo, integer* m, integer* n, real* aa, real* as, integer* lda, ftnlen ltype_len, ftnlen uplo_len);
+@@ -1313,10 +1313,10 @@ L140:
+     static integer nk, ks, ix, iy, ns, lx, ly;
+     static real errmax;
+     extern logical lseres_(char* , char*, integer*, integer*, real*, real*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cssbmv_(integer*, char*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int cssbmv_(integer*, char*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
+     static real transl;
+-    extern /* Subroutine */ void csspmv_(integer*, char*, integer*, real*, real*, real*, integer*, real*, real*, integer*);
+-    extern /* Subroutine */ void cssymv_(integer*, char*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int csspmv_(integer*, char*, integer*, real*, real*, real*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int cssymv_(integer*, char*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
+     static integer laa, lda;
+     static real als, bls;
+     extern logical lse_(real*, real*, integer*);
+@@ -1753,14 +1753,14 @@ L130:
+     static char ctrans[14];
+     static real errmax;
+     extern logical lseres_(char*, char*, integer*, integer*, real*, real*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cstbmv_(integer*, char*, char*, char*, integer*, integer*, real*, integer*, real*, integer*);
++    extern /* Subroutine */ int cstbmv_(integer*, char*, char*, char*, integer*, integer*, real*, integer*, real*, integer*);
+     static real transl;
+-    extern /* Subroutine */ void cstbsv_(integer*, char*, char*, char*, integer*, integer*, real*, integer*, real*, integer*);
++    extern /* Subroutine */ int cstbsv_(integer*, char*, char*, char*, integer*, integer*, real*, integer*, real*, integer*);
+     static char transs[1];
+-    extern /* Subroutine */ void cstpmv_(integer*, char*, char*, char*, integer*, real*, real*, integer*);
+-    extern /* Subroutine */ void cstrmv_(integer*, char*, char*, char*, integer*, real*, integer*, real*, integer*);
+-    extern /* Subroutine */ void cstpsv_(integer*, char*, char*, char*, integer*, real*, real*, integer*);
+-    extern /* Subroutine */ void cstrsv_(integer*, char*, char*, char*, integer*, real*, integer*, real*, integer*);
++    extern /* Subroutine */ int cstpmv_(integer*, char*, char*, char*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int cstrmv_(integer*, char*, char*, char*, integer*, real*, integer*, real*, integer*);
++    extern /* Subroutine */ int cstpsv_(integer*, char*, char*, char*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int cstrsv_(integer*, char*, char*, char*, integer*, real*, integer*, real*, integer*);
+     static integer laa, icd, lda, ict, icu;
+     extern logical lse_(real*, real*, integer*);
+     static real err;
+@@ -2224,7 +2224,7 @@ L130:
+     static real alpha, w[1];
+     static logical isame[13];
+ /* Subroutine */ int smake_(char*, char*, char*, integer*, integer*, real*, integer*, real*, integer*, integer*, integer*, logical*, real*, ftnlen, ftnlen, ftnlen);
+-    extern /* Subroutine */ void csger_(integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, integer*);
++    extern /* Subroutine */ int csger_(integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, integer*);
+     static integer nargs;
+     extern /* Subroutine */ int smvch_(char*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*, real*, real*, real*, real*, real*, logical*, integer*, logical*, ftnlen);
+     static logical reset;
+@@ -2565,10 +2565,10 @@ L150:
+     static logical reset;
+     static char cuplo[14];
+     static integer incxs;
+-    extern /* Subroutine */ void csspr_(integer*, char*, integer*, real*, real*, integer*, real*);
++    extern /* Subroutine */ int csspr_(integer*, char*, integer*, real*, real*, integer*, real*);
+     static logical upper;
+     static char uplos[1];
+-    extern /* Subroutine */ void cssyr_(integer*, char*, integer*, real*, real*, integer*, real*, integer*);
++    extern /* Subroutine */ int cssyr_(integer*, char*, integer*, real*, real*, integer*, real*, integer*);
+     static integer ia, ja, ic, nc, jj, lj, in;
+     static logical packed;
+     static integer ix, ns, lx;
+@@ -2924,10 +2924,10 @@ L130:
+     static logical upper;
+     static char uplos[1];
+     static integer ia, ja, ic;
+-    extern /* Subroutine */ void csspr2_(integer*, char*, integer*, real*, real*, integer*, real*, integer*, real*);
++    extern /* Subroutine */ int csspr2_(integer*, char*, integer*, real*, real*, integer*, real*, integer*, real*);
+     static integer nc, jj, lj, in;
+     static logical packed;
+-    extern /* Subroutine */ void cssyr2_(integer*, char*, integer*, real*, real*, integer*, real*, integer*, real*, integer*);
++    extern /* Subroutine */ int cssyr2_(integer*, char*, integer*, real*, real*, integer*, real*, integer*, real*, integer*);
+     static integer ix, iy, ns, lx, ly;
+     static real errmax;
+     extern logical lseres_(char* type__, char* uplo, integer* m, integer* n, real* aa, real* as, integer* lda, ftnlen, ftnlen);
+diff --git a/ctest/c_sblat3c.c b/ctest/c_sblat3c.c
+index 7e703a427..2eea504e3 100644
+--- a/ctest/c_sblat3c.c
++++ b/ctest/c_sblat3c.c
+@@ -296,7 +296,7 @@ static logical c_false = FALSE_;
+     static logical rorder;
+     static integer layout;
+     static logical ltestt, tsterr;
+-    extern /* Subroutine */ void cs3chke_(char*);
++    extern /* Subroutine */ int cs3chke_(char*);
+     static real alf[7], bet[7];
+     extern logical lse_(real*, real*, integer*);
+     static real eps, err;
+@@ -783,11 +783,11 @@ L230:
+     static logical trana, tranb;
+     static integer nargs;
+     static logical reset;
+-    extern /* Subroutine */ void sprcn1_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, integer*, real*, integer*, integer*, real*, integer*, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int sprcn1_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, integer*, real*, integer*, integer*, real*, integer*, ftnlen, ftnlen, ftnlen);
+     extern /* Subroutine */ int smake_(char*, char*, char*, integer*, integer*, real*, integer*, real*, integer*, logical*, real*, ftnlen, ftnlen, ftnlen);
+     extern /* Subroutine */ int smmch_(char*, char*, integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*, real*, real*, real*, integer*, real*, real*, logical*, integer*, logical*, ftnlen, ftnlen);
+     static integer ia, ib, ma, mb, na, nb, nc, ik, im, in, ks, ms, ns;
+-    extern /* Subroutine */ void csgemm_(integer*, char*, char*, integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int csgemm_(integer*, char*, char*, integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
+     static char tranas[1], tranbs[1], transa[1], transb[1];
+     static real errmax;
+     extern logical lseres_(char*, char*, integer*, integer*, real*, real*, integer*, ftnlen, ftnlen);
+@@ -1123,7 +1123,7 @@ L130:
+ 
+ 
+ 
+-/* Subroutine */ void sprcn1_(integer* nout, integer* nc, char* sname, integer* iorder, char* transa, char* transb, integer* m, integer* n, integer* k, real* alpha, integer* lda, integer* ldb, real* beta, integer* ldc, ftnlen sname_len, ftnlen transa_len, ftnlen transb_len)
++/* Subroutine */ int sprcn1_(integer* nout, integer* nc, char* sname, integer* iorder, char* transa, char* transb, integer* m, integer* n, integer* k, real* alpha, integer* lda, integer* ldb, real* beta, integer* ldc, ftnlen sname_len, ftnlen transa_len, ftnlen transb_len)
+ {
+ 
+     /* Local variables */
+@@ -1183,8 +1183,8 @@ L130:
+     static integer ia, ib, na, nc, im, in, ms, ns;
+     static real errmax;
+     extern logical lseres_(char*, char*, integer*, integer*, real*, real*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cssymm_(integer*, char*, char*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
+-    extern void sprcn2_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, real*, integer*, integer*, real*, integer*, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int cssymm_(integer*, char*, char*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
++    extern int sprcn2_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, real*, integer*, integer*, real*, integer*, ftnlen, ftnlen, ftnlen);
+     extern /* Subroutine */ int smake_(char*, char*, char*, integer*, integer*, real*, integer*, real*, integer*, logical*, real*, ftnlen, ftnlen, ftnlen);
+     extern /* Subroutine */ int smmch_(char*, char*, integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*, real*, real*, real*, integer*, real*, real*, logical*, integer*, logical*, ftnlen, ftnlen);
+     static integer laa, lbb, lda, lcc, ldb, ldc, ics;
+@@ -1498,7 +1498,7 @@ L120:
+ } /* schk2_ */
+ 
+ 
+-/* Subroutine */ void sprcn2_(integer* nout, integer* nc, char* sname, integer* iorder, char* side, char* uplo, integer* m, integer* n, real* alpha, integer* lda, integer* ldb, real* beta, integer* ldc, ftnlen sname_len, ftnlen side_len, ftnlen uplo_len)
++/* Subroutine */ int sprcn2_(integer* nout, integer* nc, char* sname, integer* iorder, char* side, char* uplo, integer* m, integer* n, real* alpha, integer* lda, integer* ldb, real* beta, integer* ldc, ftnlen sname_len, ftnlen side_len, ftnlen uplo_len)
+ {
+ 
+     /* Local variables */
+@@ -1553,15 +1553,15 @@ L120:
+     static integer nargs;
+     static logical reset;
+     static char uplos[1];
+-    extern /* Subroutine */ void sprcn3_(integer*, integer*, char*, integer*, char*, char*, char*, char*, integer*, integer*, real*, integer*, integer*, ftnlen , ftnlen, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int sprcn3_(integer*, integer*, char*, integer*, char*, char*, char*, char*, integer*, integer*, real*, integer*, integer*, ftnlen , ftnlen, ftnlen, ftnlen, ftnlen);
+     static integer ia, na, nc, im, in, ms, ns;
+     static char tranas[1], transa[1];
+     static real errmax;
+     extern /* Subroutine */ int smake_(char*, char*, char*, integer*, integer*, real*, integer*, real*, integer*, logical*, real*, ftnlen, ftnlen, ftnlen);
+     extern /* Subroutine */ int smmch_(char*, char*, integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*, real*, real*, real*, integer*, real*, real*, logical*, integer*, logical*, ftnlen, ftnlen);
+     extern logical lseres_(char*, char*, integer*, integer*, real*, real*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cstrmm_(integer*, char*, char*, char*, char*, integer*, integer*, real*, real*, integer*, real*, integer*);
+-    extern /* Subroutine */ void cstrsm_(integer*, char*, char*, char*, char*, integer*, integer*, real*, real*, integer*, real*, integer*);
++    extern /* Subroutine */ int cstrmm_(integer*, char*, char*, char*, char*, integer*, integer*, real*, real*, integer*, real*, integer*);
++    extern /* Subroutine */ int cstrsm_(integer*, char*, char*, char*, char*, integer*, integer*, real*, real*, integer*, real*, integer*);
+     static integer laa, icd, lbb, lda, ldb, ics;
+     static real als;
+     static integer ict, icu;
+@@ -1938,7 +1938,7 @@ L160:
+ } /* schk3_ */
+ 
+ 
+-/* Subroutine */ void sprcn3_(integer* nout, integer* nc, char* sname, integer* iorder, char* side, char* uplo, char* transa, char* diag, integer* m, integer* n, real* alpha, integer* lda, integer* ldb, ftnlen sname_len, ftnlen side_len, ftnlen uplo_len, ftnlen transa_len, ftnlen diag_len)
++/* Subroutine */ int sprcn3_(integer* nout, integer* nc, char* sname, integer* iorder, char* side, char* uplo, char* transa, char* diag, integer* m, integer* n, real* alpha, integer* lda, integer* ldb, ftnlen sname_len, ftnlen side_len, ftnlen uplo_len, ftnlen transa_len, ftnlen diag_len)
+ {
+ 
+     /* Local variables */
+@@ -2004,14 +2004,14 @@ L160:
+     static char trans[1];
+     static logical upper;
+     static char uplos[1];
+-    extern /* Subroutine */ void sprcn4_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, real*, integer*, real*, integer*, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int sprcn4_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, real*, integer*, real*, integer*, ftnlen, ftnlen, ftnlen);
+     extern /* Subroutine */ int smake_(char*, char*, char*, integer*, integer*, real*, integer*, real*, integer*, logical*, real*, ftnlen, ftnlen, ftnlen);
+     extern /* Subroutine */ int smmch_(char*, char*, integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*, real*, real*, real*, integer*, real*, real*, logical*, integer*, logical*, ftnlen, ftnlen);
+     static integer ia, ib, jc, ma, na, nc, ik, in, jj, lj, ks, ns;
+     static real errmax;
+     extern logical lseres_(char*, char*, integer*, integer*, real*, real*, integer*, ftnlen, ftnlen);
+     static char transs[1];
+-    extern /* Subroutine */ void cssyrk_(integer*, char*, char*, integer*, integer*, real*, real*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int cssyrk_(integer*, char*, char*, integer*, integer*, real*, real*, integer*, real*, real*, integer*);
+     static integer laa, lda, lcc, ldc;
+     static real als;
+     static integer ict, icu;
+@@ -2325,7 +2325,7 @@ L130:
+ } /* schk4_ */
+ 
+ 
+-/* Subroutine */ void sprcn4_(integer* nout, integer* nc, char* sname, integer* iorder, char* uplo, char* transa, integer* n, integer* k, real* alpha, integer* lda, real* beta, integer* ldc, ftnlen sname_len, ftnlen uplo_len, ftnlen transa_len)
++/* Subroutine */ int sprcn4_(integer* nout, integer* nc, char* sname, integer* iorder, char* uplo, char* transa, integer* n, integer* k, real* alpha, integer* lda, real* beta, integer* ldc, ftnlen sname_len, ftnlen uplo_len, ftnlen transa_len)
+ {
+ 
+     /* Local variables */
+@@ -2382,7 +2382,7 @@ L130:
+     static logical upper;
+     static char uplos[1];
+     static integer ia, ib;
+-    extern /* Subroutine */ void sprcn5_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, real*, integer*, integer*, real*, integer*, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int sprcn5_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, real*, integer*, integer*, real*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer jc, ma, na, nc, ik, in, jj, lj, ks, ns;
+     static real errmax;
+     extern logical lseres_(char*, char*, integer*, integer*, real*, real*, integer*, ftnlen, ftnlen);
+@@ -2391,7 +2391,7 @@ L130:
+     static integer laa, lbb, lda, lcc, ldb, ldc;
+     static real als;
+     static integer ict, icu;
+-    extern /* Subroutine */ void cssyr2k_(integer*, char*, char*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
++    extern /* Subroutine */ int cssyr2k_(integer*, char*, char*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*);
+     extern logical lse_(real*, real*, integer*);
+     extern /* Subroutine */ int smmch_(char*, char*, integer*, integer*, integer*, real*, real*, integer*, real*, integer*, real*, real*, integer*, real*, real*, real*, integer*, real*, real*, logical*, integer*, logical*, ftnlen, ftnlen);
+     static real err;
+@@ -2756,7 +2756,7 @@ L160:
+ } /* schk5_ */
+ 
+ 
+-/* Subroutine */ void sprcn5_(integer* nout, integer* nc, char* sname, integer* iorder, char* uplo, char* transa, integer* n, integer* k, real* alpha, integer* lda, integer* ldb, real* beta, integer* ldc, ftnlen sname_len, ftnlen uplo_len, ftnlen transa_len)
++/* Subroutine */ int sprcn5_(integer* nout, integer* nc, char* sname, integer* iorder, char* uplo, char* transa, integer* n, integer* k, real* alpha, integer* lda, integer* ldb, real* beta, integer* ldc, ftnlen sname_len, ftnlen uplo_len, ftnlen transa_len)
+ {
+ 
+     /* Local variables */
+diff --git a/ctest/c_zblat1c.c b/ctest/c_zblat1c.c
+index 645bffd0a..93922627d 100644
+--- a/ctest/c_zblat1c.c
++++ b/ctest/c_zblat1c.c
+@@ -372,12 +372,12 @@ static doublereal c_b43 = 1.;
+     static integer i__;
+     extern /* Subroutine */ int ctest_(integer*, doublecomplex*, doublecomplex*, doublecomplex*, doublereal*);
+     static doublecomplex mwpcs[5], mwpct[5];
+-    extern /* Subroutine */ void zscaltest_(integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int zscaltest_(integer*, doublecomplex*, doublecomplex*, integer*);
+     extern int itest1_(integer*, integer*), stest1_(doublereal*, doublereal*, doublereal*, doublereal*);
+     static doublecomplex cx[8];
+     extern doublereal dznrm2test_(integer*, doublecomplex*, integer*);
+     static integer np1;
+-    extern /* Subroutine */ void zdscaltest_(integer*, doublereal*, doublecomplex*, integer*);
++    extern /* Subroutine */ int zdscaltest_(integer*, doublereal*, doublecomplex*, integer*);
+     extern integer izamaxtest_(integer*, doublecomplex*, integer*);
+     extern doublereal dzasumtest_(integer*, doublecomplex*, integer*);
+     static integer len;
+@@ -584,11 +584,11 @@ static doublereal c_b43 = 1.;
+     extern /* Subroutine */ int ctest_(integer*, doublecomplex*, doublecomplex*, doublecomplex*, doublereal*);
+     static integer ksize;
+     static doublecomplex ztemp;
+-    extern /* Subroutine */ void zdotctest_(integer*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*), zcopytest_(integer*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int zdotctest_(integer*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*), zcopytest_(integer*, doublecomplex*, integer*, doublecomplex*, integer*);
+     static integer ki;
+-    extern /* Subroutine */ void zdotutest_(integer*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*), zswaptest_(integer*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int zdotutest_(integer*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*), zswaptest_(integer*, doublecomplex*, integer*, doublecomplex*, integer*);
+     static integer kn;
+-    extern /* Subroutine */ void zaxpytest_(integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int zaxpytest_(integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*);
+     static doublecomplex cx[7], cy[7];
+     static integer mx, my;
+ 
+diff --git a/ctest/c_zblat2c.c b/ctest/c_zblat2c.c
+index 62908dd70..3050200d7 100644
+--- a/ctest/c_zblat2c.c
++++ b/ctest/c_zblat2c.c
+@@ -317,7 +317,7 @@ static logical c_false = FALSE_;
+     static logical rorder;
+     static integer layout;
+     static logical ltestt, tsterr;
+-    extern /* Subroutine */ void cz2chke_(char*);
++    extern /* Subroutine */ int cz2chke_(char*);
+     static doublecomplex alf[7];
+     static integer inc[7], nkb;
+     static doublecomplex bet[7];
+@@ -888,9 +888,9 @@ L240:
+     static integer ia, ib, ic;
+     static logical banded;
+     static integer nc, nd, im, in, kl, ml, nk, nl, ku, ix, iy, ms, lx, ly, ns;
+-    extern /* Subroutine */ void czgbmv_(integer*, char*, integer*, integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czgbmv_(integer*, char*, integer*, integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+     static char ctrans[14];
+-    extern /* Subroutine */ void czgemv_(integer*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czgemv_(integer*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+     static doublereal errmax;
+     static doublecomplex transl;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+@@ -1342,12 +1342,12 @@ L140:
+     static integer nc, ik, in;
+     static logical packed;
+     static integer nk, ks, ix, iy, ns, lx, ly;
+-    extern /* Subroutine */ void czhbmv_(integer*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+-    extern /* Subroutine */ void czhemv_(integer*, char*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czhbmv_(integer*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czhemv_(integer*, char*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+     static doublereal errmax;
+     static doublecomplex transl;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void czhpmv_(integer*, char*, integer*, doublecomplex*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czhpmv_(integer*, char*, integer*, doublecomplex*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+     static integer laa, lda;
+     static doublecomplex als, bls;
+     static doublereal err;
+@@ -1790,13 +1790,13 @@ L130:
+     static doublereal errmax;
+     static doublecomplex transl;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cztbmv_(integer*, char*, char*, char*, integer*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int cztbmv_(integer*, char*, char*, char*, integer*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
+     static char transs[1];
+-    extern /* Subroutine */ void cztbsv_(integer*, char*, char*, char*, integer*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
+-    extern /* Subroutine */ void cztpmv_(integer*, char*, char*, char*, integer*, doublecomplex*, doublecomplex*, integer*);
+-    extern /* Subroutine */ void cztpsv_(integer*, char*, char*, char*, integer*, doublecomplex*, doublecomplex*, integer*);
+-    extern /* Subroutine */ void cztrmv_(integer*, char*, char*, char*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
+-    extern /* Subroutine */ void cztrsv_(integer*, char*, char*, char*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int cztbsv_(integer*, char*, char*, char*, integer*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int cztpmv_(integer*, char*, char*, char*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int cztpsv_(integer*, char*, char*, char*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int cztrmv_(integer*, char*, char*, char*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int cztrsv_(integer*, char*, char*, char*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
+     static integer laa, icd, lda, ict, icu;
+     static doublereal err;
+     extern logical lze_(doublecomplex*, doublecomplex*, integer*);
+@@ -2271,9 +2271,9 @@ L130:
+     static integer incxs, incys;
+     extern /* Subroutine */ int zmvch_(char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, doublereal*, doublecomplex*, doublereal*, doublereal*, logical*, integer*, logical*, ftnlen);
+     static integer ia, nc, nd, im, in, ms, ix, iy, ns, lx, ly;
+-    extern /* Subroutine */ void czgerc_(integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czgerc_(integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
+     static doublereal errmax;
+-    extern /* Subroutine */ void czgeru_(integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czgeru_(integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
+     static doublecomplex transl;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+     static integer laa, lda;
+@@ -2630,11 +2630,11 @@ L150:
+     static logical isame[13];
+     extern /* Subroutine */ int zmake_(char*, char*, char*, integer*, integer*, doublecomplex*, integer*, doublecomplex*, integer*, integer*, integer*, logical*, doublecomplex*, ftnlen, ftnlen, ftnlen);
+     static integer nargs;
+-    extern /* Subroutine */ void czher_(integer*, char*, integer*, doublereal*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czher_(integer*, char*, integer*, doublereal*, doublecomplex*, integer*, doublecomplex*, integer*);
+     static logical reset;
+     static char cuplo[14];
+     static integer incxs;
+-    extern /* Subroutine */ void czhpr_(integer*, char*, integer*, doublereal*, doublecomplex*, integer*, doublecomplex*);
++    extern /* Subroutine */ int czhpr_(integer*, char*, integer*, doublereal*, doublecomplex*, integer*, doublecomplex*);
+     extern /* Subroutine */ int zmvch_(char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, doublereal*, doublecomplex*, doublereal*, doublereal*, logical*, integer*, logical*, ftnlen);
+     static logical upper;
+     static char uplos[1];
+@@ -2995,8 +2995,8 @@ L130:
+     extern /* Subroutine */ int zmvch_(char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, doublereal*, doublecomplex*, doublereal*, doublereal*, logical*, integer*, logical*, ftnlen);
+     static logical upper;
+     static char uplos[1];
+-    extern /* Subroutine */ void czher2_(integer*, char*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
+-    extern /* Subroutine */ void czhpr2_(integer*, char*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*);
++    extern /* Subroutine */ int czher2_(integer*, char*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czhpr2_(integer*, char*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*);
+     static integer ia, ja, ic, nc, jj, lj, in;
+     static logical packed;
+     static integer ix, iy, ns, lx, ly;
+diff --git a/ctest/c_zblat3c.c b/ctest/c_zblat3c.c
+index 1e8756185..24ce9086c 100644
+--- a/ctest/c_zblat3c.c
++++ b/ctest/c_zblat3c.c
+@@ -312,7 +312,7 @@ static logical c_false = FALSE_;
+     static logical rorder;
+     static integer layout;
+     static logical ltestt, tsterr;
+-    extern /* Subroutine */ void cz3chke_(char*);
++    extern /* Subroutine */ int cz3chke_(char*);
+     static doublecomplex alf[7], bet[7];
+     static doublereal eps, err;
+     extern logical lze_(doublecomplex*, doublecomplex*, integer*);
+@@ -829,7 +829,7 @@ L230:
+     static integer ia, ib;
+     extern /* Subroutine */ int zprcn1_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, integer*, doublecomplex*, integer*, integer*, doublecomplex*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer ma, mb, na, nb, nc, ik, im, in, ks, ms, ns;
+-    extern /* Subroutine */ void czgemm_(integer*, char*, char*, integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czgemm_(integer*, char*, char*, integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+     static char tranas[1], tranbs[1], transa[1], transb[1];
+     static doublereal errmax;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+@@ -1239,10 +1239,10 @@ return 0;
+     static integer ia, ib;
+     extern /* Subroutine */ int zprcn2_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, doublecomplex*, integer*, integer*, doublecomplex*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer na, nc, im, in, ms, ns;
+-    extern /* Subroutine */ void czhemm_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czhemm_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+     static doublereal errmax;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void czsymm_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czsymm_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+     static integer laa, lbb, lda, lcc, ldb, ldc, ics;
+     static doublecomplex als, bls;
+     static integer icu;
+@@ -1638,8 +1638,8 @@ return 0;
+     static char tranas[1], transa[1];
+     static doublereal errmax;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cztrmm_(integer*, char*, char*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*);
+-    extern /* Subroutine */ void cztrsm_(integer*, char*, char*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int cztrmm_(integer*, char*, char*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*);
++    extern /* Subroutine */ int cztrsm_(integer*, char*, char*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*);
+     static integer laa, icd, lbb, lda, ldb, ics;
+     static doublecomplex als;
+     static integer ict, icu;
+@@ -2114,11 +2114,11 @@ return 0;
+     extern /* Subroutine */ int zprcn6_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, doublereal*, integer*, doublereal*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer ik, in, jj, lj, ks, ns;
+     static doublereal ralpha;
+-    extern /* Subroutine */ void czherk_(integer*, char*, char*, integer*, integer*, doublereal*, doublecomplex*, integer*, doublereal*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czherk_(integer*, char*, char*, integer*, integer*, doublereal*, doublecomplex*, integer*, doublereal*, doublecomplex*, integer*);
+     static doublereal errmax;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+     static char transs[1], transt[1];
+-    extern /* Subroutine */ void czsyrk_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czsyrk_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+     static integer laa, lda, lcc, ldc;
+     static doublecomplex als;
+     static integer ict, icu;
+@@ -2608,11 +2608,11 @@ return 0;
+     static doublereal errmax;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+     static char transs[1], transt[1];
+-    extern /* Subroutine */ void czher2k_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublereal*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czher2k_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublereal*, doublecomplex*, integer*);
+     static integer laa, lbb, lda, lcc, ldb, ldc;
+     static doublecomplex als;
+     static integer ict, icu;
+-    extern /* Subroutine */ void czsyr2k_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
++    extern /* Subroutine */ int czsyr2k_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*);
+     static doublereal err;
+     extern logical lze_(doublecomplex*, doublecomplex*, integer*);
+ 
+diff --git a/ctest/c_zblat3c_3m.c b/ctest/c_zblat3c_3m.c
+index 0c76f11e7..d7053bc49 100644
+--- a/ctest/c_zblat3c_3m.c
++++ b/ctest/c_zblat3c_3m.c
+@@ -831,7 +831,7 @@ L230:
+     static integer ia, ib;
+     extern /* Subroutine */ int zprcn1_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, integer*, doublecomplex*, integer*, integer*, doublecomplex*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer ma, mb, na, nb, nc, ik, im, in, ks, ms, ns;
+-    extern /* Subroutine */ void czgemm3m_(integer*, char*, char*, integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
++    extern /* Subroutine */ int czgemm3m_(integer*, char*, char*, integer*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+     static char tranas[1], tranbs[1], transa[1], transb[1];
+     static doublereal errmax;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+@@ -1242,10 +1242,10 @@ return 0;
+     static integer ia, ib;
+     extern /* Subroutine */ int zprcn2_(integer*, integer*, char*, integer*, char*, char*, integer*, integer*, doublecomplex*, integer*, integer*, doublecomplex*, integer*, ftnlen, ftnlen, ftnlen);
+     static integer na, nc, im, in, ms, ns;
+-    extern /* Subroutine */ void czhemm_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
++    extern /* Subroutine */ int czhemm_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+     static doublereal errmax;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void czsymm_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
++    extern /* Subroutine */ int czsymm_(integer*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+     static integer laa, lbb, lda, lcc, ldb, ldc, ics;
+     static doublecomplex als, bls;
+     static integer icu;
+@@ -1641,8 +1641,8 @@ return 0;
+     static char tranas[1], transa[1];
+     static doublereal errmax;
+     extern logical lzeres_(char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cztrmm_(integer*, char*, char*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, ftnlen, ftnlen, ftnlen, ftnlen);
+-    extern /* Subroutine */ void cztrsm_(integer*, char*, char*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, ftnlen, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int cztrmm_(integer*, char*, char*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, ftnlen, ftnlen, ftnlen, ftnlen);
++    extern /* Subroutine */ int cztrsm_(integer*, char*, char*, char*, char*, integer*, integer*, doublecomplex*, doublecomplex*, integer*, doublecomplex*, integer*, ftnlen, ftnlen, ftnlen, ftnlen);
+     static integer laa, icd, lbb, lda, ldb, ics;
+     static doublecomplex als;
+     static integer ict, icu;
+-- 
+2.55.0
+

--- a/recipes/recipes_emscripten/openblas/recipe.yaml
+++ b/recipes/recipes_emscripten/openblas/recipe.yaml
@@ -12,6 +12,7 @@ source:
   patches:
   # Branch containing these patches is v0.3.34-emforge at https://github.com/jjerphan/OpenBLAS
   # Use `git format-patch v0.3.34..v0.3.34-emforge` to create patch files.
+  # Patches 0009-0012 adapt the OpenBLAS test suite for emscripten/wasm.
   - patches/0001-Remove-march-flags.patch
   - patches/0002-Skip-linktest.patch
   - patches/0003-Add-emscripten-as-supported-arch.patch
@@ -20,6 +21,10 @@ source:
   - patches/0006-Int-to-void-return-types-of-lapack-functions-used-by.patch
   - patches/0007-Enable-LAPACK_FORTRAN_STDLEN_END-for-lapacke-calling.patch
   - patches/0008-Clear-FEXTRALIB-when-linking-shared-library.patch
+  - patches/0009-Skip-fork-based-utests-for-emscripten.patch
+  - patches/0010-Run-OpenBLAS-tests-under-node-for-emscripten.patch
+  - patches/0011-Return-int-from-ctest-F77-wrappers-for-wasm-ABI.patch
+  - patches/0012-Use-int-return-for-f2c-Subroutine-decls-in-ctest.patch
 
 build:
   number: 1
@@ -34,6 +39,7 @@ requirements:
   - ${{ compiler('fortran') }}
   - cmake
   - make
+  - nodejs
   host:
   - libflang >= 20.1
 

--- a/recipes/recipes_emscripten/openblas/test_openblas.py
+++ b/recipes/recipes_emscripten/openblas/test_openblas.py
@@ -1,6 +1,9 @@
 import pyjs
 
-def test_dummy():
-    # This doesn't run any actual tests, but it forces the testing framework to load
-    # libopenblas.so which will identify if there are any missing symbols.
+
+def test_load_shared_library():
+    # Build-time already runs OpenBLAS utest + CBLAS ctest under Node
+    # (Fortran BLAS drivers are skipped: flang segfaults on wasm for those sources).
+    # This package test only forces loading libopenblas.so to catch missing symbols
+    # in the installed shared library.
     pass


### PR DESCRIPTION
## Package Details
- **Package Name**: openblas
- **Version**: 0.3.34

## Build Notes
Rebased onto main (OpenBLAS 0.3.34). Reuses the Emscripten/Flang patches from main (0001–0008). New patches 0009–0012 adapt the test suite for wasm: skip fork-based utests, run under Node, and align ctest F77/f2c wrappers with the wasm ABI.

Fortran BLAS drivers (`test/` and `ctest/*.f`) are skipped because flang 22 segfaults on wasm; the build runs utest plus CBLAS levels 1–3 with `NOFORTRAN=1`.