### PR TITLE
Rebuild NumPy from `numpy-openblas` to update `show_info` output

### DIFF
--- a/recipes/recipes_emscripten/numpy-openblas/recipe.yaml
+++ b/recipes/recipes_emscripten/numpy-openblas/recipe.yaml
@@ -13,7 +13,7 @@ source:
   patches:
   - patches/0001-Match-flang-OpenBLAS-Fortran-ABI-on-Emscripten-wasm32.patch
 build:
-  number: 0
+  number: 1
 
   files:
     exclude:


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting
- [ ] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [ ] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: numpy (from `numpy-openblas` targeting `emscripten-forge-4x-experimental`) 
- **Version**: 2.5.2

## Build Notes

NumPy was built against OpenBLAS first targeting `RISCV64`, then OpenBLAS was built for `WASM128_GENERIC` and while NumPy can use newest builds of OpenBLAS at runtime, it keeps out-of-date information from build time.

This should resolve it.