### PR TITLE
Add package ujson

### DIFF
--- a/recipes/recipes_emscripten/ujson/recipe.yaml
+++ b/recipes/recipes_emscripten/ujson/recipe.yaml
@@ -28,7 +28,6 @@ requirements:
     - python
     - cross-python_${{ target_platform }}
     - ${{ compiler('c') }}
-    - ${{ stdlib('c') }}
     - ${{ compiler('cxx') }}
   host:
     - python

--- a/recipes/recipes_emscripten/ujson/recipe.yaml
+++ b/recipes/recipes_emscripten/ujson/recipe.yaml
@@ -1,0 +1,62 @@
+context:
+  name: ujson
+  version: 5.13.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: d62e3d7625384c08082abad81a077af587fdef2761bb14c3822f4234b8d07d75
+
+build:
+  number: 0
+  script: ${PYTHON} -m pip install . ${PIP_ARGS}
+  files:
+    exclude:
+    - '**/*.pyi'
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
+
+requirements:
+  build:
+    - python
+    - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('cxx') }}
+  host:
+    - python
+    - pip
+    - setuptools >=77
+    - setuptools-scm >=3.4
+  run:
+    - python
+
+tests:
+- script: pytester
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+  files:
+    recipe:
+    - test_import_ujson.py
+
+about:
+  homepage: https://github.com/ultrajson/ultrajson
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: Ultra fast JSON decoder and encoder written in C with Python bindings
+  repository: https://github.com/ultrajson/ultrajson
+
+extra:
+  recipe-maintainers:
+  - davidbrochart

--- a/recipes/recipes_emscripten/ujson/recipe.yaml
+++ b/recipes/recipes_emscripten/ujson/recipe.yaml
@@ -26,6 +26,7 @@ build:
 requirements:
   build:
     - python
+    - pip
     - cross-python_${{ target_platform }}
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}

--- a/recipes/recipes_emscripten/ujson/test_import_ujson.py
+++ b/recipes/recipes_emscripten/ujson/test_import_ujson.py
@@ -9,7 +9,7 @@ def test_import_ujson():
     def assert_almost_equal(a, b):
         assert round(abs(a - b), 7) == 0
 
-    test_encode_decimal
+    # test_encode_decimal
     sut = decimal.Decimal("1337.1337")
     encoded = ujson.encode(sut)
     decoded = ujson.decode(encoded)

--- a/recipes/recipes_emscripten/ujson/test_import_ujson.py
+++ b/recipes/recipes_emscripten/ujson/test_import_ujson.py
@@ -1,2 +1,153 @@
 def test_import_ujson():
+    import decimal
+    import json
+    import math
+
     import ujson
+
+
+    def assert_almost_equal(a, b):
+        assert round(abs(a - b), 7) == 0
+
+    test_encode_decimal
+    sut = decimal.Decimal("1337.1337")
+    encoded = ujson.encode(sut)
+    decoded = ujson.decode(encoded)
+    assert decoded == 1337.1337
+
+    # test_write_escaped_string
+    assert "\"\\u003cimg src='\\u0026amp;'\\/\\u003e\"" == ujson.dumps(
+        "<img src='&amp;'/>", encode_html_chars=True
+    )
+
+    # test_double_long_issue
+    sut = {"a": -4342969734183514}
+    encoded = json.dumps(sut)
+    decoded = json.loads(encoded)
+    assert sut == decoded
+    encoded = ujson.encode(sut)
+    decoded = ujson.decode(encoded)
+    assert sut == decoded
+
+    # test_double_long_decimal_issue
+    sut = {"a": -12345678901234.56789012}
+    encoded = json.dumps(sut)
+    decoded = json.loads(encoded)
+    assert sut == decoded
+    encoded = ujson.encode(sut)
+    decoded = ujson.decode(encoded)
+    assert sut == decoded
+
+    # test_encode_decode_long_decimal
+    sut = {"a": -528656961.4399388}
+    encoded = ujson.dumps(sut)
+    ujson.decode(encoded)
+
+    # test_decimal_decode_test
+    sut = {"a": 4.56}
+    encoded = ujson.encode(sut)
+    decoded = ujson.decode(encoded)
+    assert_almost_equal(sut["a"], decoded["a"])
+
+    # test_encode_double_conversion
+    test_input = math.pi
+    output = ujson.encode(test_input)
+    assert round(test_input, 5) == round(json.loads(output), 5)
+    assert round(test_input, 5) == round(ujson.decode(output), 5)
+
+    # test_encode_double_neg_conversion
+    test_input = -math.pi
+    output = ujson.encode(test_input)
+
+    assert round(test_input, 5) == round(json.loads(output), 5)
+    assert round(test_input, 5) == round(ujson.decode(output), 5)
+
+    # test_encode_array_of_nested_arrays
+    test_input = [[[[]]]] * 20
+    output = ujson.encode(test_input)
+    assert test_input == json.loads(output)
+    # assert output == json.dumps(test_input)
+    assert test_input == ujson.decode(output)
+
+    # test_encode_array_of_doubles
+    test_input = [31337.31337, 31337.31337, 31337.31337, 31337.31337] * 10
+    output = ujson.encode(test_input)
+    assert test_input == json.loads(output)
+    # assert output == json.dumps(test_input)
+    assert test_input == ujson.decode(output)
+
+    # test_encode_string_conversion2
+    test_input = "A string \\ / \b \f \n \r \t"
+    output = ujson.encode(test_input)
+    assert test_input == json.loads(output)
+    assert output == '"A string \\\\ \\/ \\b \\f \\n \\r \\t"'
+    assert test_input == ujson.decode(output)
+
+    # test_encode_unicode_bmp
+    s = "\U0001f42e\U0001f42e\U0001f42d\U0001f42d"  # 🐮🐮🐭🐭
+    encoded = ujson.dumps(s)
+    encoded_json = json.dumps(s)
+
+    if len(s) == 4:
+        assert len(encoded) == len(s) * 12 + 2
+    else:
+        assert len(encoded) == len(s) * 6 + 2
+
+    assert encoded == encoded_json
+    decoded = ujson.loads(encoded)
+    assert s == decoded
+
+    # ujson outputs a UTF-8 encoded str object
+    encoded = ujson.dumps(s, ensure_ascii=False)
+
+    # json outputs an unicode object
+    encoded_json = json.dumps(s, ensure_ascii=False)
+    assert len(encoded) == len(s) + 2  # original length + quotes
+    assert encoded == encoded_json
+    decoded = ujson.loads(encoded)
+    assert s == decoded
+
+    # test_encode_symbols
+    s = "\u273f\u2661\u273f"  # ✿♡✿
+    encoded = ujson.dumps(s)
+    encoded_json = json.dumps(s)
+    assert len(encoded) == len(s) * 6 + 2  # 6 characters + quotes
+    assert encoded == encoded_json
+    decoded = ujson.loads(encoded)
+    assert s == decoded
+
+    # ujson outputs a UTF-8 encoded str object
+    encoded = ujson.dumps(s, ensure_ascii=False)
+
+    # json outputs an unicode object
+    encoded_json = json.dumps(s, ensure_ascii=False)
+    assert len(encoded) == len(s) + 2  # original length + quotes
+    assert encoded == encoded_json
+    decoded = ujson.loads(encoded)
+    assert s == decoded
+
+    # test_encode_list_conversion
+    test_input = [1, 2, 3, 4]
+    output = ujson.encode(test_input)
+    assert test_input == json.loads(output)
+    assert test_input == ujson.decode(output)
+
+    # test_encode_dict_conversion
+    test_input = {"k1": 1, "k2": 2, "k3": 3, "k4": 4}
+    output = ujson.encode(test_input)
+    assert test_input == json.loads(output)
+    assert test_input == ujson.decode(output)
+    assert test_input == ujson.decode(output)
+
+    # test_encode_to_utf8
+    test_input = b"\xe6\x97\xa5\xd1\x88".decode("utf-8")
+    enc = ujson.encode(test_input, ensure_ascii=False)
+    dec = ujson.decode(enc)
+    assert enc == json.dumps(test_input, ensure_ascii=False)
+    assert dec == json.loads(enc)
+
+    # test_decode_from_unicode
+    test_input = '{"obj": 31337}'
+    dec1 = ujson.decode(test_input)
+    dec2 = ujson.decode(str(test_input))
+    assert dec1 == dec2

--- a/recipes/recipes_emscripten/ujson/test_import_ujson.py
+++ b/recipes/recipes_emscripten/ujson/test_import_ujson.py
@@ -1,0 +1,2 @@
+def test_import_ujson():
+    import ujson


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/ujson/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary