### PR TITLE
[6x] Pin rattler-build version

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -5,7 +5,7 @@ dependencies:
   - python
   - ruamel.yaml
   - typer
-  - rattler-build >=0.74.0
+  - rattler-build >=0.74.0,<0.76.0
   - pixi
   - jinja2
   - curl

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,7 +8,7 @@ platforms = ["osx-arm64", "osx-64", "linux-64"]
 
 # default environment
 [dependencies]
-rattler-build = ">=0.67.0, <0.68.0"
+rattler-build = ">=0.74.0, <0.76.0"
 curl = "*"
 
 ############################################
@@ -18,7 +18,7 @@ curl = "*"
 [feature.feature_rattler_build.dependencies]
 git = "*"
 patch = "*"
-rattler-build = ">=0.67.0,<0.68.0"
+rattler-build = ">=0.74.0, <0.76.0"
 python = "3.11.*"
 typer = "*"
 curl = "*"


### PR DESCRIPTION
- Previously minor version updates of `rattler-build` have broken the CI. And this can happen overnight when the bot automatically merges many PRs, which causes the builds to fail and none of those packages get uploaded.
- Pinning rattler-built to prevent that from happening again.
- The pinning can be easily updated as needed.