### PR TITLE
Update openblas-experimental to develop @ b4100af

### DIFF
--- a/recipes/recipes_emscripten/openblas-experimental/patches/0001-Remove-march-flags.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0001-Remove-march-flags.patch
@@ -1,4 +1,4 @@
-From b6171cd25803adce067f48ef8651eb4390dde0ce Mon Sep 17 00:00:00 2001
+From f411d1240cb26703a8aa27c6a94bf4144a925a9a Mon Sep 17 00:00:00 2001
 From: Isabel Paredes <isabel.paredes@quantstack.net>
 Date: Mon, 8 Dec 2025 07:47:46 +0000
 Subject: [PATCH 01/11] Remove -march flags

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0002-Skip-linktest.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0002-Skip-linktest.patch
@@ -1,4 +1,4 @@
-From 5eb7fad8892c22b8a2a77190c5da64030683bd41 Mon Sep 17 00:00:00 2001
+From 9d663635bd7be0e966862c223b7c3f10ec1885a6 Mon Sep 17 00:00:00 2001
 From: Isabel Paredes <isabel.paredes@quantstack.net>
 Date: Mon, 8 Dec 2025 07:50:30 +0000
 Subject: [PATCH 02/11] Skip linktest

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0003-Add-emscripten-as-supported-arch.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0003-Add-emscripten-as-supported-arch.patch
@@ -1,4 +1,4 @@
-From 61ee256fd7ca7ffb7b0890c1b4daf38e60f070b7 Mon Sep 17 00:00:00 2001
+From e8a8a281b4108c47b5be9dfdbbf7a3377f7f699f Mon Sep 17 00:00:00 2001
 From: Isabel Paredes <isabel.paredes@quantstack.net>
 Date: Mon, 8 Dec 2025 07:51:01 +0000
 Subject: [PATCH 03/11] Add emscripten as supported arch

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0004-Add-dummy-length-arguments-for-char-arguments.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0004-Add-dummy-length-arguments-for-char-arguments.patch
@@ -1,4 +1,4 @@
-From a7489397e2e97df27c6c51b97131d5d4ebf49490 Mon Sep 17 00:00:00 2001
+From 3883241878b6369ed962f91557b6410a2e5e1cd8 Mon Sep 17 00:00:00 2001
 From: Ian Thomas <ianthomas23@gmail.com>
 Date: Mon, 8 Dec 2025 07:59:50 +0000
 Subject: [PATCH 04/11] Add dummy length arguments for char arguments

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0005-Return-void-not-int.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0005-Return-void-not-int.patch
@@ -1,4 +1,4 @@
-From b457690b0eada4ef6cb5d36843e7d2b3c7a28d80 Mon Sep 17 00:00:00 2001
+From 0ecd14e25dc2d253019139ec6a4ceb03d6929ac8 Mon Sep 17 00:00:00 2001
 From: Ian Thomas <ianthomas23@gmail.com>
 Date: Mon, 8 Dec 2025 08:00:00 +0000
 Subject: [PATCH 05/11] Return void not int

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0006-Enable-LAPACK_FORTRAN_STDLEN_END-for-lapacke-calling.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0006-Enable-LAPACK_FORTRAN_STDLEN_END-for-lapacke-calling.patch
@@ -1,4 +1,4 @@
-From c5cdc00147e6002053444f0832d3dd6ddbc20472 Mon Sep 17 00:00:00 2001
+From 0ca2b1539579fe1209ab84b34e5b33e9e5b6e393 Mon Sep 17 00:00:00 2001
 From: Ian Thomas <ianthomas23@gmail.com>
 Date: Mon, 8 Dec 2025 17:10:40 +0000
 Subject: [PATCH 06/11] Enable LAPACK_FORTRAN_STDLEN_END for lapacke calling

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0007-Clear-FEXTRALIB-when-linking-shared-library.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0007-Clear-FEXTRALIB-when-linking-shared-library.patch
@@ -1,4 +1,4 @@
-From 56450559945acfea68c452e9cd4529bb69532845 Mon Sep 17 00:00:00 2001
+From 61630ac25e17c7689128967a5c903afc1f666281 Mon Sep 17 00:00:00 2001
 From: Ian Thomas <ianthomas23@gmail.com>
 Date: Fri, 13 Mar 2026 09:07:45 +0000
 Subject: [PATCH 07/11] Clear FEXTRALIB when linking shared library

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0008-Skip-fork-based-utests-for-emscripten.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0008-Skip-fork-based-utests-for-emscripten.patch
@@ -1,4 +1,4 @@
-From 137496c581961d022b7301143e3274dd22226db3 Mon Sep 17 00:00:00 2001
+From 90138221c1cf4b8c5e4b03e4831a837c8a7b122f Mon Sep 17 00:00:00 2001
 From: Julien Jerphanion <git@jjerphan.xyz>
 Date: Thu, 13 Aug 2026 09:45:45 +0200
 Subject: [PATCH 08/11] Skip fork-based utests for emscripten

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0009-Run-OpenBLAS-tests-under-node-for-emscripten.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0009-Run-OpenBLAS-tests-under-node-for-emscripten.patch
@@ -1,4 +1,4 @@
-From f8f00cc0d46704798f8b8d5c826046ba64dbe043 Mon Sep 17 00:00:00 2001
+From 498f8ccd8a7b05127f25605279954b7e5bea5f0e Mon Sep 17 00:00:00 2001
 From: Julien Jerphanion <git@jjerphan.xyz>
 Date: Thu, 13 Aug 2026 09:45:45 +0200
 Subject: [PATCH 09/11] Run OpenBLAS tests under node for emscripten

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0010-Return-int-from-ctest-F77-wrappers-for-wasm-ABI.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0010-Return-int-from-ctest-F77-wrappers-for-wasm-ABI.patch
@@ -1,4 +1,4 @@
-From 51ae16055e094134d58002d673de5d79cf15b886 Mon Sep 17 00:00:00 2001
+From 7b04117174d65f500a9694a35b816aa01b6bb541 Mon Sep 17 00:00:00 2001
 From: Julien Jerphanion <git@jjerphan.xyz>
 Date: Thu, 13 Aug 2026 09:46:19 +0200
 Subject: [PATCH 10/11] Return int from ctest F77 wrappers for wasm ABI

--- a/recipes/recipes_emscripten/openblas-experimental/patches/0011-Use-int-return-for-f2c-Subroutine-decls-in-ctest.patch
+++ b/recipes/recipes_emscripten/openblas-experimental/patches/0011-Use-int-return-for-f2c-Subroutine-decls-in-ctest.patch
@@ -1,4 +1,4 @@
-From 9de3b2bd8018f628b0960edd1bc9601c38610811 Mon Sep 17 00:00:00 2001
+From 48cf81a20cb04e123a69a70e1b5064dce6c34575 Mon Sep 17 00:00:00 2001
 From: Julien Jerphanion <git@jjerphan.xyz>
 Date: Thu, 13 Aug 2026 09:46:19 +0200
 Subject: [PATCH 11/11] Use int return for f2c Subroutine decls in ctest

--- a/recipes/recipes_emscripten/openblas-experimental/recipe.yaml
+++ b/recipes/recipes_emscripten/openblas-experimental/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: openblas
   version: 0.3.35.dev0
-  commit: 803f36bcaabba43ddee84bf455dfcc24dc7aa0eb
+  commit: b4100af295a9d2f8987b42aa97d0b95e0c251ccd
 
 package:
   name: ${{ name }}
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/OpenMathLib/OpenBLAS/archive/${{ commit }}.tar.gz
-  sha256: ee21f655ef2c5fecd952fce993038ca9cf0d9c2f84fb4c344d9325391bb14068
+  sha256: 146b995b6f5e126759b9bc54912af88a954c77f42efb774b610e449f1f573f8c
   patches:
   # Branch containing these patches is v0.3.35.dev0-emforge at https://github.com/jjerphan/OpenBLAS
   # (rebased onto OpenMathLib/OpenBLAS develop @ ${{ commit }}).
@@ -28,7 +28,7 @@ source:
   - patches/0011-Use-int-return-for-f2c-Subroutine-decls-in-ctest.patch
 
 build:
-  number: 1
+  number: 2
 
   files:
     exclude:


### PR DESCRIPTION
## Template B: Checklist for **updating** a package

- [x] ⚠️ Bump build number if the version remains unchanged
- [ ] Or reset build number to 0 if updating the package to a newer version

---

## PR Formatting

- [x] PR title follows format: `Add [package-name]` or `Update [package-name] to [version]`
- [x] PR description includes:
  - Version being added/updated
  - Any special build considerations or patches applied

## Package Details

- **Package Name**: `openblas-experimental`
- **Version**: `0.3.35.dev0` (build 2), snapshot of OpenMathLib/OpenBLAS `develop` @ [b4100af](https://github.com/OpenMathLib/OpenBLAS/commit/b4100af295a9d2f8987b42aa97d0b95e0c251ccd)

## Build Notes

This refreshes the `develop` snapshot from `803f36bc` to `b4100af` (22 commits newer) and rebases the emforge patch series onto it. The rebased branch is [`v0.3.35.dev0-emforge`](https://github.com/jjerphan/OpenBLAS/tree/v0.3.35.dev0-emforge) at https://github.com/jjerphan/OpenBLAS.

The headline change is OpenBLAS [#6023](https://github.com/OpenMathLib/OpenBLAS/pull/6023): a WASM SIMD128 8×4 SGEMM microkernel (DGEMM stays 4×4). The range also includes [#6024](https://github.com/OpenMathLib/OpenBLAS/pull/6024) (WASM numerical CBLAS suite), [#6022](https://github.com/OpenMathLib/OpenBLAS/pull/6022) (f2c LAPACK warning fixes), and [#6020](https://github.com/OpenMathLib/OpenBLAS/pull/6020) (relaxed SIMD is now opt-in; the portable SIMD128 default is unchanged here).

The package version string is unchanged, so the build number is bumped to 2 rather than reset.

### Patches

All 11 remaining patches still apply with no fuzz. None landed upstream in this range, so none were dropped.

### Local verification

Built locally with `pixi run -e rattler-build-env build-emscripten-wasm32-pkg recipes/recipes_emscripten/openblas-experimental`:

- All 11 patches apply without fuzz.
- `utest` and the CBLAS `ctest` levels 1–3 (real and complex, column- and row-major) pass under Node.
- The packaged `test_openblas.py` passes in Chromium, Firefox and WebKit.