### PR TITLE
add gfan

### DIFF
--- a/recipes/recipes_emscripten/gfan/build.sh
+++ b/recipes/recipes_emscripten/gfan/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euxo pipefail
+
+sed -i \
+    -e 's/-march=native//g' \
+    -e 's/-finline-limit=1000//g' \
+    -e 's/-fno-guess-branch-probability//g' \
+    Makefile
+
+sed -i \
+    "s|-DGMPRATIONAL|-DGMPRATIONAL -I${PREFIX}/include -I${PREFIX}/include/cddlib|g" \
+    Makefile
+
+sed -i \
+    "s|-L/usr/local -lcddgmp|-L${PREFIX}/lib -lcddgmp|" \
+    Makefile
+
+sed -i \
+    -e 's|#include "cdd/setoper\.h"|#include "cddlib/setoper.h"|' \
+    -e 's|#include "cdd/cdd_f\.h"|#include "cddlib/cdd_f.h"|' \
+    -e 's|#include "cdd/cdd\.h"|#include "cddlib/cdd.h"|' \
+    src/lp_cdd.cpp src/gfanlib_zcone.cpp src/app_librarytest.cpp
+
+# emscripten's libc does not provide the non-standard BSD
+# u_intNN_t typedefs that src/packedmonomial.h uses -- only the standard
+# uintNN_t from <stdint.h> exist there. Normalize to the standard names.
+sed -i \
+    -e 's/u_int64_t/uint64_t/g' \
+    -e 's/u_int16_t/uint16_t/g' \
+    src/packedmonomial.h
+
+grep -rlE 'std::execution::(par|par_unseq|seq|unseq)' src/ \
+    | xargs -r sed -i -E 's/std::execution::(par|par_unseq|seq|unseq)[[:space:]]*,[[:space:]]*//g'
+
+export LDFLAGS="${LDFLAGS:-} -L${PREFIX}/lib"
+
+grep -nE 'GMPRATIONAL|march=native|inline-limit|CXXFLAGS' Makefile
+
+emmake make \
+    CXX="${CXX}" \
+    CC="${CC}" \
+    LDFLAGS="${LDFLAGS}" \
+    -j"${CPU_COUNT}"
+
+mkdir -p "${PREFIX}/bin"
+
+cp gfan "${PREFIX}/bin/gfan"
+cp gfan.wasm "${PREFIX}/bin/gfan.wasm"

--- a/recipes/recipes_emscripten/gfan/recipe.yaml
+++ b/recipes/recipes_emscripten/gfan/recipe.yaml
@@ -29,10 +29,10 @@ requirements:
     - onetbb
 
 tests:
-  - package_contents:
-      bin:
-        - gfan
-        - gfan.wasm
+- package_contents:
+    files:
+    - bin/gfan
+    - bin/gfan.wasm
 
 about:
   homepage: https://users-math.au.dk/jensen/software/gfan/gfan.html

--- a/recipes/recipes_emscripten/gfan/recipe.yaml
+++ b/recipes/recipes_emscripten/gfan/recipe.yaml
@@ -1,0 +1,45 @@
+context:
+  name: gfan
+  version: "0.8beta"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://users-math.au.dk/jensen/software/gfan/gfan${{ version }}.tar.gz
+  sha256: fa7884e5f317c50f8fb4f37bcf5d419f0fd5f7b90d6037349d1957ea73cebbee
+
+build:
+  number: 0
+
+requirements:
+  build:
+  - autoconf
+  - automake
+  - libtool
+  - make
+  - ${{ compiler("c") }}
+  - ${{ compiler('cxx') }}
+  - pkg-config
+  - autoconf-archive
+  host:
+    - gmp
+    - cddlib
+    - onetbb
+
+tests:
+  - package_contents:
+      bin:
+        - gfan
+        - gfan.wasm
+
+about:
+  homepage: https://users-math.au.dk/jensen/software/gfan/gfan.html
+  license: GPL-2.0-or-later
+  license_file: COPYING
+  summary: Gfan is a software package for computing Gröbner fans and tropical varieties.
+
+extra:
+  recipe-maintainers:
+    - wangyenshu


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

<!-- If you have a noarch package, we suggest submitting your recipe to https://github.com/conda-forge/staged-recipes/ instead. -->

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

---

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: gfan
- **Version**: 0.8beta

## Build Notes
<!-- Any special build considerations, patches applied, or issues encountered -->

