### PR TITLE
shapely: add tests reaching into deps numpy and geos

### DIFF
--- a/recipes/recipes_emscripten/shapely/recipe.yaml
+++ b/recipes/recipes_emscripten/shapely/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9
 
 build:
-  number: 2
+  number: 3
 
   files:
     exclude:

--- a/recipes/recipes_emscripten/shapely/test_shapely.py
+++ b/recipes/recipes_emscripten/shapely/test_shapely.py
@@ -2,10 +2,62 @@ import pytest
 
 
 def test_import():
-  import shapely
+    import shapely
+    import shapely.lib  # native extension load
 
-def test_basics():
-  from shapely import Polygon
-  c = Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]).minimum_clearance
-  c == pytest.approx(1.0)
-  
+
+def test_array_construction_with_numpy():
+    import numpy as np
+    from shapely import points, get_coordinates
+
+    coords = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
+    pts = points(coords)
+    assert len(pts) == 3
+
+    roundtrip = get_coordinates(pts)
+    assert roundtrip.shape == (3, 2)
+    assert roundtrip.dtype == np.float64
+    np.testing.assert_allclose(roundtrip, coords)
+
+
+def test_predicates_and_measures_with_geos():
+    from shapely import Point, Polygon
+
+    square = Polygon([[0, 0], [1, 0], [1, 1], [0, 1]])
+    assert square.is_valid
+    assert square.contains(Point(0.5, 0.5))
+    assert not square.contains(Point(2.0, 2.0))
+    assert square.area == pytest.approx(1.0)
+    assert square.length == pytest.approx(4.0)
+    assert Point(0, 0).distance(Point(3, 4)) == pytest.approx(5.0)
+
+
+def test_boolean_ops_with_geos():
+    from shapely import Polygon
+
+    a = Polygon([[0, 0], [2, 0], [2, 2], [0, 2]])
+    b = Polygon([[1, 1], [3, 1], [3, 3], [1, 3]])
+    assert a.intersection(b).area == pytest.approx(1.0)
+    assert a.union(b).area == pytest.approx(7.0)
+    assert a.difference(b).area == pytest.approx(3.0)
+
+
+def test_buffer_and_simplify_with_geos():
+    from shapely import Point, LineString
+
+    buf = Point(0, 0).buffer(1.0, quad_segs=64)
+    assert buf.area == pytest.approx(3.14159, rel=1e-3)
+
+    line = LineString([(0, 0), (0.01, 0.5), (0, 1)])
+    simplified = line.simplify(tolerance=0.1)
+    assert len(list(simplified.coords)) == 2
+
+
+def test_wkt_roundtrip_with_geos():
+    from shapely import from_wkt, to_wkt, Polygon
+
+    original = Polygon([[0, 0], [1, 0], [1, 1], [0, 1]])
+    wkt = to_wkt(original)
+    assert "POLYGON" in wkt
+    parsed = from_wkt(wkt)
+    assert parsed.equals(original)


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged (2 → 3)

## Package Details
- **Package Name**: shapely
- **Version**: 2.1.2 (build 3)

## Build Notes

The previous `test_shapely.py` had two tests — `test_import` and `test_basics`. The latter's only assertion was a stray `c == pytest.approx(1.0)` expression (no `assert`), so it could not fail. Replace with six tests that go through shapely's declared runtime deps `numpy` and `geos`, ordered numpy → geos:

- `test_import` — loads `shapely` and `shapely.lib` native module.
- `test_array_construction_with_numpy` — `shapely.points(np.ndarray)` and `get_coordinates` roundtrip.
- `test_predicates_and_measures_with_geos` — `is_valid`, `contains`, `area`, `length`, `distance` (distinct `GEOS*_r` entrypoints).
- `test_boolean_ops_with_geos` — `intersection`, `union`, `difference` (overlay path — the surface PR #6586 fixed in libgdal-core).
- `test_buffer_and_simplify_with_geos` — `Point.buffer` + `LineString.simplify` (Douglas-Peucker).
- `test_wkt_roundtrip_with_geos` — `from_wkt` / `to_wkt` reader/writer path.

No source or build.sh changes. Recipe change is limited to the build number bump.