### PR TITLE
Add cgal-cpp

### DIFF
--- a/recipes/recipes_emscripten/cgal-cpp/build.sh
+++ b/recipes/recipes_emscripten/cgal-cpp/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CGAL is header-only since 5.0. The build simply installs headers plus the
+# CMake package config (CGALConfig.cmake) so downstream find_package(CGAL) works.
+# No compilation runs here, so we don't need CMAKE_ARGS from emscripten.
+
+mkdir -p build
+cd build
+
+cmake .. \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_PREFIX_PATH="${PREFIX}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_examples=OFF \
+    -DWITH_demos=OFF \
+    -DWITH_tests=OFF
+
+ninja install

--- a/recipes/recipes_emscripten/cgal-cpp/build_tests.sh
+++ b/recipes/recipes_emscripten/cgal-cpp/build_tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mirrors the antlr-cpp-runtime test pattern: configure the tests/ subdir with
+# emcmake, build with emmake, run the resulting .js under Node. If this passes
+# we know CGAL's headers install correctly, CGAL::CGAL finds gmp/mpfr under
+# Emscripten, and the pygplates code paths (EPICK + Delaunay_triangulation_2 +
+# natural_neighbor_coordinates_2) don't blow up under WASM's limited FPU mode.
+
+emcmake cmake -S tests -B build_tests \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="${PREFIX}" \
+    -DCMAKE_FIND_ROOT_PATH="${PREFIX}"
+
+emmake make -C build_tests -j"${CPU_COUNT:-1}"
+
+echo "Running test..."
+node build_tests/test_cgal.js

--- a/recipes/recipes_emscripten/cgal-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/cgal-cpp/recipe.yaml
@@ -12,9 +12,16 @@ source:
 
 build:
   number: 0
+  # CGAL 5+ is header-only, so the built artifact is arch-independent.
+  # Upstream conda-forge tracking: https://github.com/conda-forge/cgal-cpp-feedstock/issues/55
+  noarch: generic
 
 requirements:
   build:
+  # Even though nothing gets compiled, CGAL's CMakeLists calls
+  # project(CGAL LANGUAGES CXX), which triggers compiler detection at
+  # configure time. Pin one so it doesn't fall back to /usr/bin/c++.
+  - ${{ compiler('cxx') }}
   - cmake
   - ninja
   host:

--- a/recipes/recipes_emscripten/cgal-cpp/recipe.yaml
+++ b/recipes/recipes_emscripten/cgal-cpp/recipe.yaml
@@ -1,0 +1,58 @@
+context:
+  name: cgal-cpp
+  version: 6.0.3
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/CGAL/cgal/releases/download/v${{ version }}/CGAL-${{ version }}-library.tar.xz
+  sha256: 5c82166e6934397a523f2cb0aa35921d17e97f56fbc24e649a8627ef60a76a5c
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - cmake
+  - ninja
+  host:
+  - boost-cpp
+  - gmp
+  - mpfr
+  run:
+  - boost-cpp
+  - gmp
+  - mpfr
+
+tests:
+- package_contents:
+    files:
+    - include/CGAL/version.h
+    - lib/cmake/CGAL/CGALConfig.cmake
+- script:
+  - build_tests.sh
+  requirements:
+    build:
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - nodejs
+  files:
+    recipe:
+    - build_tests.sh
+    - tests/
+
+about:
+  homepage: https://www.cgal.org/
+  license: LGPL-3.0-or-later AND GPL-3.0-or-later
+  license_file:
+  - LICENSE
+  - LICENSE.LGPL
+  - LICENSE.GPL
+  summary: The Computational Geometry Algorithms Library (header-only distribution)
+
+extra:
+  recipe-maintainers:
+  - mmesch

--- a/recipes/recipes_emscripten/cgal-cpp/tests/CMakeLists.txt
+++ b/recipes/recipes_emscripten/cgal-cpp/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.22)
+project(cgal_smoke_test CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(CGAL REQUIRED)
+
+add_executable(test_cgal test_cgal.cpp)
+target_link_libraries(test_cgal PRIVATE CGAL::CGAL)

--- a/recipes/recipes_emscripten/cgal-cpp/tests/test_cgal.cpp
+++ b/recipes/recipes_emscripten/cgal-cpp/tests/test_cgal.cpp
@@ -1,0 +1,89 @@
+// Smoke test for CGAL under Emscripten. Exercises the 2D EPICK kernel and
+// Delaunay triangulation — the parts of CGAL pygplates actually uses. Not a
+// comprehensive test (that's CGAL's own test suite); we hit a handful of
+// specific paths that matter under WASM: the exact-arithmetic fallback (which
+// links to GMP/MPFR) and a ground-truth check on a computed geometric value.
+// See CGAL issue #9062 for the FPU-mode background.
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Delaunay_triangulation_2.h>
+#include <CGAL/intersections.h>
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+using K = CGAL::Exact_predicates_inexact_constructions_kernel;
+using DT = CGAL::Delaunay_triangulation_2<K>;
+using Point = K::Point_2;
+
+using Epeck = CGAL::Exact_predicates_exact_constructions_kernel;
+
+int main() {
+    {
+        DT dt;
+        dt.insert(Point(0.0, 0.0));
+        dt.insert(Point(1.0, 0.0));
+        dt.insert(Point(0.0, 1.0));
+        dt.insert(Point(1.0, 1.0));
+        dt.insert(Point(0.5, 0.5));
+        assert(dt.number_of_vertices() == 5);
+        assert(dt.is_valid());
+        assert(dt.locate(Point(0.25, 0.25)) != DT::Face_handle());
+    }
+
+    // Cocircular points force CGAL onto the exact (GMP-backed) fallback path.
+    {
+        DT dt;
+        dt.insert(Point( 1.0,  0.0));
+        dt.insert(Point( 0.0,  1.0));
+        dt.insert(Point(-1.0,  0.0));
+        dt.insert(Point( 0.0, -1.0));
+        dt.insert(Point( 0.0,  0.0));
+        assert(dt.number_of_vertices() == 5);
+        assert(dt.is_valid());
+    }
+
+    {
+        DT dt;
+        dt.insert(Point(0.0, 0.0));
+        dt.insert(Point(1.0, 0.0));
+        dt.insert(Point(0.0, 1.0));
+        auto face = dt.finite_faces_begin();
+        Point cc = dt.circumcenter(face);
+        assert(std::abs(cc.x() - 0.5) < 1e-12);
+        assert(std::abs(cc.y() - 0.5) < 1e-12);
+    }
+
+    // EPECK exact constructions need -fwasm-exceptions to catch
+    // Uncertain_conversion_exception; guards against CGAL#9062 regressing.
+    {
+        Epeck::Segment_2 a({0, 0}, {2, 2});
+        Epeck::Segment_2 b({0, 2}, {2, 0});
+        auto result = CGAL::intersection(a, b);
+        assert(result.has_value());
+        const auto* p = std::get_if<Epeck::Point_2>(&*result);
+        assert(p != nullptr);
+        assert(CGAL::to_double(p->x()) == 1.0);
+        assert(CGAL::to_double(p->y()) == 1.0);
+    }
+
+    {
+        DT dt;
+        std::srand(42);
+        std::vector<Point> pts;
+        pts.reserve(200);
+        for (int i = 0; i < 200; ++i) {
+            double x = std::rand() / double(RAND_MAX);
+            double y = std::rand() / double(RAND_MAX);
+            pts.emplace_back(x, y);
+        }
+        dt.insert(pts.begin(), pts.end());
+        assert(dt.number_of_vertices() == 200);
+        assert(dt.is_valid());
+    }
+
+    std::cout << "CGAL smoke test OK\n";
+    return 0;
+}


### PR DESCRIPTION
### Pre-submission Checks
- [ ] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation. .... To be honest not fully sure. The conda-forge recipe isn't noarch, but in theory this is a header only library that *maybe* could be noarch. I'm not sure whether there is an established way to do this for CPP libraries though, and also not how safe it is when CMAKE etc still run. Waiting on @IsabelParedes @DerThorsten 's opinion here.

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - C++ packages: Test executable or package_contents test
- [x] `about` section with license, homepage, summary


## PR Formatting
- [x] PR title follows format: `Add [package-name]``
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**:  cgal-cpp
- **Version**: 6.0.3

## Build Notes

- header-only distribution of CGAL 6.0.3
- packaged under the same name as on conda-forge
- adding 6.0.3 because it's needed by a downstream package. Current newest is 6.2.
- since it's header only, I considered noarch packaging on conda-forge but unsure about it
- test compiles and runs under Node. It exercises 3 paths, one of them guarding against CGAL#9062 needing -fwasm-exceptions, which the emscripten-forge toolchain enables by default.