### PR TITLE
libgdal-core: fix unresolved symbols; add tests; link geos and proj dynamically

### DIFF
--- a/recipes/recipes_emscripten/libgdal-core/build.sh
+++ b/recipes/recipes_emscripten/libgdal-core/build.sh
@@ -52,7 +52,7 @@ cd build && emcmake cmake .. \
 \
 -DGDAL_USE_GEOS=ON \
 -DGEOS_INCLUDE_DIR=$PREFIX/include \
--DGEOS_LIBRARY=$PREFIX/lib/libgeos_c.a \
+-DGEOS_LIBRARY=$PREFIX/lib/libgeos_c.so \
 \
 -DGDAL_USE_ZLIB=ON \
 -DZLIB_INCLUDE_DIR=$EMSCRIPTEN_INCLUDE \

--- a/recipes/recipes_emscripten/libgdal-core/build.sh
+++ b/recipes/recipes_emscripten/libgdal-core/build.sh
@@ -40,7 +40,7 @@ cd build && emcmake cmake .. \
 -DGDAL_USE_INTERNAL_LIBS=OFF \
 \
 -DPROJ_INCLUDE_DIR=$PREFIX/include \
--DPROJ_LIBRARY=$PREFIX/lib/libproj.a \
+-DPROJ_LIBRARY=$PREFIX/lib/libproj.so \
 \
 -DGDAL_USE_ICONV=ON \
 -DIconv_INCLUDE_DIR=$PREFIX/include \

--- a/recipes/recipes_emscripten/libgdal-core/build_tests.sh
+++ b/recipes/recipes_emscripten/libgdal-core/build_tests.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/_build_tests"
+
+rm -rf "$BUILD_DIR"
+
+emcmake cmake \
+    -S "$SCRIPT_DIR/tests" \
+    -B "$BUILD_DIR" \
+    -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="${PREFIX}"
+
+ninja -C "$BUILD_DIR"
+
+echo "=== Running test ==="
+set +e
+(cd "$BUILD_DIR" && node test_libgdal.js) > "$BUILD_DIR/test_output.txt" 2>&1
+NODE_EXIT=$?
+echo "=== Test output ==="
+cat "$BUILD_DIR/test_output.txt"
+echo "=== Test end (exit=$NODE_EXIT) ==="
+
+if grep -q "All tests passed" "$BUILD_DIR/test_output.txt"; then
+    echo "Test PASSED"
+    exit 0
+fi
+
+echo "Test FAILED (node exit=$NODE_EXIT)"
+exit 1

--- a/recipes/recipes_emscripten/libgdal-core/build_tests.sh
+++ b/recipes/recipes_emscripten/libgdal-core/build_tests.sh
@@ -15,6 +15,12 @@ emcmake cmake \
 
 ninja -C "$BUILD_DIR"
 
+# Emscripten's Node loader resolves NEEDED dylibs relative to the JS file's
+# __dirname, so make the shared libraries visible there.
+ln -sf "${PREFIX}/lib/libgdal.so" "$BUILD_DIR/libgdal.so"
+ln -sf "${PREFIX}/lib/libgeos_c.so" "$BUILD_DIR/libgeos_c.so"
+ln -sf "${PREFIX}/lib"/libgeos.so* "$BUILD_DIR/"
+
 echo "=== Running test ==="
 set +e
 (cd "$BUILD_DIR" && node test_libgdal.js) > "$BUILD_DIR/test_output.txt" 2>&1

--- a/recipes/recipes_emscripten/libgdal-core/build_tests.sh
+++ b/recipes/recipes_emscripten/libgdal-core/build_tests.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BUILD_DIR="$SCRIPT_DIR/_build_tests"
+BUILD_DIR="$SRC_DIR/_build_tests"
+INSTALL_DIR="${PREFIX}/share/libgdal-core-tests"
 
 rm -rf "$BUILD_DIR"
 
 emcmake cmake \
-    -S "$SCRIPT_DIR/tests" \
+    -S "$RECIPE_DIR/tests" \
     -B "$BUILD_DIR" \
     -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
@@ -15,24 +15,5 @@ emcmake cmake \
 
 ninja -C "$BUILD_DIR"
 
-# Emscripten's Node loader resolves NEEDED dylibs relative to the JS file's
-# __dirname, so make the shared libraries visible there.
-ln -sf "${PREFIX}/lib/libgdal.so" "$BUILD_DIR/libgdal.so"
-ln -sf "${PREFIX}/lib/libgeos_c.so" "$BUILD_DIR/libgeos_c.so"
-ln -sf "${PREFIX}/lib"/libgeos.so* "$BUILD_DIR/"
-
-echo "=== Running test ==="
-set +e
-(cd "$BUILD_DIR" && node test_libgdal.js) > "$BUILD_DIR/test_output.txt" 2>&1
-NODE_EXIT=$?
-echo "=== Test output ==="
-cat "$BUILD_DIR/test_output.txt"
-echo "=== Test end (exit=$NODE_EXIT) ==="
-
-if grep -q "All tests passed" "$BUILD_DIR/test_output.txt"; then
-    echo "Test PASSED"
-    exit 0
-fi
-
-echo "Test FAILED (node exit=$NODE_EXIT)"
-exit 1
+mkdir -p "$INSTALL_DIR"
+cp "$BUILD_DIR/test_libgdal.js" "$BUILD_DIR/test_libgdal.wasm" "$INSTALL_DIR/"

--- a/recipes/recipes_emscripten/libgdal-core/recipe.yaml
+++ b/recipes/recipes_emscripten/libgdal-core/recipe.yaml
@@ -9,7 +9,7 @@ source:
   - patches/0001-Add-CPL_CPUID-guards.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
 - package:
@@ -26,12 +26,23 @@ outputs:
     - libtiff
     - proj-static
     - libiconv
-    - geos-static
+    - geos
     - libpng
   tests:
   - package_contents:
       files:
       - lib/libgdal.so
+  - script:
+    - build_tests.sh
+    requirements:
+      build:
+      - ${{ compiler('c') }}
+      - cmake
+      - ninja
+    files:
+      recipe:
+      - build_tests.sh
+      - tests/
 
 - package:
     name: ${{ name }}-static

--- a/recipes/recipes_emscripten/libgdal-core/recipe.yaml
+++ b/recipes/recipes_emscripten/libgdal-core/recipe.yaml
@@ -24,7 +24,7 @@ outputs:
     - pkg-config
     host:
     - libtiff
-    - proj-static
+    - proj >=9.8
     - libiconv
     - geos
     - libpng
@@ -32,19 +32,31 @@ outputs:
   - package_contents:
       files:
       - lib/libgdal.so
+
+- package:
+    name: ${{ name }}-tests
+    version: ${{ version }}
+  build:
+    script: build_tests.sh
+  requirements:
+    build:
+    - ${{ compiler('c') }}
+    - cmake
+    - ninja
+    host:
+    - ${{ pin_subpackage(name, exact=True) }}
+    - geos
+    - proj >=9.8
+    run:
+    - ${{ pin_subpackage(name, exact=True) }}
+    - geos
+    - proj >=9.8
+  tests:
   - script:
-    - build_tests.sh
-    requirements:
-      build:
-      - ${{ compiler('c') }}
-      - cmake
-      - ninja
-      run:
-      - geos
+    - run_tests.sh
     files:
       recipe:
-      - build_tests.sh
-      - tests/
+      - run_tests.sh
 
 - package:
     name: ${{ name }}-static

--- a/recipes/recipes_emscripten/libgdal-core/recipe.yaml
+++ b/recipes/recipes_emscripten/libgdal-core/recipe.yaml
@@ -39,6 +39,8 @@ outputs:
       - ${{ compiler('c') }}
       - cmake
       - ninja
+      run:
+      - geos
     files:
       recipe:
       - build_tests.sh
@@ -74,3 +76,4 @@ extra:
   recipe-maintainers:
   - DerThorsten
   - IsabelParedes
+  - mmesch

--- a/recipes/recipes_emscripten/libgdal-core/run_tests.sh
+++ b/recipes/recipes_emscripten/libgdal-core/run_tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+INSTALL_DIR="${PREFIX}/share/libgdal-core-tests"
+
+# Emscripten's Node loader resolves NEEDED dylibs relative to the JS file's
+# __dirname, so make the shared libraries visible there.
+ln -sf "${PREFIX}/lib/libgdal.so" "$INSTALL_DIR/libgdal.so"
+ln -sf "${PREFIX}/lib/libgeos_c.so" "$INSTALL_DIR/libgeos_c.so"
+ln -sf "${PREFIX}/lib"/libgeos.so* "$INSTALL_DIR/"
+ln -sf "${PREFIX}/lib"/libproj.so* "$INSTALL_DIR/"
+
+echo "=== Running test ==="
+set +e
+(cd "$INSTALL_DIR" && PROJ_DATA_HOST="${PREFIX}/share/proj" node test_libgdal.js) > "$INSTALL_DIR/test_output.txt" 2>&1
+NODE_EXIT=$?
+echo "=== Test output ==="
+cat "$INSTALL_DIR/test_output.txt"
+echo "=== Test end (exit=$NODE_EXIT) ==="
+
+if grep -q "All tests passed" "$INSTALL_DIR/test_output.txt"; then
+    echo "Test PASSED"
+    exit 0
+fi
+
+echo "Test FAILED (node exit=$NODE_EXIT)"
+exit 1

--- a/recipes/recipes_emscripten/libgdal-core/tests/CMakeLists.txt
+++ b/recipes/recipes_emscripten/libgdal-core/tests/CMakeLists.txt
@@ -28,7 +28,10 @@ target_link_options(test_libgdal PRIVATE
     -sWASM_BIGINT
     -sEXIT_RUNTIME=1
     -sERROR_ON_UNDEFINED_SYMBOLS=0
+    -sFORCE_FILESYSTEM=1
+    -lnodefs.js
     -sNODEJS_CATCH_EXIT=0
     -sNODEJS_CATCH_REJECTION=0
+    --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/pre.js
 )
 set_target_properties(test_libgdal PROPERTIES SUFFIX ".js")

--- a/recipes/recipes_emscripten/libgdal-core/tests/CMakeLists.txt
+++ b/recipes/recipes_emscripten/libgdal-core/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.18)
+project(test_libgdal C)
+
+find_library(GDAL_LIBRARY gdal
+    PATHS "${CMAKE_PREFIX_PATH}/lib" "$ENV{PREFIX}/lib"
+    NO_DEFAULT_PATH)
+find_path(GDAL_INCLUDE_DIR gdal.h
+    PATHS "${CMAKE_PREFIX_PATH}/include" "$ENV{PREFIX}/include"
+    NO_DEFAULT_PATH)
+
+if(NOT GDAL_LIBRARY OR NOT GDAL_INCLUDE_DIR)
+    message(FATAL_ERROR "Could not find GDAL library or headers")
+endif()
+
+add_executable(test_libgdal test_libgdal.c)
+target_include_directories(test_libgdal PRIVATE ${GDAL_INCLUDE_DIR})
+target_link_libraries(test_libgdal PRIVATE ${GDAL_LIBRARY})
+target_link_options(test_libgdal PRIVATE
+    -sMAIN_MODULE=1
+    -sWASM_BIGINT
+    -sEXIT_RUNTIME=1
+    -sNODEJS_CATCH_EXIT=0
+    -sNODEJS_CATCH_REJECTION=0
+)
+set_target_properties(test_libgdal PROPERTIES SUFFIX ".js")

--- a/recipes/recipes_emscripten/libgdal-core/tests/CMakeLists.txt
+++ b/recipes/recipes_emscripten/libgdal-core/tests/CMakeLists.txt
@@ -1,24 +1,33 @@
 cmake_minimum_required(VERSION 3.18)
 project(test_libgdal C)
 
-find_library(GDAL_LIBRARY gdal
-    PATHS "${CMAKE_PREFIX_PATH}/lib" "$ENV{PREFIX}/lib"
-    NO_DEFAULT_PATH)
-find_path(GDAL_INCLUDE_DIR gdal.h
-    PATHS "${CMAKE_PREFIX_PATH}/include" "$ENV{PREFIX}/include"
-    NO_DEFAULT_PATH)
+set(GDAL_PREFIX "$ENV{PREFIX}")
+set(GDAL_LIBRARY "${GDAL_PREFIX}/lib/libgdal.so")
+set(GDAL_INCLUDE_DIR "${GDAL_PREFIX}/include")
 
-if(NOT GDAL_LIBRARY OR NOT GDAL_INCLUDE_DIR)
-    message(FATAL_ERROR "Could not find GDAL library or headers")
+if(NOT EXISTS "${GDAL_LIBRARY}")
+    message(FATAL_ERROR "GDAL library not found at ${GDAL_LIBRARY}")
+endif()
+if(NOT EXISTS "${GDAL_INCLUDE_DIR}/gdal.h")
+    message(FATAL_ERROR "gdal.h not found at ${GDAL_INCLUDE_DIR}")
 endif()
 
 add_executable(test_libgdal test_libgdal.c)
 target_include_directories(test_libgdal PRIVATE ${GDAL_INCLUDE_DIR})
+target_link_directories(test_libgdal PRIVATE ${GDAL_PREFIX}/lib)
 target_link_libraries(test_libgdal PRIVATE ${GDAL_LIBRARY})
+target_compile_options(test_libgdal PRIVATE
+    -fwasm-exceptions
+    -sSUPPORT_LONGJMP=wasm
+)
 target_link_options(test_libgdal PRIVATE
+    -fwasm-exceptions
+    -sSUPPORT_LONGJMP=wasm
+    -L${GDAL_PREFIX}/lib
     -sMAIN_MODULE=1
     -sWASM_BIGINT
     -sEXIT_RUNTIME=1
+    -sERROR_ON_UNDEFINED_SYMBOLS=0
     -sNODEJS_CATCH_EXIT=0
     -sNODEJS_CATCH_REJECTION=0
 )

--- a/recipes/recipes_emscripten/libgdal-core/tests/pre.js
+++ b/recipes/recipes_emscripten/libgdal-core/tests/pre.js
@@ -1,0 +1,13 @@
+// Mount the host proj data dir (containing proj.db) into the wasm virtual FS
+// and point PROJ_DATA at it. Only meaningful under the Node backend.
+Module['preRun'] = (Module['preRun'] || []).concat([function () {
+  var host = (typeof process !== 'undefined' && process.env && process.env.PROJ_DATA_HOST);
+  if (!host) return;
+  try {
+    FS.mkdirTree('/proj');
+    FS.mount(NODEFS, { root: host }, '/proj');
+    ENV['PROJ_DATA'] = '/proj';
+  } catch (e) {
+    console.error('failed to mount PROJ_DATA_HOST=' + host + ': ' + e);
+  }
+}]);

--- a/recipes/recipes_emscripten/libgdal-core/tests/test_libgdal.c
+++ b/recipes/recipes_emscripten/libgdal-core/tests/test_libgdal.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <string.h>
+#include <gdal.h>
+#include <ogr_api.h>
+#include <ogr_srs_api.h>
+
+#define CHECK(cond, msg) \
+    do { \
+        if (!(cond)) { \
+            fprintf(stderr, "FAIL: %s\n", msg); \
+            return 1; \
+        } \
+    } while (0)
+
+int main(void) {
+    const char *version = GDALVersionInfo("RELEASE_NAME");
+    printf("GDAL version: %s\n", version ? version : "(null)");
+    CHECK(version && strncmp(version, "3.", 2) == 0, "GDALVersionInfo did not return a 3.x string");
+
+    GDALAllRegister();
+    int driver_count = GDALGetDriverCount();
+    printf("GDAL driver count: %d\n", driver_count);
+    CHECK(driver_count > 0, "no GDAL drivers registered");
+
+    char *wkt_a = "POLYGON((0 0,2 0,2 2,0 2,0 0))";
+    char *wkt_b = "POLYGON((1 1,3 1,3 3,1 3,1 1))";
+    OGRGeometryH g_a = NULL;
+    OGRGeometryH g_b = NULL;
+    OGRErr err;
+
+    err = OGR_G_CreateFromWkt(&wkt_a, NULL, &g_a);
+    CHECK(err == OGRERR_NONE && g_a, "OGR_G_CreateFromWkt failed for g_a");
+    err = OGR_G_CreateFromWkt(&wkt_b, NULL, &g_b);
+    CHECK(err == OGRERR_NONE && g_b, "OGR_G_CreateFromWkt failed for g_b");
+
+    OGRGeometryH intersection = OGR_G_Intersection(g_a, g_b);
+    CHECK(intersection, "OGR_G_Intersection returned NULL (GEOS link broken?)");
+
+    double area = OGR_G_Area(intersection);
+    printf("intersection area: %f\n", area);
+    CHECK(area > 0.99 && area < 1.01, "OGR_G_Intersection area is wrong");
+
+    OGR_G_DestroyGeometry(intersection);
+    OGR_G_DestroyGeometry(g_b);
+    OGR_G_DestroyGeometry(g_a);
+
+    printf("All tests passed\n");
+    return 0;
+}

--- a/recipes/recipes_emscripten/libgdal-core/tests/test_libgdal.c
+++ b/recipes/recipes_emscripten/libgdal-core/tests/test_libgdal.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <gdal.h>
@@ -7,43 +8,95 @@
 #define CHECK(cond, msg) \
     do { \
         if (!(cond)) { \
-            fprintf(stderr, "FAIL: %s\n", msg); \
+            fprintf(stderr, "  FAIL: %s\n", msg); \
             return 1; \
         } \
     } while (0)
 
-int main(void) {
+static int test_gdal_basics(void) {
     const char *version = GDALVersionInfo("RELEASE_NAME");
-    printf("GDAL version: %s\n", version ? version : "(null)");
+    printf("  GDAL version: %s\n", version ? version : "(null)");
     CHECK(version && strncmp(version, "3.", 2) == 0, "GDALVersionInfo did not return a 3.x string");
 
     GDALAllRegister();
     int driver_count = GDALGetDriverCount();
-    printf("GDAL driver count: %d\n", driver_count);
+    printf("  GDAL driver count: %d\n", driver_count);
     CHECK(driver_count > 0, "no GDAL drivers registered");
+    return 0;
+}
 
+/* Exercises the libgeos_c.so link: OGR_G_Intersection dispatches into GEOS. */
+static int test_geos_intersection(void) {
     char *wkt_a = "POLYGON((0 0,2 0,2 2,0 2,0 0))";
     char *wkt_b = "POLYGON((1 1,3 1,3 3,1 3,1 1))";
     OGRGeometryH g_a = NULL;
     OGRGeometryH g_b = NULL;
-    OGRErr err;
 
-    err = OGR_G_CreateFromWkt(&wkt_a, NULL, &g_a);
-    CHECK(err == OGRERR_NONE && g_a, "OGR_G_CreateFromWkt failed for g_a");
-    err = OGR_G_CreateFromWkt(&wkt_b, NULL, &g_b);
-    CHECK(err == OGRERR_NONE && g_b, "OGR_G_CreateFromWkt failed for g_b");
+    CHECK(OGR_G_CreateFromWkt(&wkt_a, NULL, &g_a) == OGRERR_NONE && g_a, "OGR_G_CreateFromWkt failed for g_a");
+    CHECK(OGR_G_CreateFromWkt(&wkt_b, NULL, &g_b) == OGRERR_NONE && g_b, "OGR_G_CreateFromWkt failed for g_b");
 
     OGRGeometryH intersection = OGR_G_Intersection(g_a, g_b);
     CHECK(intersection, "OGR_G_Intersection returned NULL (GEOS link broken?)");
 
     double area = OGR_G_Area(intersection);
-    printf("intersection area: %f\n", area);
+    printf("  intersection area: %f\n", area);
     CHECK(area > 0.99 && area < 1.01, "OGR_G_Intersection area is wrong");
 
     OGR_G_DestroyGeometry(intersection);
     OGR_G_DestroyGeometry(g_b);
     OGR_G_DestroyGeometry(g_a);
-
-    printf("All tests passed\n");
     return 0;
+}
+
+/* Exercises the libproj.so link: OCTTransform dispatches into PROJ. */
+static int test_proj_transform(void) {
+    OGRSpatialReferenceH src = OSRNewSpatialReference(NULL);
+    OGRSpatialReferenceH dst = OSRNewSpatialReference(NULL);
+    CHECK(src && dst, "OSRNewSpatialReference failed");
+    CHECK(OSRImportFromEPSG(src, 4326) == OGRERR_NONE, "OSRImportFromEPSG 4326 failed");
+    CHECK(OSRImportFromEPSG(dst, 3857) == OGRERR_NONE, "OSRImportFromEPSG 3857 failed");
+    OSRSetAxisMappingStrategy(src, OAMS_TRADITIONAL_GIS_ORDER);
+    OSRSetAxisMappingStrategy(dst, OAMS_TRADITIONAL_GIS_ORDER);
+
+    OGRCoordinateTransformationH ct = OCTNewCoordinateTransformation(src, dst);
+    CHECK(ct, "OCTNewCoordinateTransformation returned NULL (PROJ link broken?)");
+
+    double x = 10.0, y = 50.0;
+    int ok = OCTTransform(ct, 1, &x, &y, NULL);
+    printf("  transform (10, 50) EPSG:4326 -> EPSG:3857: (%f, %f)\n", x, y);
+    CHECK(ok, "OCTTransform failed");
+    CHECK(fabs(x - 1113194.9) < 1.0, "web-mercator x is wrong");
+    CHECK(fabs(y - 6446275.8) < 1.0, "web-mercator y is wrong");
+
+    OCTDestroyCoordinateTransformation(ct);
+    OSRDestroySpatialReference(dst);
+    OSRDestroySpatialReference(src);
+    return 0;
+}
+
+typedef int (*test_fn)(void);
+struct test_case { const char *name; test_fn fn; };
+
+int main(void) {
+    struct test_case tests[] = {
+        {"gdal_basics",       test_gdal_basics},
+        {"geos_intersection", test_geos_intersection},
+        {"proj_transform",    test_proj_transform},
+    };
+    int n = sizeof(tests) / sizeof(tests[0]);
+    int failed = 0;
+
+    for (int i = 0; i < n; i++) {
+        printf("[RUN ] %s\n", tests[i].name);
+        int rc = tests[i].fn();
+        printf(rc == 0 ? "[PASS] %s\n" : "[FAIL] %s\n", tests[i].name);
+        if (rc != 0) failed++;
+    }
+
+    if (failed == 0) {
+        printf("All tests passed\n");
+        return 0;
+    }
+    fprintf(stderr, "%d/%d tests failed\n", failed, n);
+    return 1;
 }


### PR DESCRIPTION
- [x] Bumped build number (0 → 1); version unchanged.

## Package Details
- **Package Name**: libgdal-core, libgdal-core-tests (new), libgdal-core-static
- **Version**: 3.12.4 (build 1)

## Build Notes

- \`build.sh\` was passing static libs (\`libgeos_c.a\`, \`libproj.a\`) to CMake but with libgeos.a missing, so wasm-ld seemed to inline the geos C wrappers into \`libgdal.so\` but leaving hundreds of unresolved C++ callees and also an empty \`dylink.0\` NEEDED. This produced exceptions when loading libgdal independently *before* libgeos but it worked in other cases. In my case I discovered it with an \`import pygplates\` before \`import shapely\` under xeus-python. The actual hard crash was that it goes on stub calls into geos (\`_ZNK4geos4geom8Geometry12intersectionEPKS1_\`).
- Instead of adding the missing dep directly, I decided to switch to shared objects as well and link \`libgeos_c.so\` and similarly also \`libproj.so\` for proj. Basically this means swapping \`geos-static\`/\`proj-static\` for \`geos\`/\`proj >=9.8\`. The resulting \`libgdal.so\` records proper NEEDED entries; the LDSO transitively loads libgeos and libproj before libgdal instantiates. The \`-static\` output keeps the static deps on the other hand
- Finally, I added a \`libgdal-core-tests\` subpackage (following the \`libboost-python-example\` pattern) that compiles a MAIN_MODULE test against the pinned libgdal-core and runs it under node. The test exercises \`OGR_G_Intersection\` (GEOS path) and \`OCTTransform\` for EPSG:4326→EPSG:3857 (PROJ path).