### PR TITLE
Fix osx builds

### DIFF
--- a/emci/include_build.py
+++ b/emci/include_build.py
@@ -21,6 +21,10 @@ def include_build(recipes_dir, target_platform):
         if not isinstance(platforms, dict):
             raise ValueError(f"Expected 'platforms' to be a dict in recipe.yaml at {recipe_yaml_path}")
 
+        # OSX passes target_platform=None.
+        if target_platform is None:
+            return True
+
         # check that each key is valid (ie also a key in BUILD_FOR_ARCH_DEFAULT_VALUES)
         for key in platforms.keys():
             if key not in BUILD_FOR_ARCH_DEFAULT_VALUES:

--- a/recipes/recipes_native/cross-python/recipe.yaml
+++ b/recipes/recipes_native/cross-python/recipe.yaml
@@ -3,7 +3,7 @@ context:
   version: 3.14.3
 
 build:
-  number: 5
+  number: 4
 
 outputs:
   - package:

--- a/recipes/recipes_native/cross-python/recipe.yaml
+++ b/recipes/recipes_native/cross-python/recipe.yaml
@@ -3,7 +3,7 @@ context:
   version: 3.14.3
 
 build:
-  number: 4
+  number: 5
 
 outputs:
   - package:

--- a/recipes/recipes_wasm/libffi/recipe.yaml
+++ b/recipes/recipes_wasm/libffi/recipe.yaml
@@ -10,7 +10,7 @@ source:
 - url: https://github.com/libffi/libffi/archive/refs/tags/v${{ version }}.tar.gz
   sha256: bf40d752d8f5fd4505bcd1c7d4208ea87fd12c91f087e359651c776748352dc0
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/recipes_wasm/libffi/recipe.yaml
+++ b/recipes/recipes_wasm/libffi/recipe.yaml
@@ -1,14 +1,15 @@
 context:
   name: libffi-static
   version: 3.8.0
+
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 source:
-
 - url: https://github.com/libffi/libffi/archive/refs/tags/v${{ version }}.tar.gz
   sha256: bf40d752d8f5fd4505bcd1c7d4208ea87fd12c91f087e359651c776748352dc0
+
 build:
   number: 1
 
@@ -29,6 +30,7 @@ tests:
   requirements:
     build:
     - generic-testing
+
 about:
   license: MIT
   license_file: LICENSE
@@ -38,7 +40,11 @@ about:
     to various calling conventions. This allows a programmer to call any
     function specified by a call interface description at run-time.
   homepage: https://sourceware.org/libffi/
+
 extra:
   recipe-maintainers:
   - DerThorsten
   - KGB99
+  platforms:
+    emscripten-wasm32: true
+    emscripten-wasm64: true

--- a/recipes/recipes_wasm/libffi/recipe.yaml
+++ b/recipes/recipes_wasm/libffi/recipe.yaml
@@ -45,6 +45,7 @@ extra:
   recipe-maintainers:
   - DerThorsten
   - KGB99
-  platforms:
-    emscripten-wasm32: true
-    emscripten-wasm64: true
+  ci:
+    platforms:
+      emscripten-wasm32: true
+      emscripten-wasm64: true


### PR DESCRIPTION
- OSX builds are failing

```
[9](https://github.com/emscripten-forge/recipes/actions/runs/34469476727/job/102845746696?pr=6663#step:8:50)
  File "/Users/runner/work/recipes/recipes/emci/include_build.py", line 29, in include_build
    return platforms.get(target_platform, BUILD_FOR_ARCH_DEFAULT_VALUES[target_platform])
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: None
Error: Process completed with exit code 1.
```