### PR TITLE
qt6: enable wasm-exceptions + JSPI versions

### DIFF
--- a/recipes/recipes_emscripten/qt6/build_qtbase.sh
+++ b/recipes/recipes_emscripten/qt6/build_qtbase.sh
@@ -36,6 +36,7 @@ mkdir build && cd build
     -no-warnings-are-errors \
     -nomake examples -nomake tests \
     -no-feature-cups -no-feature-vulkan -no-feature-dbus \
+    -feature-wasm-exceptions \
     -no-pch \
     -- \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}"

--- a/recipes/recipes_emscripten/qt6/build_qtbase.sh
+++ b/recipes/recipes_emscripten/qt6/build_qtbase.sh
@@ -37,6 +37,7 @@ mkdir build && cd build
     -nomake examples -nomake tests \
     -no-feature-cups -no-feature-vulkan -no-feature-dbus \
     -feature-wasm-exceptions \
+    ${QT_EXTRA_FEATURES:-} \
     -no-pch \
     -- \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}"

--- a/recipes/recipes_emscripten/qt6/recipe.yaml
+++ b/recipes/recipes_emscripten/qt6/recipe.yaml
@@ -21,8 +21,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - zlib
@@ -66,8 +64,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main', exact=True) }}
@@ -105,8 +101,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main', exact=True) }}
@@ -143,8 +137,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main', exact=True) }}
@@ -180,8 +172,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main', exact=True) }}
@@ -218,8 +208,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main', exact=True) }}
@@ -266,8 +254,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - zlib
@@ -310,8 +296,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
@@ -350,8 +334,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
@@ -391,8 +373,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
@@ -430,8 +410,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
@@ -470,8 +448,6 @@ outputs:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
-    - perl
-    - python
     - qt6-main == ${{ version }}
     host:
     - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}

--- a/recipes/recipes_emscripten/qt6/recipe.yaml
+++ b/recipes/recipes_emscripten/qt6/recipe.yaml
@@ -334,6 +334,166 @@ outputs:
     summary: Qt5 compatibility module (QTextCodec, etc.) built against qt6-main-jspi for Emscripten (WASM).
     license_file: LICENSES/LGPL-3.0-only.txt
 
+- package:
+    name: qt6-svg-jspi
+    version: ${{ version }}
+  source:
+    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtsvg-everywhere-src-${{ version }}.tar.xz
+    sha256: d594337feca84c26fb67fe87b85e6a5c12fda404b611d905f9d138210c311876
+  build:
+    script: build_qtsvg.sh
+  requirements:
+    build:
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - perl
+    - python
+    - qt6-main == ${{ version }}
+    host:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run_constraints:
+    - qt6-svg <0.0.0
+  tests:
+  - package_contents:
+      files:
+      - lib/libQt6Svg.a
+      - lib/libQt6SvgWidgets.a
+      - lib/cmake/Qt6Svg/Qt6SvgConfig.cmake
+      - include/QtSvg/QSvgRenderer
+  - script:
+    - build_tests_qtsvg.sh
+    requirements:
+      build:
+      - ${{ compiler('cxx') }}
+    files:
+      recipe:
+      - build_tests_qtsvg.sh
+  about:
+    summary: Qt6 SVG rendering module built against qt6-main-jspi for Emscripten (WASM).
+    license_file: LICENSES/LGPL-3.0-only.txt
+
+- package:
+    name: qt6-imageformats-jspi
+    version: ${{ version }}
+  source:
+    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtimageformats-everywhere-src-${{ version }}.tar.xz
+    sha256: cecd8900f34b6550076309bc94f62f828008b633a4239e0a08c86788f41001f8
+  build:
+    script: build_qtimageformats.sh
+  requirements:
+    build:
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - perl
+    - python
+    - qt6-main == ${{ version }}
+    host:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run_constraints:
+    - qt6-imageformats <0.0.0
+  tests:
+  - package_contents:
+      files:
+      - plugins/imageformats/libqtiff.a
+      - plugins/imageformats/libqwebp.a
+  - script:
+    - build_tests_qtimageformats.sh
+    requirements:
+      build:
+      - ${{ compiler('cxx') }}
+    files:
+      recipe:
+      - build_tests_qtimageformats.sh
+  about:
+    summary: Qt6 extra image-format plugins built against qt6-main-jspi for Emscripten (WASM).
+    license_file: LICENSES/LGPL-3.0-only.txt
+
+- package:
+    name: qt6-webchannel-jspi
+    version: ${{ version }}
+  source:
+    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtwebchannel-everywhere-src-${{ version }}.tar.xz
+    sha256: feb3149758bda887f0c292656194812dd2c227595badc8fbdeb2fb2311c5575f
+  build:
+    script: build_qtwebchannel.sh
+  requirements:
+    build:
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - perl
+    - python
+    - qt6-main == ${{ version }}
+    host:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run_constraints:
+    - qt6-webchannel <0.0.0
+  tests:
+  - package_contents:
+      files:
+      - lib/libQt6WebChannel.a
+      - lib/cmake/Qt6WebChannel/Qt6WebChannelConfig.cmake
+      - include/QtWebChannel/QWebChannel
+  - script:
+    - build_tests_qtwebchannel.sh
+    requirements:
+      build:
+      - ${{ compiler('cxx') }}
+    files:
+      recipe:
+      - build_tests_qtwebchannel.sh
+  about:
+    summary: Qt6 WebChannel (JavaScript <-> Qt object bridge) built against qt6-main-jspi for Emscripten (WASM).
+    license_file: LICENSES/LGPL-3.0-only.txt
+
+- package:
+    name: qt6-websockets-jspi
+    version: ${{ version }}
+  source:
+    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtwebsockets-everywhere-src-${{ version }}.tar.xz
+    sha256: 2bfe25c383c37f7690e3c59b02c9907d2744cf8527b1f3f1fc2c785b2ff3c9a3
+  build:
+    script: build_qtwebsockets.sh
+  requirements:
+    build:
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - perl
+    - python
+    - qt6-main == ${{ version }}
+    host:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run_constraints:
+    - qt6-websockets <0.0.0
+  tests:
+  - package_contents:
+      files:
+      - lib/libQt6WebSockets.a
+      - lib/cmake/Qt6WebSockets/Qt6WebSocketsConfig.cmake
+      - include/QtWebSockets/QWebSocket
+  - script:
+    - build_tests_qtwebsockets.sh
+    requirements:
+      build:
+      - ${{ compiler('cxx') }}
+    files:
+      recipe:
+      - build_tests_qtwebsockets.sh
+  about:
+    summary: Qt6 WebSockets (RFC 6455) client built against qt6-main-jspi for Emscripten (WASM).
+    license_file: LICENSES/LGPL-3.0-only.txt
+
 about:
   homepage: https://www.qt.io/
   repository: https://code.qt.io/qt/qt5.git

--- a/recipes/recipes_emscripten/qt6/recipe.yaml
+++ b/recipes/recipes_emscripten/qt6/recipe.yaml
@@ -257,7 +257,7 @@ outputs:
     script:
       env:
         QT_EXTRA_FEATURES: -feature-wasm-jspi
-      content: build_qtbase.sh
+      content: bash ${RECIPE_DIR}/build_qtbase.sh
   requirements:
     build:
     - ${{ compiler('cxx') }}

--- a/recipes/recipes_emscripten/qt6/recipe.yaml
+++ b/recipes/recipes_emscripten/qt6/recipe.yaml
@@ -240,6 +240,100 @@ outputs:
     summary: Qt6 WebSockets (RFC 6455) client for Emscripten (WASM)
     license_file: LICENSES/LGPL-3.0-only.txt
 
+# JSPI-enabled variants: same qtbase/qt5compat sources rebuilt with
+# QT_FEATURE_wasm_jspi=ON so downstream Qt6 widget apps that need to yield
+# from their event loop to the browser (all of them, effectively) get proper
+# JSPI-based suspension. Distinct package names so the solver never picks
+# them unless a downstream explicitly asks; run_constraints prevent a jspi
+# variant from ever being installed alongside its vanilla counterpart (they
+# install identical file paths).
+- package:
+    name: qt6-main-jspi
+    version: ${{ version }}
+  source:
+    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtbase-everywhere-src-${{ version }}.tar.xz
+    sha256: 5b2e00eccaf5a4d8c14134ffa0ea8dfd0a35ae1ffc7f8d87fa4305a1ed23cf22
+  build:
+    script:
+      env:
+        QT_EXTRA_FEATURES: -feature-wasm-jspi
+      content: build_qtbase.sh
+  requirements:
+    build:
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - perl
+    - python
+    - qt6-main == ${{ version }}
+    host:
+    - zlib
+    run_constraints:
+    - qt6-main <0.0.0
+  tests:
+  - package_contents:
+      files:
+      - bin/qmake6
+      - lib/libQt6Core.a
+      - lib/libQt6Gui.a
+      - lib/libQt6Widgets.a
+      - lib/libQt6Xml.a
+      - lib/libQt6Network.a
+      - lib/cmake/Qt6/Qt6Config.cmake
+      - include/QtCore/QString
+      - plugins/platforms/libqwasm.a
+  - script:
+    - build_tests_qtbase.sh
+    requirements:
+      build:
+      - ${{ compiler('cxx') }}
+    files:
+      recipe:
+      - build_tests_qtbase.sh
+  about:
+    summary: Qt6 base libraries with JSPI (JavaScript Promise Integration) enabled for Emscripten (WASM). Requires Chrome 137+, Firefox 141+, Safari 18.4+.
+    license_file: LICENSES/LGPL-3.0-only.txt
+
+- package:
+    name: qt6-5compat-jspi
+    version: ${{ version }}
+  source:
+    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qt5compat-everywhere-src-${{ version }}.tar.xz
+    sha256: 68c320fe3391096a9f2d870170edf1b67dac8af1d0e51c0c9e5343807f114287
+  build:
+    script: build_qt5compat.sh
+  requirements:
+    build:
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - perl
+    - python
+    - qt6-main == ${{ version }}
+    host:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run:
+    - ${{ pin_subpackage('qt6-main-jspi', exact=True) }}
+    run_constraints:
+    - qt6-5compat <0.0.0
+  tests:
+  - package_contents:
+      files:
+      - lib/libQt6Core5Compat.a
+      - lib/cmake/Qt6Core5Compat/Qt6Core5CompatConfig.cmake
+      - include/QtCore5Compat/QTextCodec
+  - script:
+    - build_tests_qt5compat.sh
+    requirements:
+      build:
+      - ${{ compiler('cxx') }}
+    files:
+      recipe:
+      - build_tests_qt5compat.sh
+  about:
+    summary: Qt5 compatibility module (QTextCodec, etc.) built against qt6-main-jspi for Emscripten (WASM).
+    license_file: LICENSES/LGPL-3.0-only.txt
+
 about:
   homepage: https://www.qt.io/
   repository: https://code.qt.io/qt/qt5.git

--- a/recipes/recipes_emscripten/qt6/recipe.yaml
+++ b/recipes/recipes_emscripten/qt6/recipe.yaml
@@ -1,5 +1,8 @@
 context:
   version: 6.11.2
+  # Major.minor derived from version so the version-bump bot updates the
+  # URL prefix (qt/6.11/) automatically when version rolls to 6.12.x etc.
+  major_minor: ${{ (version | split('.'))[0] }}.${{ (version | split('.'))[1] }}
 
 build:
   number: 1
@@ -9,7 +12,7 @@ outputs:
     name: qt6-main
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtbase-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtbase-everywhere-src-${{ version }}.tar.xz
     sha256: 5b2e00eccaf5a4d8c14134ffa0ea8dfd0a35ae1ffc7f8d87fa4305a1ed23cf22
   build:
     script: build_qtbase.sh
@@ -54,7 +57,7 @@ outputs:
     name: qt6-svg
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtsvg-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtsvg-everywhere-src-${{ version }}.tar.xz
     sha256: d594337feca84c26fb67fe87b85e6a5c12fda404b611d905f9d138210c311876
   build:
     script: build_qtsvg.sh
@@ -93,7 +96,7 @@ outputs:
     name: qt6-5compat
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qt5compat-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qt5compat-everywhere-src-${{ version }}.tar.xz
     sha256: 68c320fe3391096a9f2d870170edf1b67dac8af1d0e51c0c9e5343807f114287
   build:
     script: build_qt5compat.sh
@@ -131,7 +134,7 @@ outputs:
     name: qt6-imageformats
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtimageformats-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtimageformats-everywhere-src-${{ version }}.tar.xz
     sha256: cecd8900f34b6550076309bc94f62f828008b633a4239e0a08c86788f41001f8
   build:
     script: build_qtimageformats.sh
@@ -168,7 +171,7 @@ outputs:
     name: qt6-webchannel
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtwebchannel-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtwebchannel-everywhere-src-${{ version }}.tar.xz
     sha256: feb3149758bda887f0c292656194812dd2c227595badc8fbdeb2fb2311c5575f
   build:
     script: build_qtwebchannel.sh
@@ -206,7 +209,7 @@ outputs:
     name: qt6-websockets
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtwebsockets-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtwebsockets-everywhere-src-${{ version }}.tar.xz
     sha256: 2bfe25c383c37f7690e3c59b02c9907d2744cf8527b1f3f1fc2c785b2ff3c9a3
   build:
     script: build_qtwebsockets.sh
@@ -251,7 +254,7 @@ outputs:
     name: qt6-main-jspi
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtbase-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtbase-everywhere-src-${{ version }}.tar.xz
     sha256: 5b2e00eccaf5a4d8c14134ffa0ea8dfd0a35ae1ffc7f8d87fa4305a1ed23cf22
   build:
     script:
@@ -298,7 +301,7 @@ outputs:
     name: qt6-5compat-jspi
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qt5compat-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qt5compat-everywhere-src-${{ version }}.tar.xz
     sha256: 68c320fe3391096a9f2d870170edf1b67dac8af1d0e51c0c9e5343807f114287
   build:
     script: build_qt5compat.sh
@@ -338,7 +341,7 @@ outputs:
     name: qt6-svg-jspi
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtsvg-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtsvg-everywhere-src-${{ version }}.tar.xz
     sha256: d594337feca84c26fb67fe87b85e6a5c12fda404b611d905f9d138210c311876
   build:
     script: build_qtsvg.sh
@@ -379,7 +382,7 @@ outputs:
     name: qt6-imageformats-jspi
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtimageformats-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtimageformats-everywhere-src-${{ version }}.tar.xz
     sha256: cecd8900f34b6550076309bc94f62f828008b633a4239e0a08c86788f41001f8
   build:
     script: build_qtimageformats.sh
@@ -418,7 +421,7 @@ outputs:
     name: qt6-webchannel-jspi
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtwebchannel-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtwebchannel-everywhere-src-${{ version }}.tar.xz
     sha256: feb3149758bda887f0c292656194812dd2c227595badc8fbdeb2fb2311c5575f
   build:
     script: build_qtwebchannel.sh
@@ -458,7 +461,7 @@ outputs:
     name: qt6-websockets-jspi
     version: ${{ version }}
   source:
-    url: https://download.qt.io/official_releases/qt/6.11/${{ version }}/submodules/qtwebsockets-everywhere-src-${{ version }}.tar.xz
+    url: https://download.qt.io/official_releases/qt/${{ major_minor }}/${{ version }}/submodules/qtwebsockets-everywhere-src-${{ version }}.tar.xz
     sha256: 2bfe25c383c37f7690e3c59b02c9907d2744cf8527b1f3f1fc2c785b2ff3c9a3
   build:
     script: build_qtwebsockets.sh

--- a/recipes/recipes_emscripten/qt6/recipe.yaml
+++ b/recipes/recipes_emscripten/qt6/recipe.yaml
@@ -2,7 +2,7 @@ context:
   version: 6.11.2
 
 build:
-  number: 0
+  number: 1
 
 outputs:
 - package:


### PR DESCRIPTION
Three commits:

1. **\`qt6: enable wasm-exceptions\`** — adds \`-feature-wasm-exceptions\` to qtbase configure, matching the emscripten-forge convention of always using \`-fwasm-exceptions\` on wasm.
2. **\`qt6: add JSPI variant outputs (qt6-main-jspi, qt6-5compat-jspi)\`** — new sibling packages rebuilt with \`QT_FEATURE_wasm_jspi=ON\` so Qt's event dispatcher can yield to the browser via JavaScript Promise Integration. Distinct package names; \`run_constraints\` prevent jspi/vanilla siblings from co-installing (they share file paths).
3. **\`qt6: extend JSPI variants to svg, imageformats, webchannel, websockets\`** — same pattern for the remaining Qt6 submodules so downstream apps needing any Qt6 submodule under JSPI don't hit file-conflicts.

## Build notes

- Why JSPI needs to be opt-in
  - Kernels on this channel (xeus-python, pyjs, etc.) don't yet support JSPI. Making JSPI the qt6 default would break Qt-based Python extensions loaded into those kernels.
  - Browser floor is also higher: Chrome 137+, Firefox 141+, Safari 18.4+.
- Opt-in via distinct package names keeps existing consumers untouched. Existing \`qt6-main\` consumers see nothing change except the wasm-exceptions ABI improvement.