### PR TITLE
Add package httpx2-jsfetch

### DIFF
--- a/recipes/recipes_emscripten/httpx2-jsfetch/recipe.yaml
+++ b/recipes/recipes_emscripten/httpx2-jsfetch/recipe.yaml
@@ -1,0 +1,56 @@
+context:
+  name: httpx2-jsfetch
+  version: 0.1.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/h/httpx2-jsfetch-emscripten-forge/httpx2_jsfetch_emscripten_forge-${{ version }}.tar.gz
+  sha256: fa2297e6c3866e82b757050920086b99a6d849d30151534e70ab4325c83092a5
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . ${{ PIP_ARGS }}
+  noarch: python
+
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
+requirements:
+  build:
+  - pip != 25.1
+  - cross-python_${{ target_platform }}
+  - hatchling
+  host:
+  - python
+  run:
+  - python
+  - pyjs >=4.0.5
+
+tests:
+- script: pytester
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+  files:
+    recipe:
+    - test_import_httpx2_jsfetch.py
+
+about:
+  homepage: https://github.com/davidbrochart/httpx2-jsfetch-emscripten-forge
+  license: BSD-3-Clause
+  license_file: LICENSE.md
+  summary: httpx2 transports for emscripten-forge.
+
+extra:
+  recipe-maintainers:
+  - davidbrochart

--- a/recipes/recipes_emscripten/httpx2-jsfetch/recipe.yaml
+++ b/recipes/recipes_emscripten/httpx2-jsfetch/recipe.yaml
@@ -33,6 +33,7 @@ requirements:
   run:
   - python
   - pyjs >=4.0.5
+  - httpx2 >=2.12.0,<3.0.0
 
 tests:
 - script: pytester

--- a/recipes/recipes_emscripten/httpx2-jsfetch/recipe.yaml
+++ b/recipes/recipes_emscripten/httpx2-jsfetch/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: httpx2-jsfetch
-  version: 0.1.0
+  version: 0.1.1
 
 package:
   name: ${{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/h/httpx2-jsfetch-emscripten-forge/httpx2_jsfetch_emscripten_forge-${{ version }}.tar.gz
-  sha256: fa2297e6c3866e82b757050920086b99a6d849d30151534e70ab4325c83092a5
+  sha256: f1152ee33b02f72a6f53e44be9c714e7956625dcecb701221185433b5ceaca74
 
 build:
   number: 0

--- a/recipes/recipes_emscripten/httpx2-jsfetch/recipe.yaml
+++ b/recipes/recipes_emscripten/httpx2-jsfetch/recipe.yaml
@@ -32,7 +32,7 @@ requirements:
   - python
   run:
   - python
-  - pyjs >=4.0.5
+  - pyjs >=4.0.6
   - httpx2 >=2.12.0,<3.0.0
 
 tests:
@@ -44,7 +44,7 @@ tests:
     - pytester-run
   files:
     recipe:
-    - test_import_httpx2_jsfetch.py
+    - test_import_httpx2.py
 
 about:
   homepage: https://github.com/davidbrochart/httpx2-jsfetch-emscripten-forge

--- a/recipes/recipes_emscripten/httpx2-jsfetch/test_import_httpx2.py
+++ b/recipes/recipes_emscripten/httpx2-jsfetch/test_import_httpx2.py
@@ -1,3 +1,3 @@
 def test_import_httpx2():
     import httpx2
-
+    from httpx2_jsfetch import AsyncJavascriptFetchTransport, JavascriptFetchTransport

--- a/recipes/recipes_emscripten/httpx2-jsfetch/test_import_httpx2.py
+++ b/recipes/recipes_emscripten/httpx2-jsfetch/test_import_httpx2.py
@@ -1,0 +1,3 @@
+def test_import_httpx2():
+    import httpx2
+

--- a/recipes/recipes_emscripten/httpx2-jsfetch/test_import_httpx2_jsfetch.py
+++ b/recipes/recipes_emscripten/httpx2-jsfetch/test_import_httpx2_jsfetch.py
@@ -1,0 +1,3 @@
+def test_import_httpx2_jsfetch():
+    import httpx2_jsfetch
+

--- a/recipes/recipes_emscripten/httpx2-jsfetch/test_import_httpx2_jsfetch.py
+++ b/recipes/recipes_emscripten/httpx2-jsfetch/test_import_httpx2_jsfetch.py
@@ -1,3 +1,0 @@
-def test_import_httpx2_jsfetch():
-    import httpx2_jsfetch
-


### PR DESCRIPTION
### Pre-submission Checks
- [ ] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

This is a `noarch` package but it requires `pyjs`, so it cannot be submitted to conda-forge.
This package is the equivalent of https://github.com/hoodmane/httpx2-jsfetch which works with pyodide. We need this because `httpx2` requires a httpx2-jsfetch package on emscripten [here](https://github.com/pydantic/httpx2/blob/71ae23be5448f859c2b4e21d9972ddfa7b8d759d/src/httpx2/httpx2/_transports/__init__.py#L12).