### PR TITLE
Add scipy-tests

### DIFF
--- a/recipes/recipes_emscripten/scipy/build.sh
+++ b/recipes/recipes_emscripten/scipy/build.sh
@@ -27,9 +27,12 @@ export FC=$LLVM_DIR/bin/flang-new-wrapper
 # Meson finds numpy_config via pkg_config and numpy.pc
 export PKG_CONFIG_PATH=$PREFIX/lib/python$PY_VER/site-packages/numpy/_core/lib/pkgconfig
 
+# Install runtime plus tests (Meson install_tag=tests). Tests are packaged
+# as scipy-tests, not scipy; scipy.test() needs both packages.
 ${PYTHON} -m pip install . ${PIP_ARGS} --no-build-isolation \
     -Csetup-args="--cross-file=$RECIPE_DIR/emscripten.meson.cross" \
     -Csetup-args="-Dfortran_std=none" \
     -Csetup-args="-Duse-pythran=false" \
     -Cbuild-dir="_build" \
-    -Ccompile-args="--verbose"
+    -Ccompile-args="--verbose" \
+    -Cinstall-args="--tags=runtime,python-runtime,tests"

--- a/recipes/recipes_emscripten/scipy/recipe.yaml
+++ b/recipes/recipes_emscripten/scipy/recipe.yaml
@@ -1,10 +1,10 @@
 context:
   name: scipy
   version: 1.18.0
+  build_number: 1
 
-package:
-  name: ${{ name }}
-  version: ${{ version }}
+build:
+  number: ${{ build_number }}
 
 source:
 - url: https://pypi.org/packages/source/s/scipy/scipy-${{ version }}.tar.gz
@@ -29,50 +29,115 @@ source:
   - patches/0014-int-return-for-superlu_utils-and-input_error.patch
   - patches/0015-Extra-char-length-args-to-f2py-source-files.patch
 
-build:
-  number: 1
-
-  files:
-    exclude:
-    - '**/*.pyi'
-    - '**/tests/**'
-    - '**/__pycache__/**'
-    - '**/*.pyc'
-    - '**/test_*.py'
-  python:
-    skip_pyc_compilation:
-    - '**/*.py'
-requirements:
-  build:
-  - ${{ compiler('c') }}
-  - ${{ compiler('cxx') }}
-  - python
-  - cross-python_${{ target_platform }}
-  - cython
-    # - llvm_${{ target_platform }} # Installing custom LLVM in build.sh
-  - meson-python
-  - numpy
-  - pkg-config
-  host:
-  - numpy
-  - openblas
-  - pybind11
-  - python
-  run:
-  - python
-  - numpy
-  - openblas
-
-tests:
-- script: pytester
-  files:
-    recipe:
-    - test_scipy.py
-  requirements:
+outputs:
+  # One SciPy build; runtime files go to scipy, tests to scipy-tests.
+  - staging:
+      name: scipy-build
     build:
-    - pytester
-    run:
-    - pytester-run
+      script: build.sh
+    requirements:
+      build:
+      - ${{ compiler('c') }}
+      - ${{ compiler('cxx') }}
+      - python
+      - cross-python_${{ target_platform }}
+      - cython
+        # - llvm_${{ target_platform }} # Installing custom LLVM in build.sh
+      - meson-python
+      - numpy
+      - pkg-config
+      host:
+      - numpy
+      - openblas
+      - pybind11
+      - python
+
+  - package:
+      name: scipy
+      version: ${{ version }}
+    inherit: scipy-build
+    build:
+      number: ${{ build_number }}
+      script: echo "Collecting SciPy runtime files from cache"
+      files:
+        exclude:
+        - '**/*.pyi'
+        - '**/__pycache__/**'
+        - '**/*.pyc'
+        - '**/tests/**'
+        - '**/test_*.py'
+      python:
+        skip_pyc_compilation:
+        - '**/*.py'
+    requirements:
+      host:
+      - python
+      - numpy
+      - openblas
+      run:
+      - python
+      - numpy
+      - openblas
+    tests:
+    - package_contents:
+        site_packages:
+        - scipy/__init__.py
+        files:
+          not_exists:
+          - lib/python*/site-packages/scipy/**/tests/**
+          - lib/python*/site-packages/scipy/**/test_*.py
+    - script: pytester
+      files:
+        recipe:
+        - test_scipy.py
+      requirements:
+        build:
+        - pytester
+        run:
+        - pytester-run
+
+  # Overlay of SciPy test modules onto site-packages/scipy. Other recipes
+  # can add scipy-tests as a test requirement and call scipy.test().
+  - package:
+      name: scipy-tests
+      version: ${{ version }}
+    inherit: scipy-build
+    build:
+      number: ${{ build_number }}
+      script: echo "Collecting SciPy test files from cache"
+      files:
+        include:
+        - lib/python*/site-packages/scipy/**/tests/**
+        - lib/python*/site-packages/scipy/**/test_*.py
+        exclude:
+        - '**/__pycache__/**'
+        - '**/*.pyc'
+        - '**/*.pyi'
+      python:
+        skip_pyc_compilation:
+        - '**/*.py'
+    requirements:
+      host:
+      - python
+      run:
+      - ${{ pin_subpackage('scipy', exact=True) }}
+      - pytest
+      - hypothesis
+      - gmpy2
+    tests:
+    - package_contents:
+        site_packages:
+        - scipy/linalg/tests/test_batch.py
+        - scipy/stats/tests/test_stats.py
+    - script: pytester
+      files:
+        recipe:
+        - test_scipy_tests.py
+      requirements:
+        build:
+        - pytester
+        run:
+        - pytester-run
 
 about:
   homepage: http://www.scipy.org/

--- a/recipes/recipes_emscripten/scipy/recipe.yaml
+++ b/recipes/recipes_emscripten/scipy/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: scipy
   version: 1.18.0
-  build_number: 1
+  build_number: 2
 
 build:
   number: ${{ build_number }}

--- a/recipes/recipes_emscripten/scipy/test_scipy_tests.py
+++ b/recipes/recipes_emscripten/scipy/test_scipy_tests.py
@@ -1,0 +1,11 @@
+import pathlib
+
+import scipy
+
+
+def test_scipy_tests_are_installed():
+    root = pathlib.Path(scipy.__file__).resolve().parent
+    test_files = list(root.glob("**/tests/test_*.py"))
+    assert test_files, (
+        "scipy-tests must overlay SciPy test modules under site-packages/scipy"
+    )


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

`scipy-tests` is an additional output of the existing `scipy` recipe (not a new `recipes/recipes_emscripten/scipy-tests/` directory). It overlays SciPy's test modules, including any wasm test extensions, onto `site-packages/scipy`.

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

Build number is 2 for both `scipy` and `scipy-tests` (the template's "0" is for a brand-new recipe). Tests are `package_contents` plus `test_scipy_tests.py` (overlay check), not `test_import_scipy-tests.py`. Source URL, SHA256, and patches are unchanged from the existing scipy recipe.

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: scipy-tests
- **Version**: 1.18.0

## Build Notes
One SciPy build, two packages: `scipy` stays runtime-only; `scipy-tests` ships the test modules. Other recipes can add `scipy-tests` as a test requirement and call `scipy.test()`. `scipy-tests` depends on the matching `scipy` build, plus `pytest`, `hypothesis`, and `gmpy2`. Meson is invoked with `--tags=runtime,python-runtime,tests` so the test files exist to package.