### PR TITLE
add perl

### DIFF
--- a/recipes/recipes_emscripten/perl/0001-emscripten-no-fork-no-spawn-system.patch
+++ b/recipes/recipes_emscripten/perl/0001-emscripten-no-fork-no-spawn-system.patch
@@ -1,0 +1,41 @@
+diff --git a/pp_sys.c b/pp_sys.c
+index 78e3dd0..047c40c 100644
+--- a/pp_sys.c
++++ b/pp_sys.c
+@@ -4786,22 +4786,15 @@ PP_wrapped(pp_system, 0, 1)
+         PerlProc__exit(-1);
+     }
+ #else /* ! FORK or VMS or OS/2 */
++#if defined(WIN32) || defined(OS2) || defined(__VMS)
+     PL_statusvalue = 0;
+     result = 0;
+     if (PL_op->op_flags & OPf_STACKED) {
+         SV * const really = *++MARK;
+-#  if defined(WIN32) || defined(OS2) || defined(__VMS)
+         value = (I32)do_aspawn(really, MARK, SP);
+-#  else
+-        value = (I32)do_aspawn(really, (void **)MARK, (void **)SP);
+-#  endif
+     }
+     else if (SP - MARK != 1) {
+-#  if defined(WIN32) || defined(OS2) || defined(__VMS)
+         value = (I32)do_aspawn(NULL, MARK, SP);
+-#  else
+-        value = (I32)do_aspawn(NULL, (void **)MARK, (void **)SP);
+-#  endif
+     }
+     else {
+         value = (I32)do_spawn(SvPVx_nolen(sv_mortalcopy(*SP)));
+@@ -4811,6 +4804,12 @@ PP_wrapped(pp_system, 0, 1)
+     STATUS_NATIVE_CHILD_SET(value);
+     SP = ORIGMARK;
+     XPUSHi(result ? value : STATUS_CURRENT);
++#else
++    /* No fork(), and no Windows/OS2/VMS spawn() API either (e.g.
++     * Emscripten/wasm32): there is no way to run a child process at
++     * all, so system() cannot be implemented on this platform. */
++    DIE(aTHX_ PL_no_func, "system");
++#endif
+ #endif /* !FORK or VMS or OS/2 */
+ #endif
+     RETURN;

--- a/recipes/recipes_emscripten/perl/0002-emscripten-sigsuspend-not-here.patch
+++ b/recipes/recipes_emscripten/perl/0002-emscripten-sigsuspend-not-here.patch
@@ -1,0 +1,17 @@
+diff --git a/ext/POSIX/POSIX.xs b/ext/POSIX/POSIX.xs
+index 33381c2..7668670 100644
+--- a/ext/POSIX/POSIX.xs
++++ b/ext/POSIX/POSIX.xs
+@@ -3034,6 +3034,12 @@ sigpending(sigset)
+     CODE:
+ #ifdef __amigaos4__
+ 	RETVAL = not_here("sigpending");
++#elif defined(__EMSCRIPTEN__)
++	/* Emscripten's libc declares sigsuspend() but provides no
++	 * implementation for it (undefined symbol at link time).
++	 * sigpending() itself does link and work fine here, so only
++	 * the sigsuspend alias needs to raise at runtime instead. */
++	RETVAL = ix ? not_here("sigsuspend") : sigpending(sigset);
+ #else
+ 	RETVAL = ix ? sigsuspend(sigset) : sigpending(sigset);
+ #endif

--- a/recipes/recipes_emscripten/perl/build.sh
+++ b/recipes/recipes_emscripten/perl/build.sh
@@ -260,6 +260,12 @@ command -v "${RANLIB}"
 
 "${CC}" --version
 
+perl_lib="${PREFIX}/lib/perl5"
+perl_archlib="${perl_lib}/${PKG_VERSION%.*}"
+perl_core=/core_perl
+perl_site=/site_perl
+perl_vendor=/vendor_perl
+
 # Configure Perl for Emscripten
 
 emconfigure ./Configure \
@@ -269,6 +275,13 @@ emconfigure ./Configure \
     -Dhostperl="${HOST_DIR}/miniperl" \
     -Dhostgenerate="${HOST_DIR}/generate_uudmap" \
     -Dprefix="${PREFIX}" \
+    -Dvendorprefix="${PREFIX}" \
+    -Dprivlib="${perl_lib}${perl_core}" \
+    -Dsitelib="${perl_lib}${perl_site}" \
+    -Dvendorlib="${perl_lib}${perl_vendor}" \
+    -Darchlib="${perl_archlib}${perl_core}" \
+    -Dsitearch="${perl_archlib}${perl_site}" \
+    -Dvendorarch="${perl_archlib}${perl_vendor}" \
     -Dman1dir=none \
     -Dman3dir=none \
     -Duseshrplib=false \

--- a/recipes/recipes_emscripten/perl/build.sh
+++ b/recipes/recipes_emscripten/perl/build.sh
@@ -277,9 +277,8 @@ emconfigure ./Configure \
     -Dmyhostname=localhost \
     -Dmydomain=.local \
     -Dperladmin=root@localhost \
-    -Dlns=/bin/ln \
-    -Duse64bitint
-
+    -Dlns=/bin/ln 
+    
 # Build target Perl
 
 emmake make -j"${CPU_COUNT:-2}" perl

--- a/recipes/recipes_emscripten/perl/build.sh
+++ b/recipes/recipes_emscripten/perl/build.sh
@@ -1,0 +1,342 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "${SRC_DIR}"
+
+HOST_DIR="${BUILD_DIR}/host-tools"
+HOST_PREFIX="${BUILD_DIR}/host-install"
+INSTALL_DIR="${BUILD_DIR}/install"
+
+rm -rf \
+    "${HOST_DIR}" \
+    "${HOST_PREFIX}" \
+    "${INSTALL_DIR}"
+
+mkdir -p \
+    "${HOST_DIR}" \
+    "${HOST_PREFIX}" \
+    "${INSTALL_DIR}"
+
+# Native build toolchain
+
+HOST_CC="${CC_FOR_BUILD:-gcc}"
+HOST_CXX="${CXX_FOR_BUILD:-g++}"
+HOST_AR="${AR_FOR_BUILD:-ar}"
+HOST_RANLIB="${RANLIB_FOR_BUILD:-ranlib}"
+
+# Build native host Perl
+
+echo "==> Configuring native Perl"
+
+CC="${HOST_CC}" \
+CXX="${HOST_CXX}" \
+AR="${HOST_AR}" \
+RANLIB="${HOST_RANLIB}" \
+./Configure \
+    -des \
+    -Dprefix="${HOST_PREFIX}" \
+    -Dman1dir=none \
+    -Dman3dir=none \
+    -Duseshrplib=false \
+    -Dusemymalloc=n \
+    -Dmyhostname=localhost \
+    -Dmydomain=.local \
+    -Dperladmin=root@localhost
+
+CC="${HOST_CC}" \
+CXX="${HOST_CXX}" \
+AR="${HOST_AR}" \
+RANLIB="${HOST_RANLIB}" \
+make -j"${CPU_COUNT:-2}" miniperl generate_uudmap
+
+test -x miniperl
+test -x generate_uudmap
+
+# Preserve the native tools.
+# They must survive the distclean before the Emscripten build.
+
+cp miniperl "${HOST_DIR}/miniperl"
+cp generate_uudmap "${HOST_DIR}/generate_uudmap"
+
+chmod 755 \
+    "${HOST_DIR}/miniperl" \
+    "${HOST_DIR}/generate_uudmap"
+
+echo "==> Host Perl version"
+"${HOST_DIR}/miniperl" -e 'print "$^V\n"'
+
+# Clean the source tree before switching compilers
+
+make distclean
+
+# Create Emscripten hint file
+
+cat > hints/emscripten.sh <<'EOF'
+#!/bin/sh
+
+###############################################################################
+# Perl 5.44.0 / Emscripten / WebAssembly
+###############################################################################
+
+osname='emscripten'
+archname='wasm'
+osvers='emscripten'
+
+myhostname='localhost'
+mydomain='.local'
+perladmin='root@localhost'
+
+###############################################################################
+# Toolchain
+###############################################################################
+
+cc='emcc'
+ld='emcc'
+ar='emar'
+ranlib='emranlib'
+
+###############################################################################
+# Filesystem
+###############################################################################
+
+lns='/bin/ln'
+
+###############################################################################
+# Do not search host libraries.
+#
+# The target sysroot is passed explicitly from build.sh.
+###############################################################################
+
+loclibpth=''
+glibpth=''
+
+###############################################################################
+# Static Perl
+###############################################################################
+
+dynamic_ext=''
+usemymalloc='n'
+useshrplib='false'
+uselargefiles='n'
+
+###############################################################################
+# Skip the C library nm-symbol-scan.
+#
+# Configure's "Figure out where the libc is located" block (searching
+# glibpth/loclibpth, then falling back to an interactive "Where is your
+# C library?" prompt) is gated entirely on usenm being true. With
+# loclibpth/glibpth empty above, that search always fails, and under
+# -des (non-interactive) it loops on an empty default until it gives
+# up and aborts the whole build.
+#
+# There is nothing for that scan to find anyway: Emscripten's libc is
+# synthesized on demand by emcc (cached under ~/.emscripten_cache), not
+# a host libc.a for the host's nm to inspect. Disabling usenm skips the
+# scan entirely and falls back to trial compilation for symbol checks,
+# same as darwin.sh, interix.sh, dragonfly.sh, os390.sh, and other
+# hints for platforms without a conventional host-style libc.
+###############################################################################
+
+usenm='false'
+
+###############################################################################
+# WASM32
+###############################################################################
+
+selectminbits='32'
+alignbytes='4'
+
+###############################################################################
+# Dynamic loading is unavailable in the browser runtime.
+###############################################################################
+
+dlsrc='none'
+d_dlopen='undef'
+
+###############################################################################
+# Unix process APIs unavailable in browser WASM.
+###############################################################################
+
+d_fork='undef'
+d_vfork='undef'
+d_waitpid='undef'
+d_wait4='undef'
+d_pseudofork='undef'
+
+d_procselfexe='undef'
+d_setproctitle='undef'
+
+d_setruid='undef'
+d_setrgid='undef'
+d_seteuid='undef'
+d_setegid='undef'
+
+###############################################################################
+# No pthreads for the baseline WebPerl build.
+###############################################################################
+
+i_pthread='undef'
+d_pthread_atfork='undef'
+d_pthread_yield='undef'
+d_pthread_attr_setscope='undef'
+
+###############################################################################
+# Miscellaneous unavailable libc APIs.
+###############################################################################
+
+d_malloc_size='undef'
+d_malloc_good_size='undef'
+d_fdclose='undef'
+d_shm='undef'
+
+###############################################################################
+# Compiler flags
+###############################################################################
+
+ccflags="$ccflags -D_GNU_SOURCE"
+ccflags="$ccflags -D_POSIX_C_SOURCE=200809L"
+ccflags="$ccflags -DNO_MATHOMS"
+ccflags="$ccflags -fno-strict-aliasing"
+
+###############################################################################
+# Silence -Wimplicit-void-ptr-cast.
+#
+# Newer Clang (as bundled by this Emscripten release) warns on ordinary,
+# valid C idioms like "return NULL;" from a typed-pointer function,
+# because that implicit void*-to-T* conversion would be illegal in C++.
+# This is a portability note, not a bug in Perl's C sources, but at
+# hundreds of hits per file it drowns out real errors in the build log.
+###############################################################################
+
+ccflags="$ccflags -Wno-implicit-void-ptr-cast"
+
+cppflags="$cppflags -D_GNU_SOURCE"
+cppflags="$cppflags -D_POSIX_C_SOURCE=200809L"
+cppflags="$cppflags -DNO_MATHOMS"
+cppflags="$cppflags -fno-strict-aliasing"
+
+###############################################################################
+# Linker flags
+#
+# Keep these minimal while getting Perl 5.44 cross compilation working.
+###############################################################################
+
+ldflags="$ldflags -O2"
+
+libs="$libs -lm"
+EOF
+
+chmod 644 hints/emscripten.sh
+
+export CC=emcc
+export CXX=em++
+export AR=emar
+export RANLIB=emranlib
+
+# Locate the actual Emscripten installation.
+
+if [ -n "${EMSCRIPTEN:-}" ]; then
+    EMSCRIPTEN_ROOT="${EMSCRIPTEN}"
+else
+    EMSCRIPTEN_ROOT="${BUILD_PREFIX}/opt/emsdk/upstream/emscripten"
+fi
+
+export EMSCRIPTEN="${EMSCRIPTEN_ROOT}"
+
+EMSCRIPTEN_SYSROOT="${EMSCRIPTEN_ROOT}/system"
+
+test -d "${EMSCRIPTEN_ROOT}"
+test -d "${EMSCRIPTEN_SYSROOT}"
+
+echo "==> Emscripten root: ${EMSCRIPTEN_ROOT}"
+echo "==> Emscripten sysroot: ${EMSCRIPTEN_SYSROOT}"
+
+echo "==> Emscripten toolchain"
+
+command -v "${CC}"
+command -v "${CXX}"
+command -v "${AR}"
+command -v "${RANLIB}"
+
+"${CC}" --version
+
+# Configure Perl for Emscripten
+
+emconfigure ./Configure \
+    -des \
+    -Dhintfile=emscripten \
+    -Dsysroot="${EMSCRIPTEN_SYSROOT}" \
+    -Dhostperl="${HOST_DIR}/miniperl" \
+    -Dhostgenerate="${HOST_DIR}/generate_uudmap" \
+    -Dprefix="${PREFIX}" \
+    -Dman1dir=none \
+    -Dman3dir=none \
+    -Duseshrplib=false \
+    -Dusemymalloc=n \
+    -Duselargefiles=n \
+    -Dmyhostname=localhost \
+    -Dmydomain=.local \
+    -Dperladmin=root@localhost \
+    -Dlns=/bin/ln \
+    -Duse64bitint
+
+# Build target Perl
+
+emmake make -j"${CPU_COUNT:-2}" perl
+
+test -f perl
+chmod 755 perl
+
+# Install using the native host miniperl
+
+"${HOST_DIR}/miniperl" \
+    installperl \
+    "--destdir=${INSTALL_DIR}"
+
+# Install Perl libraries
+
+if [ -d "${INSTALL_DIR}${PREFIX}/lib" ]; then
+    mkdir -p "${PREFIX}/lib"
+
+    cp -a \
+        "${INSTALL_DIR}${PREFIX}/lib/." \
+        "${PREFIX}/lib/"
+fi
+
+# Install Emscripten executable
+
+mkdir -p "${PREFIX}/bin"
+
+if [ -f perl.js ]; then
+    install -Dm755 \
+        perl.js \
+        "${PREFIX}/bin/perl.js"
+
+    install -Dm755 \
+        perl.js \
+        "${PREFIX}/bin/perl"
+else
+    install -Dm755 \
+        perl \
+        "${PREFIX}/bin/perl"
+fi
+
+if [ -f perl.wasm ]; then
+    install -Dm644 \
+        perl.wasm \
+        "${PREFIX}/bin/perl.wasm"
+fi
+
+# Licenses
+
+LICENSE_DIR="${PREFIX}/share/licenses/${PKG_NAME}"
+
+mkdir -p "${LICENSE_DIR}"
+
+install -Dm644 \
+    "${SRC_DIR}/Artistic" \
+    "${LICENSE_DIR}/Artistic"
+
+install -Dm644 \
+    "${SRC_DIR}/Copying" \
+    "${LICENSE_DIR}/Copying"

--- a/recipes/recipes_emscripten/perl/recipe.yaml
+++ b/recipes/recipes_emscripten/perl/recipe.yaml
@@ -38,9 +38,6 @@ tests:
     files:
     - bin/perl.wasm
     - bin/perl
-    - lib/perl5/core_perl
-    - lib/perl5/site_perl
-    - lib/perl5/vendor_perl
 
 about:
   homepage: https://www.perl.org/

--- a/recipes/recipes_emscripten/perl/recipe.yaml
+++ b/recipes/recipes_emscripten/perl/recipe.yaml
@@ -1,0 +1,48 @@
+context:
+  name: perl
+  version: "5.44.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://www.cpan.org/src/5.0/perl-${{ version }}.tar.gz
+  sha256: 3b855066b92491cb40e86affb1ca57d1a388aa43e51b91c7806a32c2f65f96c3
+  patches:
+    - 0001-emscripten-no-fork-no-spawn-system.patch
+    - 0002-emscripten-sigsuspend-not-here.patch
+
+build:
+  number: 0
+  script: build.sh
+
+requirements:
+  build:
+    - autoconf
+    - automake
+    - libtool
+    - make
+    - patch
+    - pkg-config
+    - autoconf-archive
+    - perl
+    - ${{ compiler("c") }}
+    - ${{ compiler('cxx') }}
+    - nodejs
+
+tests:
+- package_contents:
+    files:
+    - bin/perl.wasm
+    - bin/perl
+
+about:
+  homepage: https://www.perl.org/
+  license: GPL-1.0-or-later
+  license_file: Copying
+  summary: Perl is a highly capable, feature-rich programming language with over 38 years of development.
+
+extra:
+  recipe-maintainers:
+    - wangyenshu

--- a/recipes/recipes_emscripten/perl/recipe.yaml
+++ b/recipes/recipes_emscripten/perl/recipe.yaml
@@ -27,6 +27,8 @@ requirements:
     - pkg-config
     - autoconf-archive
     - perl
+    - gcc
+    - gxx
     - ${{ compiler("c") }}
     - ${{ compiler('cxx') }}
     - nodejs
@@ -36,6 +38,9 @@ tests:
     files:
     - bin/perl.wasm
     - bin/perl
+    - lib/perl5/core_perl
+    - lib/perl5/site_perl
+    - lib/perl5/vendor_perl
 
 about:
   homepage: https://www.perl.org/


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: perl
- **Version**: 5.44.0

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

