### PR TITLE
Add numpy-tests

### DIFF
--- a/recipes/recipes_emscripten/numpy/build.sh
+++ b/recipes/recipes_emscripten/numpy/build.sh
@@ -21,6 +21,9 @@ sed -i '1i#!/usr/bin/env python' $BUILD_PREFIX/bin/cython
 sed -i 's/-fexceptions/-fwasm-exceptions/g' numpy/_core/meson.build
 
 
+# Install runtime plus tests (Meson install_tag=tests). Tests are packaged
+# as numpy-tests, not numpy; numpy.test() needs both packages.
 MESON_ARGS="-Dhave_backtrace=false" ${PYTHON} -m pip install . -vvv --no-deps --no-build-isolation \
     -Csetup-args="-Dallow-noblas=true" \
-    -Csetup-args="--cross-file=$MESON_CROSS_FILE"
+    -Csetup-args="--cross-file=$MESON_CROSS_FILE" \
+    -Cinstall-args="--tags=runtime,python-runtime,tests"

--- a/recipes/recipes_emscripten/numpy/build.sh
+++ b/recipes/recipes_emscripten/numpy/build.sh
@@ -23,7 +23,8 @@ sed -i 's/-fexceptions/-fwasm-exceptions/g' numpy/_core/meson.build
 
 # Install runtime plus tests (Meson install_tag=tests). Tests are packaged
 # as numpy-tests, not numpy; numpy.test() needs both packages.
+# devel  — numpy.pc, headers, and numpy._core.lib (imported by test_configtool).
 MESON_ARGS="-Dhave_backtrace=false" ${PYTHON} -m pip install . -vvv --no-deps --no-build-isolation \
     -Csetup-args="-Dallow-noblas=true" \
     -Csetup-args="--cross-file=$MESON_CROSS_FILE" \
-    -Cinstall-args="--tags=runtime,python-runtime,tests"
+    -Cinstall-args="--tags=runtime,python-runtime,tests,devel"

--- a/recipes/recipes_emscripten/numpy/recipe.yaml
+++ b/recipes/recipes_emscripten/numpy/recipe.yaml
@@ -36,7 +36,6 @@ outputs:
       version: ${{ version }}
     inherit: numpy-build
     build:
-      number: ${{ build_number }}
       script: echo "Collecting NumPy runtime files from cache"
       files:
         exclude:
@@ -89,7 +88,6 @@ outputs:
       version: ${{ version }}
     inherit: numpy-build
     build:
-      number: ${{ build_number }}
       script: echo "Collecting NumPy test files from cache"
       files:
         include:

--- a/recipes/recipes_emscripten/numpy/recipe.yaml
+++ b/recipes/recipes_emscripten/numpy/recipe.yaml
@@ -45,7 +45,10 @@ outputs:
         - '**/__pycache__/**'
         - '**/*.pyc'
         - '**/test_*.py'
-        # C helpers built with meson install_tag=tests
+        # Test-only C extensions (meson install_tag=tests). They live under
+        # numpy/_core/ next to runtime modules, so **/tests/** does not match
+        # them; exclude them from numpy and ship them in numpy-tests.
+        # _simd is matched as .so/.wasm so the runtime stub _simd.pyi is kept.
         - '**/_core/_multiarray_tests*'
         - '**/_core/_umath_tests*'
         - '**/_core/_rational_tests*'
@@ -93,6 +96,7 @@ outputs:
         include:
         - lib/python*/site-packages/numpy/**/tests/**
         - lib/python*/site-packages/numpy/**/test_*.py
+        # Same test-only C extensions excluded from numpy above.
         - lib/python*/site-packages/numpy/_core/_multiarray_tests*
         - lib/python*/site-packages/numpy/_core/_umath_tests*
         - lib/python*/site-packages/numpy/_core/_rational_tests*

--- a/recipes/recipes_emscripten/numpy/recipe.yaml
+++ b/recipes/recipes_emscripten/numpy/recipe.yaml
@@ -3,51 +3,133 @@ context:
   cross_target_plattform: emscripten-wasm32
   target_plattform: emscripten-wasm32
   default_abi_level: 2.2
+  build_number: 1
 
-package:
-  name: numpy
-  version: ${{ version }}
+build:
+  number: ${{ build_number }}
+
 source:
   url: https://github.com/numpy/numpy/releases/download/v${{ version }}/numpy-${{ version }}.tar.gz
   sha256: df2d5874ff183595a4ba404edd04f6bd9b5505c1d7708573f6a6c17489a67563
-build:
-  number: 0
 
-  files:
-    exclude:
-    - '**/*.pyi'
-    - '**/tests/**'
-    - '**/*.ini'
-    - '**/__pycache__/**'
-    - '**/*.pyc'
-    - '**/test_*.py'
-  python:
-    skip_pyc_compilation:
-    - '**/*.py'
-requirements:
-  build:
-  - ${{ compiler("c") }}
-  - cross-python_${{target_platform}}
-  - cython >=3.0.6
-  - meson-python >=0.18.0
-  - ninja >=1.8.2
-  - pip >=24.0
-  - pkg-config
-  - python
-  host:
-  - python
-  run_exports:
-  - numpy >=${{ default_abi_level }},<3
-tests:
-- script: pytester
-  requirements:
+outputs:
+  # One NumPy build; runtime files go to numpy, tests to numpy-tests.
+  - staging:
+      name: numpy-build
     build:
-    - pytester
-    run:
-    - pytester-run
-  files:
-    recipe:
-    - test_numpy.py
+      script: build.sh
+    requirements:
+      build:
+      - ${{ compiler("c") }}
+      - cross-python_${{target_platform}}
+      - cython >=3.0.6
+      - meson-python >=0.18.0
+      - ninja >=1.8.2
+      - pip >=24.0
+      - pkg-config
+      - python
+      host:
+      - python
+
+  - package:
+      name: numpy
+      version: ${{ version }}
+    inherit: numpy-build
+    build:
+      number: ${{ build_number }}
+      script: echo "Collecting NumPy runtime files from cache"
+      files:
+        exclude:
+        - '**/*.pyi'
+        - '**/tests/**'
+        - '**/*.ini'
+        - '**/__pycache__/**'
+        - '**/*.pyc'
+        - '**/test_*.py'
+        # C helpers built with meson install_tag=tests
+        - '**/_core/_multiarray_tests*'
+        - '**/_core/_umath_tests*'
+        - '**/_core/_rational_tests*'
+        - '**/_core/_struct_ufunc_tests*'
+        - '**/_core/_operand_flag_tests*'
+        - '**/_core/_reduction_loop_tests*'
+        - '**/_core/_simd.so'
+        - '**/_core/_simd.*.so'
+        - '**/_core/_simd.wasm'
+      python:
+        skip_pyc_compilation:
+        - '**/*.py'
+    requirements:
+      host:
+      - python
+      run_exports:
+      - numpy >=${{ default_abi_level }},<3
+    tests:
+    - package_contents:
+        site_packages:
+        - numpy/__init__.py
+        files:
+          not_exists:
+          - lib/python*/site-packages/numpy/**/tests/**
+          - lib/python*/site-packages/numpy/**/test_*.py
+    - script: pytester
+      requirements:
+        build:
+        - pytester
+        run:
+        - pytester-run
+      files:
+        recipe:
+        - test_numpy.py
+
+  # Overlay of NumPy test modules onto site-packages/numpy. Other recipes
+  # can add numpy-tests as a test requirement and call numpy.test().
+  - package:
+      name: numpy-tests
+      version: ${{ version }}
+    inherit: numpy-build
+    build:
+      number: ${{ build_number }}
+      script: echo "Collecting NumPy test files from cache"
+      files:
+        include:
+        - lib/python*/site-packages/numpy/**/tests/**
+        - lib/python*/site-packages/numpy/**/test_*.py
+        - lib/python*/site-packages/numpy/_core/_multiarray_tests*
+        - lib/python*/site-packages/numpy/_core/_umath_tests*
+        - lib/python*/site-packages/numpy/_core/_rational_tests*
+        - lib/python*/site-packages/numpy/_core/_struct_ufunc_tests*
+        - lib/python*/site-packages/numpy/_core/_operand_flag_tests*
+        - lib/python*/site-packages/numpy/_core/_reduction_loop_tests*
+        - lib/python*/site-packages/numpy/_core/_simd*
+        exclude:
+        - '**/__pycache__/**'
+        - '**/*.pyc'
+        - '**/*.pyi'
+      python:
+        skip_pyc_compilation:
+        - '**/*.py'
+    requirements:
+      host:
+      - python
+      run:
+      - ${{ pin_subpackage('numpy', exact=True) }}
+      - pytest
+      - hypothesis
+    tests:
+    - package_contents:
+        site_packages:
+        - numpy/_core/tests/test_multiarray.py
+        - numpy/linalg/tests/test_linalg.py
+    - script: pytester
+      files:
+        recipe:
+        - test_numpy_tests.py
+      requirements:
+        build:
+        - pytester
+        run:
+        - pytester-run
 
 about:
   homepage: http://numpy.org/

--- a/recipes/recipes_emscripten/numpy/recipe.yaml
+++ b/recipes/recipes_emscripten/numpy/recipe.yaml
@@ -104,10 +104,11 @@ outputs:
         - lib/python*/site-packages/numpy/_core/_operand_flag_tests*
         - lib/python*/site-packages/numpy/_core/_reduction_loop_tests*
         - lib/python*/site-packages/numpy/_core/_simd*
+        # typing.tests.test_isfile checks installed *.pyi stubs.
+        - lib/python*/site-packages/numpy/**/*.pyi
         exclude:
         - '**/__pycache__/**'
         - '**/*.pyc'
-        - '**/*.pyi'
       python:
         skip_pyc_compilation:
         - '**/*.py'

--- a/recipes/recipes_emscripten/numpy/test_numpy_tests.py
+++ b/recipes/recipes_emscripten/numpy/test_numpy_tests.py
@@ -1,0 +1,11 @@
+import pathlib
+
+import numpy as np
+
+
+def test_numpy_tests_are_installed():
+    root = pathlib.Path(np.__file__).resolve().parent
+    test_files = list(root.glob("**/tests/test_*.py"))
+    assert test_files, (
+        "numpy-tests must overlay NumPy test modules under site-packages/numpy"
+    )


### PR DESCRIPTION
## Template A: Checklist for **adding** a package

### Pre-submission Checks
- [x] Package requires building for `emscripten-wasm32` platform (not a noarch package), in other words, the package requires compilation.

`numpy-tests` is an additional output of the existing `numpy` recipe (not a new `recipes/recipes_emscripten/numpy-tests/` directory). It overlays NumPy's test modules, including C test helpers (`_multiarray_tests`, `_umath_tests`, …) and `*.pyi` stubs, onto `site-packages/numpy`.

### Recipe Structure
Added `recipes/recipes_emscripten/[package-name]/recipe.yaml` with proper structure:
- [x] `context` section with `version` (and optionally `name`)
- [x] `package` section with name and version using Jinja2 templates
- [x] `source` section with:
  - Source URL is valid and points to archive file (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip`)
  - Source URL contains `${{ version }}` template for version updates
  - SHA256 hash is correct (verified with `curl -sL <url> | sha256sum`)
  - Patches (if any) are included in `[package-name]/patches/` directory
- [x] `build` section with appropriate script/method
  - Python packages: `${PYTHON} -m pip install . ${PIP_ARGS}`
  - R packages: `$R CMD INSTALL $R_ARGS .`
  - C++ packages: Uses `emcmake`/`emmake` or `emconfigure`/`emmake`
  - Rust packages: Uses `rust-nightly` and `maturin` or appropriate Rust build tool
  - Build number is 0
  - If the script is longer than 3 lines, a *build.sh* is included
- [x] `requirements` section (build, host, run as needed)
- [x] `tests` section
  - Python packages: `test_import_[package].py` file created and referenced
  - C++ packages: Test executable or package_contents test
  - R packages: Package contents test
- [x] `about` section with license, homepage, summary

Build number is 1 for both `numpy` and `numpy-tests` (the template's "0" is for a brand-new recipe). Tests are `package_contents` plus `test_numpy_tests.py` (overlay check), not `test_import_numpy-tests.py`. Rebased onto main after numpy 2.5.3 (#6598).

## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

## PR Formatting
- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details
- **Package Name**: numpy-tests
- **Version**: 2.5.3 (build 1)

## Build Notes
One NumPy build, two packages: `numpy` stays runtime-only; `numpy-tests` ships the test modules, C helpers (`_multiarray_tests`, `_umath_tests`, `_simd`, …), and `*.pyi` stubs. Other recipes can add `numpy-tests` as a test requirement and call `numpy.test()`. `numpy-tests` depends on the matching `numpy` build, plus `pytest` and `hypothesis`.

Meson is invoked with `--tags=runtime,python-runtime,tests,devel` so:
- `tests` files exist to package into `numpy-tests`
- `devel` (`numpy.pc`, headers, `numpy._core.lib`) is installed into `numpy`, which `test_configtool` and SciPy's `dependency('numpy')` need

This follows the `scipy-tests` split from #6334. It does not run `numpy.test()` in CI; that is left to [Update numpy to run the full test suite #6676](https://github.com/emscripten-forge/recipes/pull/6676).
