### PR TITLE
Add pygplates-experimental 1.1.0.dev10

### DIFF
--- a/recipes/recipes_emscripten/pygplates-experimental/build.sh
+++ b/recipes/recipes_emscripten/pygplates-experimental/build.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+emscripten_root=$(em-config EMSCRIPTEN_ROOT)
+toolchain_path="${emscripten_root}/cmake/Modules/Platform/Emscripten.cmake"
+
+PY_VER=$(${BUILD_PREFIX}/bin/python -c "import sys; print('{}.{}'.format(*sys.version_info[:2]))")
+PY_VER_MAJOR=${PY_VER%.*}
+PY_VER_MINOR=${PY_VER#*.}
+
+# Toolchain + find_package plumbing goes in CMAKE_ARGS (env-level).
+# CMAKE_FIND_ROOT_PATH_MODE_* = BOTH opens find_package() to look outside the
+# emscripten sysroot into the conda host prefix (ZLIB, CGAL, GDAL, PROJ, Qt6).
+export CMAKE_ARGS="${CMAKE_ARGS:-} \
+  -DCMAKE_TOOLCHAIN_FILE=${toolchain_path} \
+  -DCMAKE_PROJECT_INCLUDE=${RECIPE_DIR}/overwriteProp.cmake \
+  -DCMAKE_PREFIX_PATH=${PREFIX} \
+  -DCMAKE_FIND_ROOT_PATH=${PREFIX} \
+  -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+  -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH \
+  -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
+  -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=BOTH"
+
+# Bypass cross-python's ${PYTHON} wrapper: it hardcodes
+# os.environ['_PYTHON_SYSCONFIGDATA_NAME']=...emscripten... at import time, and
+# that wasm sysconfig contamination reaches CMake's FindPython3 probe.
+# GPLATES_SKIP_FIND_PYTHON3 (recipe patch 0001) bypasses the probe entirely;
+# we supply every Python3_* variable it would derive, from -D flags below.
+BUILD_PY="${BUILD_PREFIX}/venv/build/bin/python"
+
+# FindBoost runs its own find_library and doesn't reliably honor pre-set
+# Boost_<component>_LIBRARY hints. Fix by materializing correctly-named
+# libraries in a shim directory and pointing BOOST_LIBRARYDIR there:
+#   - Symlink every libboost_*.a from $PREFIX/lib (so filesystem, program_options,
+#     system, etc. resolve).
+#   - Rename libboost_python${PY}-${PY}.a to plain libboost_python${PY}.a
+#     (libboost-python's build tags with a double Python version suffix).
+#   - Provide an empty libboost_thread.a stub, since emscripten-forge's
+#     boost-cpp doesn't build boost::thread (no wasm threads). Symbol-level
+#     uses will surface as link errors and can be handled with a follow-up
+#     patch if pygplates goes beyond boost::thread's header-only bits.
+BOOST_SHIM="${SRC_DIR}/wasm_boost_shim"
+mkdir -p "${BOOST_SHIM}"
+for lib in "${PREFIX}"/lib/libboost_*.a; do
+  ln -sf "${lib}" "${BOOST_SHIM}/$(basename "${lib}")"
+done
+ln -sf "${PREFIX}/lib/libboost_python${PY_VER_MAJOR}${PY_VER_MINOR}-${PY_VER_MAJOR}${PY_VER_MINOR}.a" \
+       "${BOOST_SHIM}/libboost_python${PY_VER_MAJOR}${PY_VER_MINOR}.a"
+emar rcs "${BOOST_SHIM}/libboost_thread.a"
+emar rcs "${BOOST_SHIM}/libboost_atomic.a"
+
+env -u _PYTHON_SYSCONFIGDATA_NAME "${BUILD_PY}" -m pip install . \
+  --prefix="${PREFIX}" --no-deps --no-build-isolation -vv \
+  -Ccmake.define.EMSCRIPTEN=1 \
+  -Ccmake.define.GPLATES_BUILD_GPLATES=FALSE \
+  -Ccmake.define.GPLATES_INSTALL_STANDALONE_SHARED_LIBRARY_DEPENDENCIES=FALSE \
+  -Ccmake.define.GPLATES_SKIP_FIND_PYTHON3=TRUE \
+  -Ccmake.define.Boost_ROOT="${PREFIX}" \
+  -Ccmake.define.Boost_NO_BOOST_CMAKE=TRUE \
+  -Ccmake.define.Boost_NO_SYSTEM_PATHS=TRUE \
+  -Ccmake.define.CMAKE_POLICY_DEFAULT_CMP0167=OLD \
+  -Ccmake.define.QT_HOST_PATH="${BUILD_PREFIX}" \
+  -Ccmake.define.BOOST_LIBRARYDIR="${BOOST_SHIM}" \
+  -Ccmake.define.Boost_LIBRARY_DIRS="${BOOST_SHIM}" \
+  -Ccmake.define.Boost_LIBRARY_DIR_RELEASE="${BOOST_SHIM}" \
+  -Ccmake.define.BOOST_INCLUDEDIR="${PREFIX}/include" \
+  -Ccmake.define.Python3_EXECUTABLE="${BUILD_PY}" \
+  -Ccmake.define.Python3_INCLUDE_DIR="${PREFIX}/include/python${PY_VER}" \
+  -Ccmake.define.Python3_LIBRARY="${PREFIX}/lib/libpython${PY_VER}.a" \
+  -Ccmake.define.Python3_VERSION_MAJOR="${PY_VER_MAJOR}" \
+  -Ccmake.define.Python3_VERSION_MINOR="${PY_VER_MINOR}" \
+  -Ccmake.define.Python3_STDLIB="${PREFIX}/lib/python${PY_VER}" \
+  -Ccmake.define.Python3_NumPy_INCLUDE_DIR="${BUILD_PREFIX}/lib/python${PY_VER}/site-packages/numpy/_core/include"

--- a/recipes/recipes_emscripten/pygplates-experimental/overwriteProp.cmake
+++ b/recipes/recipes_emscripten/pygplates-experimental/overwriteProp.cmake
@@ -1,0 +1,32 @@
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
+# pygplates is add_library(... MODULE ...), which uses CMAKE_MODULE_LIBRARY_*
+# flags, not CMAKE_SHARED_LIBRARY_*. Set both so a plain SHARED target and
+# our MODULE python extension both get -sSIDE_MODULE=1 -sEXPORT_ALL=1 (needed
+# so PyInit_pygplates is exported to the loader).
+set(_EMFORGE_SIDE_MODULE_FLAGS "-s WASM_BIGINT -s SIDE_MODULE=1 -s EXPORT_ALL=1")
+set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${_EMFORGE_SIDE_MODULE_FLAGS}")
+set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${_EMFORGE_SIDE_MODULE_FLAGS}")
+set(CMAKE_MODULE_LIBRARY_CREATE_C_FLAGS "${_EMFORGE_SIDE_MODULE_FLAGS}")
+set(CMAKE_MODULE_LIBRARY_CREATE_CXX_FLAGS "${_EMFORGE_SIDE_MODULE_FLAGS}")
+set(CMAKE_STRIP FALSE)
+
+# Force module-mode FindBoost. Boost's shipped BoostConfig.cmake performs an
+# architecture check by inspecting the compiled .a files; it doesn't recognize
+# wasm bytecode and defaults to "looks 64-bit", rejecting our wasm32 static
+# libs with "libboost_*.a (64 bit, need 32)". FindBoost skips that check.
+# CMP0167=OLD keeps FindBoost usable under CMake 4+.
+set(Boost_NO_BOOST_CMAKE TRUE)
+set(Boost_USE_STATIC_LIBS TRUE)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 OLD)
+endif()
+
+# Qt6Core depends on WrapRt. Qt's FindWrapRt.cmake runs check_cxx_source_compiles
+# for clock_gettime/shm_open, which fail under the emscripten cross-toolchain
+# (link step doesn't produce a runnable native binary). The module has an
+# early-return path when the target already exists, so pre-create an empty
+# INTERFACE target: on emscripten, clock_gettime and shm_open live in libc,
+# no separate librt linkage is needed.
+if(NOT TARGET WrapRt::WrapRt)
+    add_library(WrapRt::WrapRt INTERFACE IMPORTED)
+endif()

--- a/recipes/recipes_emscripten/pygplates-experimental/patches/0001-Allow-skipping-find_package-Python3-for-cross-compil.patch
+++ b/recipes/recipes_emscripten/pygplates-experimental/patches/0001-Allow-skipping-find_package-Python3-for-cross-compil.patch
@@ -1,0 +1,125 @@
+From 5ce59176af3d957ef60dc3f9463467167a1d2b1c Mon Sep 17 00:00:00 2001
+From: Matthias Meschede <MMesch@users.noreply.github.com>
+Date: Fri, 4 Sep 2026 12:38:20 +0200
+Subject: [PATCH] Allow skipping find_package(Python3) for cross-compile builds
+
+CMake's FindPython3 module runs the interpreter and cross-references
+sys.platform against sysconfig.get_platform() and SOABI. If those
+don't agree - the normal case in a cross-compile where the interpreter
+is native but sysconfig has been redirected to a target-side
+sysconfigdata - FindPython3 rejects the interpreter and reports:
+
+    Could NOT find Python3 (missing: Interpreter) (found version "X.Y.Z")
+    Interpreter: Cannot run the interpreter "<path>"
+
+The message is misleading: the interpreter runs fine, its answers just
+don't cohere by FindPython3's assumption of a single self-consistent
+Python. Emscripten-forge's cross-python is one example - its wrapper
+exports _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata__emscripten_wasm32-...
+at process start, and any Python child inherits it - but the same class
+of failure appears in any cross-compile setup that swaps sysconfig for
+the target while keeping a native interpreter.
+
+Add GPLATES_SKIP_FIND_PYTHON3. When set, skip the find_package call and
+expect the caller to supply the Python discovery result via -D:
+
+    Python3_EXECUTABLE       - native interpreter used by execute_process
+    Python3_INCLUDE_DIR      - target Python headers
+    Python3_LIBRARY          - target libpython
+    Python3_VERSION_MAJOR    - major version (usually 3)
+    Python3_VERSION_MINOR    - minor version
+    Python3_NumPy_INCLUDE_DIR - target NumPy C-API headers (optional)
+
+The Python3::Module and Python3::Python IMPORTED targets that
+FindPython3 would create are synthesized manually so downstream
+target_link_libraries() calls keep working. Python3_add_library() (a
+helper defined by FindPython3, not a CMake builtin) is replaced with a
+plain add_library(... MODULE ...) plus a PREFIX="" property and a
+Python3::Module link - the same shape Python3_add_library produces.
+
+Only affects builds that opt in; find_package continues to run
+untouched for every other build.
+---
+ src/CMakeLists.txt | 59 ++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 54 insertions(+), 5 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 3db8c60..d5653e7 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -77,9 +77,49 @@ else()  # CMake < 3.18
+ 	set(GPLATES_PYTHON_DEVELOPMENT_COMPONENT_NAME Development)
+ endif()
+ 
+-# Note that we don't really need to specify the 'Interpreter' component but we do in case it makes 'Development' more robust.
+-# We also specify the optional component NumPy to get access to the numpy C-API header include directories.
+-find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS Interpreter ${GPLATES_PYTHON_DEVELOPMENT_COMPONENT_NAME} OPTIONAL_COMPONENTS NumPy)
++# Cross-compile escape hatch for FindPython3. FindPython3 rejects a native
++# interpreter whose sysconfig has been redirected to a target-side data file
++# (as most cross builds do), reporting the misleading "Cannot run the
++# interpreter". Rather than fight that check, opting into
++# GPLATES_SKIP_FIND_PYTHON3 bypasses find_package and takes every value the
++# caller supplies via -D at face value. Python3::Module and Python3::Python
++# are synthesized so downstream target_link_libraries() calls stay untouched.
++if (GPLATES_SKIP_FIND_PYTHON3)
++	foreach (_var IN ITEMS EXECUTABLE INCLUDE_DIR LIBRARY VERSION_MAJOR VERSION_MINOR)
++		if (NOT Python${_PYTHON_MAJOR_VER}_${_var})
++			message(FATAL_ERROR "GPLATES_SKIP_FIND_PYTHON3 requires -DPython${_PYTHON_MAJOR_VER}_${_var}=...")
++		endif()
++	endforeach()
++	set(Python${_PYTHON_MAJOR_VER}_FOUND TRUE)
++	set(Python${_PYTHON_MAJOR_VER}_Interpreter_FOUND TRUE)
++	set(Python${_PYTHON_MAJOR_VER}_Development_FOUND TRUE)
++	set(Python${_PYTHON_MAJOR_VER}_Development.Module_FOUND TRUE)
++	set(Python${_PYTHON_MAJOR_VER}_Development.Embed_FOUND TRUE)
++	set(Python${_PYTHON_MAJOR_VER}_INCLUDE_DIRS ${Python${_PYTHON_MAJOR_VER}_INCLUDE_DIR})
++	set(Python${_PYTHON_MAJOR_VER}_LIBRARIES ${Python${_PYTHON_MAJOR_VER}_LIBRARY})
++	if (Python${_PYTHON_MAJOR_VER}_NumPy_INCLUDE_DIR AND NOT Python${_PYTHON_MAJOR_VER}_NumPy_INCLUDE_DIRS)
++		set(Python${_PYTHON_MAJOR_VER}_NumPy_INCLUDE_DIRS ${Python${_PYTHON_MAJOR_VER}_NumPy_INCLUDE_DIR})
++	endif()
++	if (Python${_PYTHON_MAJOR_VER}_NumPy_INCLUDE_DIRS)
++		set(Python${_PYTHON_MAJOR_VER}_NumPy_FOUND TRUE)
++	endif()
++	# Synthesize the IMPORTED targets that FindPython3 would have created.
++	if (NOT TARGET Python${_PYTHON_MAJOR_VER}::Module)
++		add_library(Python${_PYTHON_MAJOR_VER}::Module INTERFACE IMPORTED)
++		set_target_properties(Python${_PYTHON_MAJOR_VER}::Module PROPERTIES
++			INTERFACE_INCLUDE_DIRECTORIES "${Python${_PYTHON_MAJOR_VER}_INCLUDE_DIR}")
++	endif()
++	if (NOT TARGET Python${_PYTHON_MAJOR_VER}::Python)
++		add_library(Python${_PYTHON_MAJOR_VER}::Python UNKNOWN IMPORTED)
++		set_target_properties(Python${_PYTHON_MAJOR_VER}::Python PROPERTIES
++			IMPORTED_LOCATION "${Python${_PYTHON_MAJOR_VER}_LIBRARY}"
++			INTERFACE_INCLUDE_DIRECTORIES "${Python${_PYTHON_MAJOR_VER}_INCLUDE_DIR}")
++	endif()
++else()
++	# Note that we don't really need to specify the 'Interpreter' component but we do in case it makes 'Development' more robust.
++	# We also specify the optional component NumPy to get access to the numpy C-API header include directories.
++	find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS Interpreter ${GPLATES_PYTHON_DEVELOPMENT_COMPONENT_NAME} OPTIONAL_COMPONENTS NumPy)
++endif()
+ 
+ # Get the Python major/minor versions.
+ set(GPLATES_PYTHON_VERSION_MAJOR ${Python${_PYTHON_MAJOR_VER}_VERSION_MAJOR})
+@@ -505,8 +545,17 @@ else()  # pygplates ...
+ 	#
+ 	# Note this is the external Python library that is not embedded inside GPlates.
+ 	if (GPLATES_PYTHON_3)
+-		# We used the Python3 find module.
+-		Python3_add_library(pygplates MODULE ScribeExportPyGPlates.cc)
++		if (GPLATES_SKIP_FIND_PYTHON3)
++			# Python3_add_library is a helper defined by FindPython3, unavailable
++			# when we skipped find_package. Reproduce its output shape: a MODULE
++			# target with no lib-prefix, linked against Python3::Module.
++			add_library(pygplates MODULE ScribeExportPyGPlates.cc)
++			set_target_properties(pygplates PROPERTIES PREFIX "")
++			target_link_libraries(pygplates PRIVATE Python3::Module)
++		else()
++			# We used the Python3 find module.
++			Python3_add_library(pygplates MODULE ScribeExportPyGPlates.cc)
++		endif()
+ 	else()  # Python2
+ 		# We used the Python2 find module.
+ 		Python2_add_library(pygplates MODULE ScribeExportPyGPlates.cc)
+-- 
+2.54.0
+

--- a/recipes/recipes_emscripten/pygplates-experimental/recipe.yaml
+++ b/recipes/recipes_emscripten/pygplates-experimental/recipe.yaml
@@ -1,0 +1,94 @@
+context:
+  name: pygplates
+  version: 1.1.0.dev10
+  # Snapshot of the 'feature/pygplates-drop-qt-gui' branch of GPlates/GPlates.
+  # That branch replaces the Qt5+Widgets+OpenGL+qwt+glew stack of pyGPlates 1.0
+  # with just Qt6 Core + Core5Compat, which is what makes an emscripten build
+  # tractable.
+  commit: bd6fea5b8cdd6e63f5fa14eff8e33e02788af01c
+
+package:
+  name: ${{ name }}-experimental
+  version: ${{ version }}
+
+source:
+  url: https://github.com/GPlates/GPlates/archive/${{ commit }}.tar.gz
+  sha256: 4978a9fdfda43736ca21371ce85fc04ea23de0171abf23980441aeba91a25b07
+  patches:
+  # Guards find_package(Python3) behind GPLATES_SKIP_FIND_PYTHON3, since
+  # FindPython3 fails under emscripten cross-compile when sys.platform and
+  # SOABI disagree.
+  - patches/0001-Allow-skipping-find_package-Python3-for-cross-compil.patch
+
+build:
+  number: 0
+  files:
+    exclude:
+    - '**/__pycache__/**'
+    - '**/*.pyc'
+    - '**/test_*.py'
+  python:
+    skip_pyc_compilation:
+    - '**/*.py'
+
+requirements:
+  build:
+  - ${{ compiler('cxx') }}
+  - cross-python_${{ target_platform }}
+  - python
+  - pip
+  - cmake >=3.22
+  - make
+  - scikit-build-core >=0.11.1
+  - numpy >=2.0
+  # Native Qt6 from conda-forge (resolver picks conda-forge version since
+  # emscripten-forge-4x has no linux-64 build). Provides moc/rcc/uic/qmake
+  # for cross-compile via QT_HOST_PATH.
+  - qt6-main
+  host:
+  - python
+  - numpy >=2.0
+  - libboost-python
+  - boost-cpp
+  - cgal-cpp
+  - gmp
+  - mpfr
+  - libgdal-core
+  - proj ==9.8.1
+  - qt6-main
+  - qt6-5compat
+  - zlib
+  run:
+  - python
+  - numpy
+  - libgdal-core
+  - proj ==9.8.1
+  - qt6-main
+  - qt6-5compat
+  - zlib
+  - gmp
+  - mpfr
+  - boost-cpp
+
+tests:
+- script: pytester
+  files:
+    recipe:
+    - test_pygplates.py
+  requirements:
+    build:
+    - pytester
+    run:
+    - pytester-run
+
+about:
+  homepage: https://www.gplates.org/
+  repository: https://github.com/GPlates/GPlates
+  license: GPL-2.0-only
+  license_file: COPYING
+  summary: Python library for fine-grained access to GPlates functionality (Emscripten build, GUI-less snapshot)
+
+extra:
+  maintainers:
+  - mmesch
+  channel: emscripten-forge-4x-experimental

--- a/recipes/recipes_emscripten/pygplates-experimental/test_pygplates.py
+++ b/recipes/recipes_emscripten/pygplates-experimental/test_pygplates.py
@@ -1,0 +1,83 @@
+"""Functional smoke tests for pygplates under emscripten/wasm.
+
+Exercises key primitives without needing external data files:
+  - version + import
+  - PointOnSphere geometry + lat/lon roundtrip
+  - MultiPointOnSphere
+  - Feature / FeatureCollection model
+  - Great-circle distance math
+
+Kept small enough to be a fast browser-side smoke test; more thorough
+coverage lives in pygplates' own upstream test suite.
+"""
+
+import math
+
+import pytest
+
+
+def test_import_and_version():
+    import pygplates
+    assert hasattr(pygplates, "__version__")
+    assert pygplates.__version__
+
+
+def test_point_on_sphere_lat_lon_roundtrip():
+    import pygplates
+    p = pygplates.PointOnSphere(45.0, 100.0)
+    lat, lon = p.to_lat_lon()
+    assert math.isclose(lat, 45.0, abs_tol=1e-9)
+    assert math.isclose(lon, 100.0, abs_tol=1e-9)
+
+
+def test_point_on_sphere_pole_and_equator():
+    import pygplates
+    north = pygplates.PointOnSphere(90.0, 0.0)
+    equator = pygplates.PointOnSphere(0.0, 0.0)
+    lat_n, _ = north.to_lat_lon()
+    lat_e, lon_e = equator.to_lat_lon()
+    assert math.isclose(lat_n, 90.0, abs_tol=1e-9)
+    assert math.isclose(lat_e, 0.0, abs_tol=1e-9)
+    assert math.isclose(lon_e, 0.0, abs_tol=1e-9)
+
+
+def test_multi_point_on_sphere():
+    import pygplates
+    pts = [
+        pygplates.PointOnSphere(0.0, 0.0),
+        pygplates.PointOnSphere(10.0, 20.0),
+        pygplates.PointOnSphere(-30.0, 45.0),
+    ]
+    mp = pygplates.MultiPointOnSphere(pts)
+    assert len(list(mp)) == 3
+
+
+def test_feature_geometry_roundtrip():
+    import pygplates
+    p = pygplates.PointOnSphere(10.0, 20.0)
+    feature = pygplates.Feature()
+    feature.set_geometry(p)
+    got = feature.get_geometry()
+    assert got is not None
+    lat, lon = got.to_lat_lon()
+    assert math.isclose(lat, 10.0, abs_tol=1e-9)
+    assert math.isclose(lon, 20.0, abs_tol=1e-9)
+
+
+def test_feature_collection_iteration():
+    import pygplates
+    features = [pygplates.Feature() for _ in range(3)]
+    for i, f in enumerate(features):
+        f.set_geometry(pygplates.PointOnSphere(float(i * 10), 0.0))
+    fc = pygplates.FeatureCollection(features)
+    collected = list(fc)
+    assert len(collected) == 3
+
+
+def test_great_circle_arc_length():
+    import pygplates
+    # Quarter-arc: equator (0, 0) to (0, 90) - should span pi/2 radians.
+    start = pygplates.PointOnSphere(0.0, 0.0)
+    end = pygplates.PointOnSphere(0.0, 90.0)
+    arc = pygplates.GreatCircleArc(start, end)
+    assert math.isclose(arc.get_arc_length(), math.pi / 2, rel_tol=1e-6)


### PR DESCRIPTION
Pinned to a snapshot of the feature/pygplates-drop-qt-gui branch of GPlates/GPlates (upstream commit bd6fea5b/https://github.com/GPlates/GPlates/pull/60), which strips the Qt5 + Widgets
+ OpenGL + qwt + glew stack from pygplates and leaves just Qt6 Core + Core5Compat. This minimal shape makes an emscripten build tractable.

Routes to the emscripten-forge-4x-experimental channel because the source pin is a non-standard development branch, not a released version.

## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [ ] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [ ] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates **>> pinned to commit for now**
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: pygplates
- **Version**: 1.1.0.dev10

## Build Notes

Build machinery notable bits:
- Patches src/CMakeLists.txt to bypass find_package(Python3) under cross-compile (FindPython3 rejects native interpreter + wasm sysconfig) and to synthesise Python3::Module / replace Python3_add_library.
- Uses conda-forge's native qt6-main in build deps for host tools (moc/rcc/uic) via QT_HOST_PATH.
- Boost shim directory renames libboost_python313-313.a to plain form FindBoost expects, and stubs libboost_thread.a + libboost_atomic.a (emscripten-forge boost-cpp doesn't build them - no wasm threads).
- Pre-creates WrapRt::WrapRt target so Qt6Core's dependency probe passes without running check_cxx_source_compiles under the emscripten toolchain.