### PR TITLE
Rebuild `xtensor-blas` without pin on `openblas`

### DIFF
--- a/recipes/recipes_emscripten/xtensor-blas/recipe.yaml
+++ b/recipes/recipes_emscripten/xtensor-blas/recipe.yaml
@@ -13,7 +13,7 @@ source:
   - patches/shared.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -23,7 +23,7 @@ requirements:
   - xtensor
   run:
   - xtensor
-  - openblas=0.3.26
+  - openblas
 
 tests:
 - script:


### PR DESCRIPTION
## Package Details
- **Package Name**: xtensor-blas 
- **Version**: 0.23.0

## Build Notes

As discussed privately with @anutosh491.
