### PR TITLE
Add package obstore

### DIFF
--- a/recipes/recipes_emscripten/obstore/build.sh
+++ b/recipes/recipes_emscripten/obstore/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export MATURIN_PYTHON_SYSCONFIGDATA_DIR=${PREFIX}/etc/conda/_sysconfigdata__emscripten_wasm32-emscripten.py
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+${PYTHON} -m pip install /obstore. ${PIP_ARGS}

--- a/recipes/recipes_emscripten/obstore/build.sh
+++ b/recipes/recipes_emscripten/obstore/build.sh
@@ -2,4 +2,4 @@
 
 export MATURIN_PYTHON_SYSCONFIGDATA_DIR=${PREFIX}/etc/conda/_sysconfigdata__emscripten_wasm32-emscripten.py
 export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
-${PYTHON} -m pip install /obstore. ${PIP_ARGS}
+${PYTHON} -m pip install ./obstore ${PIP_ARGS}

--- a/recipes/recipes_emscripten/obstore/recipe.yaml
+++ b/recipes/recipes_emscripten/obstore/recipe.yaml
@@ -27,7 +27,7 @@ requirements:
     - pip
     - cross-python_${{ target_platform }}
     - maturin >=1.7.0,<2.0
-    - {{ compiler("c") }}
+    - ${{ compiler("c") }}
     - rust-nightly
   host:
     - python

--- a/recipes/recipes_emscripten/obstore/recipe.yaml
+++ b/recipes/recipes_emscripten/obstore/recipe.yaml
@@ -1,0 +1,61 @@
+context:
+  name: obstore
+  version: 0.11.1
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+- url: https://github.com/developmentseed/obstore/archive/refs/tags/py-v{{ version }}.tar.gz
+  sha256: fa1d90414a59f42001c4642d8af1a5869e7b1e91937dec4599c548088e8beea7
+
+build:
+  number: 0
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
+
+requirements:
+  build:
+    - python
+    - pip
+    - cross-python_${{ target_platform }}
+    - maturin >=1.7.0,<2.0
+    - {{ compiler("c") }}
+    - rust-nightly
+  host:
+    - python
+    - maturin >=1.4.0,<2.0
+    - pip
+  run:
+    - python
+    - typing_extensions >=4.0.0
+
+tests:
+- script: pytester
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+  files:
+    recipe:
+    - test_obstore.py
+
+about:
+  homepage: https://developmentseed.org/obstore
+  summary: Simple, fast integration with Amazon S3, Google Cloud Storage, Azure Storage, and S3-compliant APIs like Cloudflare R2.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  repository: https://github.com/developmentseed/obstore
+
+extra:
+  recipe-maintainers:
+  - davidbrochart

--- a/recipes/recipes_emscripten/obstore/recipe.yaml
+++ b/recipes/recipes_emscripten/obstore/recipe.yaml
@@ -7,7 +7,7 @@ package:
   version: ${{ version }}
 
 source:
-- url: https://github.com/developmentseed/obstore/archive/refs/tags/py-v{{ version }}.tar.gz
+- url: https://github.com/developmentseed/obstore/archive/refs/tags/py-v${{ version }}.tar.gz
   sha256: fa1d90414a59f42001c4642d8af1a5869e7b1e91937dec4599c548088e8beea7
 
 build:

--- a/recipes/recipes_emscripten/obstore/recipe.yaml
+++ b/recipes/recipes_emscripten/obstore/recipe.yaml
@@ -26,12 +26,12 @@ requirements:
     - python
     - pip
     - cross-python_${{ target_platform }}
-    - maturin >=1.7.0,<2.0
+    - maturin >=1.7.0,<2.0.0
     - ${{ compiler("c") }}
     - rust-nightly
   host:
     - python
-    - maturin >=1.4.0,<2.0
+    - maturin >=1.4.0,<2.0.0
     - pip
   run:
     - python

--- a/recipes/recipes_emscripten/obstore/recipe.yaml
+++ b/recipes/recipes_emscripten/obstore/recipe.yaml
@@ -31,7 +31,6 @@ requirements:
     - rust-nightly
   host:
     - python
-    - maturin >=1.4.0,<2.0.0
     - pip
   run:
     - python

--- a/recipes/recipes_emscripten/obstore/test_obstore.py
+++ b/recipes/recipes_emscripten/obstore/test_obstore.py
@@ -1,0 +1,2 @@
+def test_import_obstore():
+    import obstore


### PR DESCRIPTION
### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/obstore/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary